### PR TITLE
fix(yarn): token abstraction

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
+      - name: Set NPM Authorization
+        run: yarn config set npmAuthToken "\${NPM_TOKEN}"
+
       - name: Deploy NPM Packages
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Description

The changes within this PR are to allow CD to set the NPM_TOKEN for deploying packages.