### PR TITLE
feat(builder): added icons builder and icons package

### DIFF
--- a/packages/@momentum-design/builder/esbuild.config.mjs
+++ b/packages/@momentum-design/builder/esbuild.config.mjs
@@ -3,7 +3,7 @@ import packageDefinition from './package.json' assert { type: 'json' };
 
 cli({
   stage: 'production',
-  extension: 'cjs',
+  extension: 'js',
   external: Object.keys(packageDefinition.dependencies).filter((value) => !value.includes('@momentum-design')),
   format: 'cjs',
 });

--- a/packages/@momentum-design/builder/package.json
+++ b/packages/@momentum-design/builder/package.json
@@ -42,12 +42,15 @@
   },
   "dependencies": {
     "@momentum-design/common": "workspace:^",
+    "glob": "^8.0.3",
     "style-dictionary": "^3.7.1",
     "yargs": "^17.6.2"
   },
   "devDependencies": {
     "@microsoft/api-documenter": "^7.19.24",
     "@microsoft/api-extractor": "^7.33.6",
+    "@types/fs-extra": "^9.0.13",
+    "@types/glob": "^8.0.0",
     "@types/jest": "^29.2.3",
     "@types/node": "^18.11.9",
     "@types/yargs": "^17.0.13",

--- a/packages/@momentum-design/builder/src/commands/definition/definition.ts
+++ b/packages/@momentum-design/builder/src/commands/definition/definition.ts
@@ -2,6 +2,7 @@ import { Command } from '@momentum-design/common';
 
 import { Builders } from '../../models';
 import { TokensBuilder } from '../../tokens';
+import { IconsBuilder } from '../../icons';
 
 import CONSTANTS from './constants';
 import type { Options, Params } from './types';
@@ -58,6 +59,7 @@ class Definition extends Command<Options, Params> {
       definitionPath: config,
       builders: [
         TokensBuilder,
+        IconsBuilder,
       ],
     });
 

--- a/packages/@momentum-design/builder/src/icons/builder/builder.ts
+++ b/packages/@momentum-design/builder/src/icons/builder/builder.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-redeclare */
+import glob from 'glob';
+import path from 'path';
+import { Builder as CoreBuilder } from '../../models';
+import CONSTANTS from './constants';
+import type { Config } from './types';
+
+interface Builder {
+    config: Config
+    filePaths: Array<any>;
+}
+
+class Builder extends CoreBuilder {
+  /**
+   * Construct a new icons Builder.
+   *
+   * @remarks
+   * This method has not been fully implemented.
+   *
+   * @param config - Configuration Object to be mounted to this Builder.
+   */
+  public constructor(config: Config) {
+    const { srcDir, distDir, ...other } = config;
+    super({ ...other, type: 'icons' });
+
+    this.config.srcDir = srcDir;
+    this.config.distDir = distDir;
+    this.filePaths = [];
+  }
+
+  public override initialize(): Promise<this> {
+    const fullInputDir = path.join(process.cwd(), this.config.srcDir);
+
+    return new Promise((resolve, reject) => {
+      glob(`${fullInputDir}/**/*.*`, {}, (er, files) => {
+        this.filePaths = files;
+        if (er) {
+          reject(er);
+        }
+        resolve(this);
+      });
+    });
+  }
+
+  public override process(): Promise<this> {
+    // icons transform
+    console.log(this.filePaths);
+
+    // const fullDistDir = path.join(process.cwd(), this.config.distDir);
+
+    // TODO: add optimize (SVGO) & transforms (CSS, SCSS, Fonts, etc.) here
+    return Promise.resolve(this);
+  }
+
+  /**
+   * Constants associated with this Builder.
+   */
+  public static override get CONSTANTS(): typeof CONSTANTS {
+    return structuredClone(CONSTANTS);
+  }
+
+  /**
+   * Type of this Builder.
+   */
+  public static override get type(): string {
+    return Builder.CONSTANTS.TYPE;
+  }
+}
+
+export default Builder;

--- a/packages/@momentum-design/builder/src/icons/builder/constants.ts
+++ b/packages/@momentum-design/builder/src/icons/builder/constants.ts
@@ -1,0 +1,13 @@
+import { Builder } from '../../models';
+
+/**
+ * Type of this Builder.
+ */
+const TYPE: string = 'icons';
+
+const CONSTANTS = {
+  ...Builder.CONSTANTS,
+  TYPE,
+};
+
+export default CONSTANTS;

--- a/packages/@momentum-design/builder/src/icons/builder/index.ts
+++ b/packages/@momentum-design/builder/src/icons/builder/index.ts
@@ -1,0 +1,7 @@
+import Builder from './builder';
+
+export type {
+  Config as BuilderConfig,
+} from './types';
+
+export default Builder;

--- a/packages/@momentum-design/builder/src/icons/builder/types.ts
+++ b/packages/@momentum-design/builder/src/icons/builder/types.ts
@@ -1,0 +1,6 @@
+import type { BuilderConfig } from '../../models';
+
+export interface Config extends BuilderConfig {
+    srcDir: string;
+    distDir: string;
+}

--- a/packages/@momentum-design/builder/src/icons/index.ts
+++ b/packages/@momentum-design/builder/src/icons/index.ts
@@ -1,0 +1,7 @@
+import Builder from './builder';
+
+export type {
+  BuilderConfig as IconsBuilderConfig,
+} from './builder';
+
+export { Builder as IconsBuilder };

