### PR TITLE
fix(automation): build on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
+      - name: Build Packages
+        run: yarn build
+
       - name: Set NPM Authorization
         run: yarn config set npmAuthToken ${{ secrets.NPM_TOKEN_CISCO_MD }}
 


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to add a build flow to the publish automation flow to make sure that all packages are built before publishing to the artifactories.