### PR TITLE
feat(token-builder): add reference support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ Please see CONTRIBUTING.md for resources on how to contribute to this project.
 Please see SCRIPTS.md for resources on how to run this project.
 
 # Contact Information
+
 @Author chrisadubois
 @Author interactiveTimmy

--- a/packages/@momentum-design/token-builder/README.md
+++ b/packages/@momentum-design/token-builder/README.md
@@ -52,6 +52,7 @@ When utilizing the functionality of this project as either a JavaScript module o
   ],
   "formats": ["{format-a}", "{format-b}"],
   "prefix": "{prefix}"
+  "references": true,
 }
 ```
 
@@ -60,12 +61,13 @@ In order to provide a better understanding of each key and its relative value wi
 * **files** `Array<ConfigFile>` - A list of file configuration objects, each resulting in a built token file. (See [the **ConfigFile** interface](https://github.com/momentum-design/momentum-design/blob/design-token-updates/packages/%40momentum-design/token-builder/src/common/types.ts))
   * **destination** `string` - The destination path and file name (without extension) for the built token file.
   * **filters** `Filters` - Inclusive CTI model filters to apply when generating the built token file. (See [the **Filters** interface](https://github.com/momentum-design/momentum-design/blob/design-token-updates/packages/%40momentum-design/token-builder/src/common/types.ts))
-    * **categories** `Array<string>` - Categories within the CTI model to filter for.
-    * **items** `Array<string>` - Items within the CTI model to filter for.
-    * **types** `Array<string>` - Types within the CTI model to filter for.
+    * **categories** `Array<string>` - Categories within the CTI model to filter for. This is the first tier within the token object.
+    * **items** `Array<string>` - Items within the CTI model to filter for. This is the third tier within the token object.
+    * **types** `Array<string>` - Types within the CTI model to filter for. this is the second tier within the token object.
   * **targets** `Array<string>` - Absolute or glob pattern file selectors to use when retreiving source tokens from the target input directory.
 * **formats** `Array<Format>` - Array of supported formats to build source tokens into. (See [the **Format** interface](https://github.com/momentum-design/momentum-design/blob/design-token-updates/packages/%40momentum-design/token-builder/src/common/types.ts))
 * **prefix** `string` - Prefix to prepend to variable names within supporting formats.
+* **references** `boolean` - If to output references when possible.
 
 Note that the **formats** key Array can only contain one or more of this tool's supported formats. These can be found as keys of `CONSTANTS.FORMATS` within [this file](https://github.com/momentum-design/momentum-design/blob/design-token-updates/packages/%40momentum-design/token-builder/src/common/constants.ts).
 

--- a/packages/@momentum-design/token-builder/src/common/config-file.fixture.ts
+++ b/packages/@momentum-design/token-builder/src/common/config-file.fixture.ts
@@ -7,6 +7,7 @@ const CONFIG_FILE_FIXTURE: ConfigFile = {
     items: ['config-file-item-a', 'config-file-item-b'],
     types: ['config-file-type-a', 'config-file-type-b'],
   },
+  references: true,
   targets: ['config-file-target-a', 'config-file-target-b'],
 };
 

--- a/packages/@momentum-design/token-builder/src/common/types.ts
+++ b/packages/@momentum-design/token-builder/src/common/types.ts
@@ -13,6 +13,7 @@ export interface Filters {
 export interface ConfigFile {
   destination: string;
   filters: Filters;
+  references?: boolean;
   targets: Array<string>;
 }
 

--- a/packages/@momentum-design/token-builder/src/models/dictionary/dictionary.test.ts
+++ b/packages/@momentum-design/token-builder/src/models/dictionary/dictionary.test.ts
@@ -74,7 +74,7 @@ describe('@momentum-design/token-builder - models.Dictionary', () => {
 
       it('should be an Object of Platforms with a matching output', () => {
         Object.values(platforms).forEach((platform) => {
-          expect(platform.output).toBe(path.join(dictionary.output, platform.group, '/'));
+          expect(platform.output).toBe(path.join(dictionary.output, platform.path, '/'));
         });
       });
 

--- a/packages/@momentum-design/token-builder/src/models/file/file.fixture.ts
+++ b/packages/@momentum-design/token-builder/src/models/file/file.fixture.ts
@@ -8,6 +8,7 @@ const FIXTURE_CONFIG: Config = {
   destination: CONFIG_FILE_FIXTURE.destination,
   filters: structuredClone(CONFIG_FILE_FIXTURE.filters),
   format: Object.keys(CONSTANTS.FORMATS).pop() as Format,
+  references: true,
 };
 
 class FileFixture extends File {

--- a/packages/@momentum-design/token-builder/src/models/file/file.test.ts
+++ b/packages/@momentum-design/token-builder/src/models/file/file.test.ts
@@ -140,6 +140,12 @@ describe('@momentum-design/token-builder - models.File', () => {
       });
     });
 
+    describe('#references', () => {
+      it('should be the reference provided to the File', () => {
+        expect(file.references).toBe(FileFixture.FIXTURE_CONFIG.references);
+      });
+    });
+
     describe('#sdConfig', () => {
       it('should be an Object with a destination that reflects the File\'s file property', () => {
         expect(file.sdConfig.destination).toBe(file.file);
@@ -151,6 +157,10 @@ describe('@momentum-design/token-builder - models.File', () => {
 
       it('should be an Object with a filter that reflects the File\'s filter property', () => {
         expect(JSON.stringify(file.sdConfig.filter)).toBe(JSON.stringify(file.filter));
+      });
+
+      it('should be an Object with options containing an outputReferences that reflects the File\'s reference', () => {
+        expect(file.sdConfig.options?.outputReferences).toBe(file.references);
       });
     });
 

--- a/packages/@momentum-design/token-builder/src/models/file/file.ts
+++ b/packages/@momentum-design/token-builder/src/models/file/file.ts
@@ -69,7 +69,14 @@ class File {
       destination: this.file,
       format: this.format,
       filter: this.filter,
+      options: {
+        outputReferences: this.references,
+      },
     };
+  }
+
+  public get references(): boolean {
+    return this.config.references || false;
   }
 
   public get types(): Array<string> {

--- a/packages/@momentum-design/token-builder/src/models/file/types.ts
+++ b/packages/@momentum-design/token-builder/src/models/file/types.ts
@@ -4,4 +4,5 @@ export interface Config {
   destination: string;
   filters: Filters;
   format: Format;
+  references?: boolean;
 }

--- a/packages/@momentum-design/token-builder/src/models/platform/platform.test.ts
+++ b/packages/@momentum-design/token-builder/src/models/platform/platform.test.ts
@@ -40,6 +40,10 @@ describe('@momentum-design/token-builder - models.Platform', () => {
       it('should be a File with a format property that matches the Platform\'s format property', () => {
         expect(platform.file.format).toBe(CONSTANTS.FORMATS[platform.format].FORMAT);
       });
+
+      it('should be a File with a references property that matches the Platform\'s provided file references', () => {
+        expect(platform.file.references).toBe(PlatformFixture.FIXTURE_CONFIG.file.references);
+      });
     });
 
     describe('#format', () => {
@@ -56,7 +60,13 @@ describe('@momentum-design/token-builder - models.Platform', () => {
 
     describe('#output', () => {
       it('should be a path built from the provided output, the group, and an ammended "/" character', () => {
-        expect(platform.output).toBe(path.join(PlatformFixture.FIXTURE_CONFIG.output, platform.group, '/'));
+        expect(platform.output).toBe(path.join(PlatformFixture.FIXTURE_CONFIG.output, platform.path, '/'));
+      });
+    });
+
+    describe('#path', () => {
+      it('should be the path associated with the format provided to the Platform', () => {
+        expect(platform.path).toBe(CONSTANTS.FORMATS[platform.format].PATH);
       });
     });
 

--- a/packages/@momentum-design/token-builder/src/models/platform/platform.ts
+++ b/packages/@momentum-design/token-builder/src/models/platform/platform.ts
@@ -18,6 +18,7 @@ class Platform {
       destination: this.config.file.destination,
       filters: this.config.file.filters,
       format: this.format,
+      references: this.config.file.references,
     });
   }
 
@@ -30,7 +31,11 @@ class Platform {
   }
 
   public get output(): string {
-    return path.join(this.config.output, this.group, '/');
+    return path.join(this.config.output, this.path, '/');
+  }
+
+  public get path(): string {
+    return CONSTANTS.FORMATS[this.config.format].PATH;
   }
 
   public get prefix(): string | undefined {

--- a/packages/@momentum-design/tokens/config/tokens/webex.json
+++ b/packages/@momentum-design/tokens/config/tokens/webex.json
@@ -10,5 +10,6 @@
     }
   ],
   "formats": ["CSS_VARIABLES", "SCSS_VARIABLES", "WEB_JSON"],
-  "prefix": "mdw"
+  "prefix": "md",
+  "references": true
 }


### PR DESCRIPTION
# Description

The scope of the changes in this pull request is to allow for references to be used within the `@momentum-design/token-builder` package. This allows for built tokens to render with references to their associated values, instead of having the finalized value.