### PR TITLE
fix(automation): git index for changes on deploy

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -118,7 +118,7 @@ jobs:
 
       - id: generate-package-matrix
         name: Generate Package Matrix
-        run: echo "packages=$(yarn md-automation -- --command get-packages --changed --commit-index 2 --dependent)" >> $GITHUB_OUTPUT
+        run: echo "packages=$(yarn md-automation -- --command get-packages --changed --commit-index 1 --dependent)" >> $GITHUB_OUTPUT
 
       - name: Display Package Matrix
         run: echo "generated package matrix - ${{ steps.generate-package-matrix.outputs.packages }}"


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to fix the index used when determining which changes need to be deployed. This was previously looking back one additional merge, causing it to publish packages with potentially no changes in them.

Below is from a PR that only had changes within `@momentum-design/tokens` and `@momentum-design/token-builder`. As noted, it looked back at the previous PR, which included all packages within its changes.

<img width="342" alt="Screen Shot 2022-11-14 at 4 06 30 PM" src="https://user-images.githubusercontent.com/14828820/201765532-55062759-ecc7-47e3-a63e-011f61f6f196.png">