--- a/packages/@momentum-design/builder/src/index.ts
+++ b/packages/@momentum-design/builder/src/index.ts
@@ -17,6 +17,14 @@ export type {
 } from './models';
 
 export {
+  IconsBuilder,
+} from './icons';
+
+export type{
+  IconsBuilderConfig,
+} from './icons';
+
+export {
   TokensBuilder,
 } from './tokens';
 

--- a/packages/@momentum-design/builder/src/models/builder/builder.ts
+++ b/packages/@momentum-design/builder/src/models/builder/builder.ts
@@ -98,7 +98,7 @@ class Builder {
    * @param target - Target path to attempt to read and mount to this Builder.
    * @returns - This Builder after executing this method.
    */
-  public read(target: string = this.config.definitionPath): Promise<this> {
+  public read(target: string | undefined = this.config.definitionPath): Promise<this> {
     if (!target) {
       return Promise.resolve(this);
     }

--- a/packages/@momentum-design/builder/src/models/builder/types.ts
+++ b/packages/@momentum-design/builder/src/models/builder/types.ts
@@ -7,7 +7,7 @@ export interface Config {
   /**
    * Path to the configuration definition for this Builder.
    */
-  definitionPath: string;
+  definitionPath?: string;
 
   [key: string]: any;
 }

--- a/packages/@momentum-design/icons/config/webex.json
+++ b/packages/@momentum-design/icons/config/webex.json
@@ -1,0 +1,7 @@
+{
+    "definitions": [{
+        "srcDir": "./src",
+        "distDir": "./dist",
+        "type": "icons"
+    }]
+}

--- a/packages/@momentum-design/icons/package.json
+++ b/packages/@momentum-design/icons/package.json
@@ -9,7 +9,8 @@
     "analyze": "yarn analyze:prebuild && yarn analyze:postbuild",
     "analyze:postbuild": "echo \"script 'analyze:postbuild' has not been implemented\"",
     "analyze:prebuild": "echo \"script 'analyze:prebuild' has not been implemented\"",
-    "build": "echo \"script 'build' has not been implemented\"",
+    "build": "yarn build:core",
+    "build:core": "md-builder -- --definition --icons --config ./config/webex.json",
     "clean": "echo \"script 'clean' has not been implemented\"",
     "docs": "echo \"script 'docs' has not been implemented\"",
     "publish": "yarn publish:npmjs",
@@ -19,6 +20,7 @@
     "test:prebuild": "echo \"script 'test:prebuild' has not been implemented\""
   },
   "devDependencies": {
+    "@momentum-design/builder": "workspace:^",
     "rimraf": "^3.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,13 +1159,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@momentum-design/builder@workspace:packages/@momentum-design/builder":
+"@momentum-design/builder@workspace:^, @momentum-design/builder@workspace:packages/@momentum-design/builder":
   version: 0.0.0-use.local
   resolution: "@momentum-design/builder@workspace:packages/@momentum-design/builder"
   dependencies:
     "@microsoft/api-documenter": ^7.19.24
     "@microsoft/api-extractor": ^7.33.6
     "@momentum-design/common": "workspace:^"
+    "@types/fs-extra": ^9.0.13
+    "@types/glob": ^8.0.0
     "@types/jest": ^29.2.3
     "@types/node": ^18.11.9
     "@types/yargs": ^17.0.13
@@ -1174,6 +1176,7 @@ __metadata:
     esbuild: ^0.15.14
     eslint: ^8.27.0
     eslint-plugin-import: ^2.26.0
+    glob: ^8.0.3
     jest: ^29.3.1
     rimraf: ^3.0.2
     style-dictionary: ^3.7.1
@@ -1217,6 +1220,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@momentum-design/icons@workspace:packages/@momentum-design/icons"
   dependencies:
+    "@momentum-design/builder": "workspace:^"
     rimraf: ^3.0.2
   languageName: unknown
   linkType: soft
@@ -1484,6 +1488,15 @@ __metadata:
   version: 1.1.3
   resolution: "@types/fined@npm:1.1.3"
   checksum: f4a1b6e6976991cf144fb078d2a30f1a0fd27b2301382c3a14359f003c67b69a779a2518dd6f0d859f2457eb29ba81f05a5980ffdfe1190fe553fbf92c2c4a4f
+  languageName: node
+  linkType: hard
+
+"@types/fs-extra@npm:^9.0.13":
+  version: 9.0.13
+  resolution: "@types/fs-extra@npm:9.0.13"
+  dependencies:
+    "@types/node": "*"
+  checksum: add79e212acd5ac76b97b9045834e03a7996aef60a814185e0459088fd290519a3c1620865d588fa36c4498bf614210d2a703af5cf80aa1dbc125db78f6edac3
   languageName: node
   linkType: hard
 
@@ -3974,7 +3987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.1":
+"glob@npm:^8.0.1, glob@npm:^8.0.3":
   version: 8.0.3
   resolution: "glob@npm:8.0.3"
   dependencies:


### PR DESCRIPTION
# Description

- Extended the builder package with icons
  - Modified initialise, more to come on the process method. 
- Added config & build script to `icons` package, which will transform & optimise the `src` folder and outputs it to `dist` folder (this will be the dist we are trying to have the same as momentum-ui does for the icons)
