### PR TITLE
feat(token-builder): distribute esm module

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -40,7 +40,13 @@ module.exports = {
     ],
     '@typescript-eslint/no-unused-vars': 'error',
     'import/extensions': 'off',
-    'import/no-extraneous-dependencies': ['error', { devDependencies: ['**/config/**/*.*'] }],
+    'import/no-extraneous-dependencies': ['off', {
+      devDependencies: [
+        '**/config/**/*.*',
+        '**/jest.config.*',
+        '**/test/**/*.*',
+      ],
+    }],
     'import/no-relative-packages': 'off',
     'import/prefer-default-export': 'off',
     'no-confusing-arrow': 'off',

--- a/config/esbuild/esbuild.config.js
+++ b/config/esbuild/esbuild.config.js
@@ -3,12 +3,13 @@ import { join } from 'path';
 
 import { PROJECT_PREFIX } from './esbuild.constants.js';
 
-const cli = async ({ stage, extension = 'js', format = 'esm' }) => {
+const cli = async ({ stage, extension = 'js', external, format = 'esm' }) => {
   const projectPath = process.cwd();
 
   await esbuild.build({
     bundle: true,
     entryPoints: [`${join(projectPath, 'src', 'main.js')}`],
+    external,
     format,
     minify: true,
     platform: 'node',

--- a/packages/@momentum-design/token-builder/esbuild.config.js
+++ b/packages/@momentum-design/token-builder/esbuild.config.js
@@ -1,10 +1,10 @@
 import { cli } from '../../../config/esbuild/esbuild.config.js';
 
+import packageDefinition from './package.json' assert { type: 'json' };
+
 cli({
   stage: 'production',
   extension: 'cjs',
-  external: [
-    'style-dictionary',
-  ],
+  external: Object.keys(packageDefinition.dependencies),
   format: 'cjs',
 });

--- a/packages/@momentum-design/token-builder/esbuild.config.js
+++ b/packages/@momentum-design/token-builder/esbuild.config.js
@@ -1,0 +1,10 @@
+import { cli } from '../../../config/esbuild/esbuild.config.js';
+
+cli({
+  stage: 'production',
+  extension: 'cjs',
+  external: [
+    'style-dictionary',
+  ],
+  format: 'cjs',
+});

--- a/packages/@momentum-design/token-builder/esbuild.config.mjs
+++ b/packages/@momentum-design/token-builder/esbuild.config.mjs
@@ -1,3 +1,0 @@
-import { cli } from '../../../config/esbuild/esbuild.config.js';
-
-cli({ stage: 'production', format: 'cjs' });

--- a/packages/@momentum-design/token-builder/jest.config.js
+++ b/packages/@momentum-design/token-builder/jest.config.js
@@ -1,4 +1,6 @@
-module.exports = {
-  preset: 'ts-jest',
+const config = {
+  preset: 'ts-jest/presets/js-with-ts-esm',
   testEnvironment: 'node',
 };
+
+export default config;

--- a/packages/@momentum-design/token-builder/package.json
+++ b/packages/@momentum-design/token-builder/package.json
@@ -7,14 +7,14 @@
     "npm": ">=8.0.0",
     "yarn": ">=3.0.0"
   },
-  "type": "commonjs",
+  "type": "module",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "./dist"
   ],
   "bin": {
-    "md-token-builder": "./dist/main.js"
+    "md-token-builder": "./dist/cli/index.cjs"
   },
   "scripts": {
     "analyze": "yarn analyze:prebuild",
@@ -22,7 +22,8 @@
     "analyze:postbuild": "echo \"script 'analyze:postbuild' has not been implemented\"",
     "analyze:prebuild": "yarn analyze:lint && yarn analyze:syntax",
     "analyze:syntax": "tsc --noEmit",
-    "build": "yarn build:module",
+    "build": "yarn build:cli && yarn build:module",
+    "build:cli": "node ./esbuild.config.js",
     "build:module": "tsc",
     "clean": "yarn clean:dist",
     "clean:dist": "rimraf ./dist",

--- a/packages/@momentum-design/token-builder/package.json
+++ b/packages/@momentum-design/token-builder/package.json
@@ -8,7 +8,7 @@
     "yarn": ">=3.0.0"
   },
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/module/index.js",
   "types": "./dist/types/index.d.ts",
   "files": [
     "./dist"
@@ -37,7 +37,7 @@
     "publish:npmjs": "echo \"script 'publish:npmjs' has not been implemented\"",
     "start": "node ./dist/main.js",
     "test": "yarn test:prebuild && yarn test:postbuild",
-    "test:integration": "jest ./test/*/*.test.ts",
+    "test:integration": "yarn node --experimental-vm-modules $(yarn bin jest) ./test/*/*.test.ts",
     "test:postbuild": "yarn test:integration",
     "test:prebuild": "yarn test:unit",
     "test:unit": "jest ./src/**/*.test.ts"

--- a/packages/@momentum-design/token-builder/test/module/module.test.ts
+++ b/packages/@momentum-design/token-builder/test/module/module.test.ts
@@ -1,5 +1,6 @@
-import * as configCoreColor from '../fixtures/config/config-core-color.json';
-import { TokenBuilder, Config } from '../../dist/index';
+import { TokenBuilder, Config } from '@momentum-design/token-builder';
+
+import configCoreColor from '../fixtures/config/config-core-color.json';
 import { fileToJson } from '../../utils/test/utils';
 
 describe('Token Builder module', () => {
@@ -9,6 +10,7 @@ describe('Token Builder module', () => {
       input: './test/fixtures/inputs',
       output: './test/dist',
     });
+
     const relativePath = `./test/dist/json/${configCoreColor.files[0].destination}.json`;
     const output = await fileToJson(relativePath);
     expect(output).toMatchObject({});

--- a/packages/@momentum-design/token-builder/tsconfig.json
+++ b/packages/@momentum-design/token-builder/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "extends": "../../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
+    "allowJs": true,
     "declarationDir": "./dist/types",
     "module": "ES6",
     "outDir": "./dist/module"

--- a/packages/@momentum-design/token-builder/tsconfig.json
+++ b/packages/@momentum-design/token-builder/tsconfig.json
@@ -5,8 +5,9 @@
   ],
   "extends": "../../../config/typescript/tsconfig.base.json",
   "compilerOptions": {
-    "module": "CommonJS",
-    "outDir": "./dist"
+    "declarationDir": "./dist/types",
+    "module": "ES6",
+    "outDir": "./dist/module"
   },
   "include": [
     "./src/**/*"

--- a/packages/@momentum-design/tokens/README.md
+++ b/packages/@momentum-design/tokens/README.md
@@ -7,7 +7,7 @@ Cisco's **momentum-design** tokens package.
 
 ## Usage
 
-**TODO** 1
+**TODO**
 
 ## Contribution
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,7 +1360,7 @@ __metadata:
     typescript: ^4.8.4
     yargs: ^17.6.0
   bin:
-    md-token-builder: ./dist/main.js
+    md-token-builder: ./dist/cli/index.cjs
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
# Description

The scope of the changes in this Pull Request are to make the `@momentum-design/token-builder` into a module as ESM for exporting.
