### PR TITLE
fix: md-token-builder invalid references

### DIFF
--- a/packages/@cisco-momentum/icons/package.json
+++ b/packages/@cisco-momentum/icons/package.json
@@ -7,8 +7,7 @@
   ],
   "scripts": {
     "analyze": "echo \"script 'analyze' is not implemented\"",
-    "build": "yarn build:webex",
-    "build:webex": "md-token-builder --config ./config/tokens/webex.json --input ./src/webex --output ./dist/webex",
+    "build": "echo \"script 'build' is not implemented\"",
     "clean": "yarn clean:dist",
     "clean:dist": "rimraf ./dist",
     "test": "echo \"this script is not implemented\"",

--- a/packages/@cisco-momentum/illustrations/package.json
+++ b/packages/@cisco-momentum/illustrations/package.json
@@ -7,8 +7,7 @@
   ],
   "scripts": {
     "analyze": "echo \"script 'analyze' is not implemented\"",
-    "build": "yarn build:webex",
-    "build:webex": "md-token-builder --config ./config/tokens/webex.json --input ./src/webex --output ./dist/webex",
+    "build": "echo \"script 'build' is not implemented\"",
     "clean": "yarn clean:dist",
     "clean:dist": "rimraf ./dist",
     "test": "echo \"this script is not implemented\"",


### PR DESCRIPTION
# Description

The changes within this pull request address the invalid `build` scripts within all packages that do not currently have a `build` workflow.