### PR TITLE
feat(remove-defualt): defualt typo in schemas

### DIFF
--- a/packages/@momentum-design/token-builder/src/schemas/json/common.json
+++ b/packages/@momentum-design/token-builder/src/schemas/json/common.json
@@ -428,7 +428,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-              "defualt": {
+              "default": {
                   "$ref": "#/definitions/Icon"
               },
               "pressed": {
@@ -436,7 +436,7 @@
               }
           },
           "required": [
-              "defualt",
+              "default",
               "pressed"
           ],
           "title": "Mint"

--- a/packages/@momentum-design/token-builder/src/schemas/json/dark.json
+++ b/packages/@momentum-design/token-builder/src/schemas/json/dark.json
@@ -296,9 +296,6 @@
               },
               "active": {
                   "$ref": "#/definitions/Active"
-              },
-              "defualt": {
-                  "$ref": "#/definitions/Primary"
               }
           },
           "required": [
@@ -793,9 +790,6 @@
               },
               "active": {
                   "$ref": "#/definitions/Active"
-              },
-              "defualt": {
-                  "$ref": "#/definitions/Primary"
               },
               "primary": {
                   "$ref": "#/definitions/Primary"

--- a/packages/@momentum-design/token-builder/src/schemas/json/light.json
+++ b/packages/@momentum-design/token-builder/src/schemas/json/light.json
@@ -187,7 +187,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-              "defualt": {
+              "default": {
                   "$ref": "#/definitions/SecondaryClass"
               },
               "hover": {
@@ -195,7 +195,7 @@
               }
           },
           "required": [
-              "defualt",
+              "default",
               "hover"
           ],
           "title": "GradientAccent"
@@ -317,9 +317,6 @@
               },
               "active": {
                   "$ref": "#/definitions/Active"
-              },
-              "defualt": {
-                  "$ref": "#/definitions/SecondaryClass"
               }
           },
           "required": [
@@ -790,9 +787,6 @@
               },
               "active": {
                   "$ref": "#/definitions/Active"
-              },
-              "defualt": {
-                  "$ref": "#/definitions/SecondaryClass"
               },
               "primary": {
                   "$ref": "#/definitions/SecondaryClass"

--- a/packages/@momentum-design/tokens/src/theme/webex/common.json
+++ b/packages/@momentum-design/tokens/src/theme/webex/common.json
@@ -323,7 +323,7 @@
             }
           },
           "mint": {
-            "defualt": {
+            "default": {
               "value": "{color.decorative.pink.60}",
               "type": "color"
             },
@@ -333,7 +333,7 @@
             }
           },
           "purple": {
-            "defualt": {
+            "default": {
               "value": "{color.decorative.purple.60}",
               "type": "color"
             },
@@ -343,7 +343,7 @@
             }
           },
           "violet": {
-            "defualt": {
+            "default": {
               "value": "{color.decorative.violet.60}",
               "type": "color"
             },
@@ -353,7 +353,7 @@
             }
           },
           "orange": {
-            "defualt": {
+            "default": {
               "value": "{color.core.orange.60}",
               "type": "color"
             },

--- a/packages/@momentum-design/tokens/src/theme/webex/dark.json
+++ b/packages/@momentum-design/tokens/src/theme/webex/dark.json
@@ -752,7 +752,7 @@
           },
           "accent": {
             "active": {
-              "defualt": {
+              "default": {
                 "value": "{color.core.blue.40}",
                 "type": "color",
                 "description": "Core Token: core.blue.40\nHEX: 64B4FA\n--------------\nRest state of control components(radio, toggle, checkbox)"

--- a/packages/@momentum-design/tokens/src/theme/webex/light.json
+++ b/packages/@momentum-design/tokens/src/theme/webex/light.json
@@ -747,7 +747,7 @@
           },
           "accent": {
             "active": {
-              "defualt": {
+              "default": {
                 "value": "{color.core.blue.60}",
                 "type": "color",
                 "description": "Core Token: core.blue.60\nHEXL: 0A78CC\n------------------------------\nUsed for rest state of control components (radio, toggle, checkbox)"
@@ -883,7 +883,7 @@
               }
             },
             "negative": {
-              "defualt": {
+              "default": {
                 "value": "linear-gradient(90deg, #AB0A1500 0%, #AB0A1599 22.4%, #AB0A1599 76.04%, #AB0A1500 100%)",
                 "type": "color",
                 "description": "Core Token: core.red.70 0% 0%, core.red.70 60% 22.4%, core.red.70 60% 76.04%,  core.red.70 0% 100%\nHEX: linear-gradient(90deg, #AB0A1500 0%, #AB0A1599 22.4%, #AB0A1599 76.04%, #AB0A1500 100%)\n--------------------------------\nUsed for divider default on the compose area for classified spaces. "
@@ -895,7 +895,7 @@
               }
             },
             "warning": {
-              "defualt": {
+              "default": {
                 "value": "linear-gradient(90deg, #7D470500 0%, #7D470599 22.4%, #7D470599 76.04%, #7D470500 100%)",
                 "type": "color",
                 "description": "Core Token: core.yellow.40 0% 0%, core.yellow.40 60% 22.4%, core.yellow.40 60% 76.04%, core.yellow.40 0% 100%\nHEX: linear-gradient(90deg, #7D470500 0%, #7D470599 22.4%, #7D470599 76.04%, #7D470500 100%)\n--------------------------------\nUsed for divider on the compose area for external participants."
@@ -907,7 +907,7 @@
               }
             },
             "accent": {
-              "defualt": {
+              "default": {
                 "value": "linear-gradient(90deg, #0352A600 0%, #0352A699 22.4%, #0352A699 76.04%, #0352A600 100%)",
                 "type": "color",
                 "description": "Core Token: core.blue.40 0% 0%, core.blue.40 60% 22.4%, core.blue.40 60% 76.04%, core.blue.40 0% 100%\nHEX: linear-gradient(90deg, #0352A600 0%, #0352A699 22.4%, #0352A699 76.04%, #0352A600 100%)\n--------------------------------\nUsed for divider on the compose area for the announcement space."


### PR DESCRIPTION
# Description

Schemas had a typo on default (using 'defualt'). Correcting it in this PR so that https://github.com/momentum-design/momentum-design/pull/160 can be testes against correct schemas.

# Notes
Im only changing the theme/webex files so that the pipeline in this PR passes. But I do not intend this changes to be permanent, but overwritten by design-token-updates branch PRs