### PR TITLE
Feat/token builder/json minimal format

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,5 @@
-name: Deploy Docs site to Pages
+name: Deploy Documentation CD
+run-name: ${{ github.actor }} is running Deploy Documentation CD
 
 on:
   push:

--- a/packages/@momentum-design/token-builder/src/common/constants.ts
+++ b/packages/@momentum-design/token-builder/src/common/constants.ts
@@ -39,8 +39,19 @@ const SD_FORMATS = {
   },
 };
 
+const LOCAL_FORMATS = {
+  MD_JSON_MINIMAL: {
+    EXTENSION: 'json',
+    FORMAT: 'md-json-minimal',
+    GROUP: 'md',
+    NAME: 'md/json-minimal',
+    PATH: './json-minimal/',
+  },
+};
+
 const FORMATS = {
   ...SD_FORMATS,
+  ...LOCAL_FORMATS,
 };
 
 const SD_TRANSFORMS = {
@@ -60,6 +71,7 @@ const TRANSFORMS = {
 const CONSTANTS = {
   FILE_ENCODING,
   FORMATS,
+  LOCAL_FORMATS,
   LOCAL_TRANSFORMS,
   SD_FORMATS,
   SD_TRANSFORMS,

--- a/packages/@momentum-design/token-builder/src/formats/index.ts
+++ b/packages/@momentum-design/token-builder/src/formats/index.ts
@@ -1,0 +1,5 @@
+import JsonMinimal from './json-minimal';
+
+export {
+  JsonMinimal as JsonMinimalFormat,
+};

--- a/packages/@momentum-design/token-builder/src/formats/json-minimal/constants.ts
+++ b/packages/@momentum-design/token-builder/src/formats/json-minimal/constants.ts
@@ -1,0 +1,7 @@
+import { CONSTANTS as COMMON_CONSTANTS } from '../../common';
+
+const CONSTANTS = {
+  NAME: COMMON_CONSTANTS.FORMATS.MD_JSON_MINIMAL.FORMAT,
+};
+
+export default CONSTANTS;

--- a/packages/@momentum-design/token-builder/src/formats/json-minimal/index.ts
+++ b/packages/@momentum-design/token-builder/src/formats/json-minimal/index.ts
@@ -1,0 +1,3 @@
+import JsonMinimal from './json-minimal';
+
+export default JsonMinimal;

--- a/packages/@momentum-design/token-builder/src/formats/json-minimal/json-minimal.ts
+++ b/packages/@momentum-design/token-builder/src/formats/json-minimal/json-minimal.ts
@@ -1,0 +1,48 @@
+import { Format as SDFormat, Formatter as SDFormatter } from 'style-dictionary';
+
+import CONSTANTS from './constants';
+
+class JsonMinimal {
+  public get formatter(): SDFormatter {
+    return ({ dictionary }): string => {
+      const mutable = {};
+
+      dictionary.allTokens.forEach((token) => {
+        let current: Record<string, any>;
+
+        token.path.forEach((path, index) => {
+          if (!current) {
+            current = mutable;
+          }
+
+          current[path] = current[path] || {};
+
+          if (index === token.path.length - 1) {
+            current[path] = token.value;
+          }
+
+          current = current[path];
+        });
+      });
+
+      return JSON.stringify(mutable, null, 2);
+    };
+  }
+
+  public get name(): string {
+    return JsonMinimal.CONSTANTS.NAME;
+  }
+
+  public get sdConfig(): SDFormat {
+    return {
+      name: this.name,
+      formatter: this.formatter,
+    };
+  }
+
+  public static get CONSTANTS(): typeof CONSTANTS {
+    return structuredClone(CONSTANTS);
+  }
+}
+
+export default JsonMinimal;

--- a/packages/@momentum-design/token-builder/src/index.ts
+++ b/packages/@momentum-design/token-builder/src/index.ts
@@ -1,5 +1,14 @@
 export { CONSTANTS } from './common';
+export { JsonMinimalFormat } from './formats';
 export { Dictionary, File, Platform, TokenBuilder } from './models';
+export { ElevationTransform } from './transforms';
 
 export type { Format, Filter, Filters, ConfigFile, Config } from './common';
 export type { DictionaryConfig, FileConfig, PlatformConfig, TokenBuilderConfig } from './models';
+export type {
+  ElevationTransformConfig,
+  ElevationTransformMatcher,
+  ElevationTransformToken,
+  ElevationTransformTransformer,
+  ElevationTransformType,
+} from './transforms';

--- a/packages/@momentum-design/token-builder/src/models/token-builder/token-builder.ts
+++ b/packages/@momentum-design/token-builder/src/models/token-builder/token-builder.ts
@@ -12,7 +12,8 @@ import {
 } from '@momentum-design/telemetry';
 import { SomeJSONSchema } from 'ajv/dist/types/json-schema';
 import { CONSTANTS, Config as ExternalConfig } from '../../common';
-import { Elevation as ElevationTransform } from '../../transforms';
+import { ElevationTransform } from '../../transforms';
+import { JsonMinimalFormat } from '../../formats';
 import Dictionary from '../dictionary';
 
 import type { Config } from './types';
@@ -68,6 +69,27 @@ class TokenBuilder {
                   transform = new ElevationTransform();
 
                   StyleDictionary.registerTransform(transform.sdConfig);
+                  break;
+
+                default:
+              }
+            });
+        }
+
+        if (configObj.formats) {
+          configObj.formats.filter((format) => Object.keys(CONSTANTS.LOCAL_FORMATS).includes(format))
+            .forEach((formatKey) => {
+              console.log('found format', formatKey);
+              const formatName = CONSTANTS.FORMATS[formatKey].NAME;
+
+              let format: JsonMinimalFormat;
+
+              switch (formatName) {
+                case CONSTANTS.LOCAL_FORMATS.MD_JSON_MINIMAL.NAME:
+                  console.log('mounting format');
+                  format = new JsonMinimalFormat();
+
+                  StyleDictionary.registerFormat(format.sdConfig);
                   break;
 
                 default:

--- a/packages/@momentum-design/token-builder/src/models/token-builder/token-builder.ts
+++ b/packages/@momentum-design/token-builder/src/models/token-builder/token-builder.ts
@@ -79,14 +79,12 @@ class TokenBuilder {
         if (configObj.formats) {
           configObj.formats.filter((format) => Object.keys(CONSTANTS.LOCAL_FORMATS).includes(format))
             .forEach((formatKey) => {
-              console.log('found format', formatKey);
               const formatName = CONSTANTS.FORMATS[formatKey].NAME;
 
               let format: JsonMinimalFormat;
 
               switch (formatName) {
                 case CONSTANTS.LOCAL_FORMATS.MD_JSON_MINIMAL.NAME:
-                  console.log('mounting format');
                   format = new JsonMinimalFormat();
 
                   StyleDictionary.registerFormat(format.sdConfig);

--- a/packages/@momentum-design/token-builder/src/transforms/elevation/index.ts
+++ b/packages/@momentum-design/token-builder/src/transforms/elevation/index.ts
@@ -1,3 +1,11 @@
 import Elevation from './elevation';
 
+export type {
+  Config as ElevationConfig,
+  Matcher as ElevationMatcher,
+  Token as ElevationToken,
+  Transformer as ElevationTransformer,
+  Type as ElevationType,
+} from './types';
+
 export default Elevation;

--- a/packages/@momentum-design/token-builder/src/transforms/index.ts
+++ b/packages/@momentum-design/token-builder/src/transforms/index.ts
@@ -1,5 +1,13 @@
 import Elevation from './elevation';
 
+export type {
+  ElevationConfig as ElevationTransformConfig,
+  ElevationMatcher as ElevationTransformMatcher,
+  ElevationToken as ElevationTransformToken,
+  ElevationTransformer as ElevationTransformTransformer,
+  ElevationType as ElevationTransformType,
+} from './elevation';
+
 export {
-  Elevation,
+  Elevation as ElevationTransform,
 };

--- a/packages/@momentum-design/tokens/config/tokens/core.json
+++ b/packages/@momentum-design/tokens/config/tokens/core.json
@@ -27,7 +27,7 @@
       ]
     }
   ],
-  "formats": ["CSS_VARIABLES", "SCSS_VARIABLES", "WEB_JSON", "ANDROID_RESOURCES", "SWIFT_CLASS"],
+  "formats": ["CSS_VARIABLES", "SCSS_VARIABLES", "WEB_JSON", "ANDROID_RESOURCES", "SWIFT_CLASS", "MD_JSON_MINIMAL"],
   "prefix": "md",
   "outputReferences": true,
   "transforms": ["ATTRIBUTE_CTI", "NAME_CTI_KABAB", "MD_ELEVATION"]


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to create a new formatter for `token-builder` called `json-minimal`. This generates an extremely light-weight json DTO for distribution.

## Additional Changes

* Added Docs workflow username to runner
* Removed bad package script for a non-existant workspace
* Updated the `tokens` package to use the new formatter.