### PR TITLE
feat: added flows to assets builder

### DIFF
--- a/packages/@momentum-design/builder/FORMATS.md
+++ b/packages/@momentum-design/builder/FORMATS.md
@@ -1,0 +1,5 @@
+# Supported Output Formats
+
+Optimised SVG
+TTF
+Swift

--- a/packages/@momentum-design/builder/src/assets/builder/async-utils.ts
+++ b/packages/@momentum-design/builder/src/assets/builder/async-utils.ts
@@ -1,0 +1,49 @@
+import {
+  Logger,
+  generateMetadata,
+} from '@momentum-design/telemetry';
+import CONSTANTS from './constants';
+
+const PACKAGE = 'builder';
+const logger = Logger.child(generateMetadata(PACKAGE, `${CONSTANTS.TYPE}-async-utils`));
+
+/**
+ * The AsyncUtils class.
+ *
+ * Contains async utilities like executing in serial etc.
+ *
+ * @beta
+ */
+class AsyncUtils {
+  /**
+   * Async for-loop utility function
+   *
+   * @param promises - promise constructors to execute in serial
+   */
+  protected async asyncForLoop(promises: Array<() => Promise<any>>): Promise<void> {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const promise of promises) {
+      // eslint-disable-next-line no-await-in-loop
+      await promise();
+    }
+  }
+
+  /**
+   * Runs the provided promise constructors in serial
+   *
+   * @param promises - array of promise constructors to run in serial
+   * @returns Promise, which will resolve with this when all of the
+    * provided promise constructors resolve, or rejected when any promise is rejected
+   */
+  public series(promises: Array<() => Promise<any>>): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.asyncForLoop(promises).then(() => resolve(this))
+        .catch((error) => {
+          logger.error(`Error while executing in serial. Error: ${error}`);
+          reject(error);
+        });
+    });
+  }
+}
+
+export default AsyncUtils;

--- a/packages/@momentum-design/builder/src/assets/builder/builder.ts
+++ b/packages/@momentum-design/builder/src/assets/builder/builder.ts
@@ -32,9 +32,24 @@ class Builder extends CoreBuilder {
     const { flows, ...other } = config;
     super({ ...other, type: CONSTANTS.TYPE });
 
-    this.flows = flows.map((flowData) => new Flow(flowData));
+    this.flows = flows?.map((flowData) => new Flow(flowData));
 
     this.asyncUtils = new AsyncUtils();
+  }
+
+  /**
+   * Verifies the config
+   *
+   * @returns a Promise, which resolves if
+   * everythings fine / rejects if there is a problem in the config
+   */
+  public verifyConfig(): Promise<this> {
+    if (!this.flows.length) {
+      const reason = 'No \'flows\' found in config.';
+      logger.error(reason);
+      return Promise.reject(reason);
+    }
+    return Promise.resolve(this);
   }
 
   /**
@@ -43,7 +58,8 @@ class Builder extends CoreBuilder {
    */
   public override initialize(): Promise<this> {
     logger.info('Build started.');
-    return Promise.resolve(this);
+
+    return this.verifyConfig();
   }
 
   /**

--- a/packages/@momentum-design/builder/src/assets/builder/constants.ts
+++ b/packages/@momentum-design/builder/src/assets/builder/constants.ts
@@ -5,8 +5,13 @@ import { Builder } from '../../models';
  */
 const TYPE: string = 'assets';
 
+const FORMATS = {
+  OPTIMISED_SVG: 'OPTIMIZED_SVG' as const,
+};
+
 const CONSTANTS = {
   ...Builder.CONSTANTS,
+  FORMATS,
   TYPE,
 };
 

--- a/packages/@momentum-design/builder/src/assets/builder/file-handler.ts
+++ b/packages/@momentum-design/builder/src/assets/builder/file-handler.ts
@@ -7,7 +7,7 @@ import {
 import path from 'path';
 import CONSTANTS from './constants';
 
-export type File = {
+export type FileType = {
   srcPath: string;
   distPath?: string;
   data?: any;
@@ -41,7 +41,7 @@ class FileHandler {
    * @param distDir - dist directory, where files should be written to
    * @returns Array of file objects, including `srcPath` and `distPath`
    */
-  public createFileObjectsFromPaths(filePaths: Array<string>, distDir: string): Array<File> {
+  public createFileObjectsFromPaths(filePaths: Array<string>, distDir: string): Array<FileType> {
     return filePaths.map((path) => (
       { srcPath: path, distPath: this.replaceDirInPath(path, distDir) }
     ));
@@ -75,8 +75,8 @@ class FileHandler {
    * @param file - File to read data from
    * @returns Promise, which resolves to the file object with data if successful
    */
-  public readFile(file: File): Promise<File> {
-    return new Promise<File>((resolve, reject) => {
+  public readFile(file: FileType): Promise<FileType> {
+    return new Promise<FileType>((resolve, reject) => {
       fs.readFile(file.srcPath, 'utf-8', (error, data) => {
         if (error) {
           logger.error(`Error while reading file (${file.srcPath}): ${error}`);
@@ -96,8 +96,8 @@ class FileHandler {
    * @param file - File object, including `data` and `distPath`
    * @returns Promise, which resolves to the file object if successful
    */
-  public writeFile(file: File): Promise<File> {
-    return new Promise<File>((resolve, reject) => {
+  public writeFile(file: FileType): Promise<FileType> {
+    return new Promise<FileType>((resolve, reject) => {
       if (!file.distPath) {
         const errorMessage = `No distPath provided for file: ${file}`;
         logger.error(errorMessage);
@@ -122,7 +122,7 @@ class FileHandler {
    * @param files - files to read
    * @returns Promise, which resolves to file array if successful
    */
-  public readFiles(files: Array<File>): Promise<File[]> {
+  public readFiles(files: Array<FileType>): Promise<FileType[]> {
     return Promise.all(files.map(this.readFile));
   }
 
@@ -131,7 +131,7 @@ class FileHandler {
    * @param files - files to write
    * @returns Promise, which resolves to file array if successful
    */
-  public writeFiles(files: Array<File>): Promise<File[]> {
+  public writeFiles(files: Array<FileType>): Promise<FileType[]> {
     return Promise.all(files.map(this.writeFile));
   }
 }

--- a/packages/@momentum-design/builder/src/assets/builder/flow.ts
+++ b/packages/@momentum-design/builder/src/assets/builder/flow.ts
@@ -1,0 +1,106 @@
+import {
+  Logger,
+  generateMetadata,
+} from '@momentum-design/telemetry';
+import path from 'path';
+import CONSTANTS from './constants';
+import FileHandler from './file-handler';
+import type { FileType } from './file-handler';
+import type { FlowType, Formats } from './types';
+import Transformer from './transformer';
+
+const PACKAGE = 'builder';
+const logger = Logger.child(generateMetadata(PACKAGE, `${CONSTANTS.TYPE}-flow`));
+
+/**
+ * The Flow class.
+ *
+ * Contains flow properties and methods like reading, transforming and writing files
+ *
+ * @beta
+ */
+class Flow {
+    id: string;
+
+    target: string;
+
+    destination: string;
+
+    format: Formats;
+
+    files: Array<FileType>;
+
+    fileHandler: FileHandler;
+
+    transformer: Transformer;
+
+    public constructor(flowData: FlowType) {
+      this.id = flowData.id;
+      this.target = path.join(process.cwd(), flowData.target);
+      this.destination = path.join(process.cwd(), flowData.destination);
+      this.format = flowData.format;
+      this.files = [];
+
+      this.fileHandler = new FileHandler();
+      this.transformer = new Transformer();
+    }
+
+    /**
+     * Get file paths and read files
+     *
+     * @returns Promise of this
+     */
+    public read(): Promise<this> {
+      return new Promise((resolve, reject) => {
+        logger.info(`Started read step of flow '${this.id}'.`);
+        this.fileHandler.getFilePathsInFolder(this.target, (error, filePaths) => {
+          if (error) {
+            logger.error(`Error while parsing files in '${this.target}': ${error}`);
+            reject(error);
+          }
+
+          // create file objects array with srcPath & distPaths:
+          const fileObjects = this.fileHandler.createFileObjectsFromPaths(filePaths, this.destination);
+
+          this.fileHandler.readFiles(fileObjects).then((filesWithData) => {
+            this.files = filesWithData;
+            logger.info(`Finished read step of flow '${this.id}'.`);
+            resolve(this);
+          }).catch((error) => {
+            logger.error(`Error while reading files: ${error}`);
+          });
+        });
+      });
+    }
+
+    /**
+     * Transforming the files data
+     *
+     * This is still WIP, more transforms will be added
+     */
+    public transform(): void {
+      logger.info(`Started transform step of flow '${this.id}'.`);
+
+      if (this.format.type === CONSTANTS.FORMATS.OPTIMISED_SVG) {
+        this.files = this.transformer.optimizeSVGFiles(this.files, this.format.config);
+      }
+
+      logger.info(`Finished transform step of flow '${this.id}'.`);
+    }
+
+    /**
+     * Creates the destination folder if it doesn't exist and writes the files
+     *
+     * @returns Promise of array of files
+     */
+    public write(): Promise<this> {
+      logger.info(`Started write step of flow '${this.id}'.`);
+      this.fileHandler.createFolderIfNotExist(this.destination);
+      return this.fileHandler.writeFiles(this.files).then(() => {
+        logger.info(`Finished write step of flow '${this.id}'.`);
+        return this;
+      });
+    }
+}
+
+export default Flow;

--- a/packages/@momentum-design/builder/src/assets/builder/transformer.ts
+++ b/packages/@momentum-design/builder/src/assets/builder/transformer.ts
@@ -4,7 +4,7 @@ import {
 } from '@momentum-design/telemetry';
 import { optimize } from 'svgo';
 import CONSTANTS from './constants';
-import type { File } from './file-handler';
+import type { FileType } from './file-handler';
 import type { SVGOConfig } from './types';
 
 const PACKAGE = 'builder';
@@ -22,7 +22,7 @@ class Transformer {
    * @param svgoConfig - config for SVGO, which determines how the SVG will be optimised
    * @returns the file with opimised data
    */
-  public optimizeSVG(file: File, svgoConfig: SVGOConfig): File {
+  public optimizeSVG(file: FileType, svgoConfig: SVGOConfig): FileType {
     try {
       const optimizedData = optimize(file.data, svgoConfig).data;
       return ({ ...file, data: optimizedData });
@@ -38,7 +38,7 @@ class Transformer {
    * @param svgoConfig - config for SVGO, which determines how the SVGs will be optimised
    * @returns the files with opimised data
    */
-  public optimizeSVGFiles(files: Array<File>, svgoConfig: SVGOConfig): File[] {
+  public optimizeSVGFiles(files: Array<FileType>, svgoConfig: SVGOConfig): FileType[] {
     return files.map((file) => this.optimizeSVG(file, svgoConfig));
   }
 }

--- a/packages/@momentum-design/builder/src/assets/builder/types.ts
+++ b/packages/@momentum-design/builder/src/assets/builder/types.ts
@@ -1,19 +1,26 @@
 import type { Config as SVGOConfigType } from 'svgo';
 import type { BuilderConfig } from '../../models';
+import CONSTANTS from './constants';
 
 export type SVGOConfig = SVGOConfigType;
 
-export type FileType = 'svg';
+interface OptimizedSVGFormat {
+    type: typeof CONSTANTS.FORMATS.OPTIMISED_SVG,
+    config: SVGOConfig
+}
+
+export type Formats = OptimizedSVGFormat;
+
+export interface FlowType {
+    id: string;
+    target: string;
+    destination: string;
+    format: Formats,
+}
 
 /**
  * @beta
  */
 export interface Config extends BuilderConfig {
-    buildName: string;
-    srcDir: string;
-    distDir: string;
-    srcType: FileType;
-    distType: FileType;
-    svgoConfig: SVGOConfig;
-    templatePath: string;
+    flows: Array<FlowType>,
 }

--- a/packages/@momentum-design/builder/src/commands/definition/definition.ts
+++ b/packages/@momentum-design/builder/src/commands/definition/definition.ts
@@ -32,14 +32,8 @@ class Definition extends Command<Options, Params> {
    * @param results - Processed Builders class Object collect data from.
    * @returns - Promise resolving to a string to be emitted.
    */
-  public prepare(results: Builders): Promise<string> {
-    const { builders } = results;
-
-    const output = builders.map((builder) => `executed "${builder.type}" builder`);
-    return Promise.resolve([
-      Definition.CONSTANTS.HEADER,
-      ...output,
-    ].join('\n'));
+  public prepare(): Promise<string> {
+    return Promise.resolve('');
   }
 
   /**

--- a/packages/@momentum-design/builder/src/commands/definition/definition.unit.test.ts
+++ b/packages/@momentum-design/builder/src/commands/definition/definition.unit.test.ts
@@ -1,6 +1,3 @@
-import { Builder, Builders } from '../../models';
-import type { BuilderConfig, BuildersConfig } from '../../models';
-
 import Definition from './definition';
 import CONSTANTS from './constants';
 
@@ -19,31 +16,10 @@ describe('@momentum-design/builder - Definition', () => {
 
   describe('scoped', () => {
     describe('prepare()', () => {
-      let builder: Builder;
-      let builderConfig: BuilderConfig;
-      let builders: Builders;
-      let buildersConfig: BuildersConfig;
-
-      beforeEach(() => {
-        builderConfig = { definitionPath: 'example-definition-path' };
-        buildersConfig = { builders: [Builder], definitionPath: 'example-definition-path' };
-        builder = new Builder(builderConfig);
-        builders = new Builders(buildersConfig);
-
-        builders.data.builders.push(builder);
-      });
-
-      it('should output the global header', () => (
-        definition.prepare(builders)
+      it('returns empty string', () => (
+        definition.prepare()
           .then((results) => {
-            expect(results.includes(Definition.CONSTANTS.HEADER)).toBe(true);
-          })
-      ));
-
-      it('should output details based on the type of each builder built', () => (
-        definition.prepare(builders)
-          .then((results) => {
-            expect(results.includes(builder.type)).toBe(true);
+            expect(results).toBe('');
           })
       ));
     });

--- a/packages/@momentum-design/builder/src/models/builder/builder.ts
+++ b/packages/@momentum-design/builder/src/models/builder/builder.ts
@@ -60,6 +60,22 @@ class Builder {
   }
 
   /**
+   * Final methods of this Builder.
+   *
+   * @remarks
+   * This method can be implemented in class definitions that extend this
+   * class. The scope of this method is to perform flows at the end of the build
+   * process.
+   *
+   * @virtual
+   *
+   * @returns - This Builder after executing this method.
+   */
+  public final(): Promise<this> {
+    return Promise.resolve(this);
+  }
+
+  /**
    * The type of this Builder.
    *
    * @virtual
@@ -80,7 +96,8 @@ class Builder {
   public build(): Promise<this> {
     return this.read()
       .then((self) => self.initialize())
-      .then((self) => self.process());
+      .then((self) => self.process())
+      .then(() => this.final());
   }
 
   /**

--- a/packages/@momentum-design/builder/src/models/builders/builders.ts
+++ b/packages/@momentum-design/builder/src/models/builders/builders.ts
@@ -103,6 +103,20 @@ class Builders extends Builder {
   }
 
   /**
+   * Final methods of this Builder.
+   *
+   * @remarks
+   * This method attemps to run the final method of all child Builder class
+   * Objects associated with this Builders class Object.
+   *
+   * @returns - This Buidler after executing this method.
+   */
+  public override final(): Promise<this> {
+    return Promise.all(this.data.builders.map((builder) => builder.final()))
+      .then(() => this);
+  }
+
+  /**
    * Constants associated with this Builders class.
    */
   public static override get CONSTANTS(): typeof CONSTANTS {

--- a/packages/@momentum-design/builder/tsconfig.json
+++ b/packages/@momentum-design/builder/tsconfig.json
@@ -4,7 +4,8 @@
   "compilerOptions": {
     "outDir": "./dist/module",
     "declarationDir": "./dist/types",
-    "module": "CommonJS"
+    "module": "CommonJS",
+    "experimentalDecorators": true
   },
   "include": [
     "./src/**/*"

--- a/packages/@momentum-design/icons/config/momentum.json
+++ b/packages/@momentum-design/icons/config/momentum.json
@@ -1,49 +1,52 @@
 {
     "definitions": [{
-        "buildName": "Optimize Core SVGs",
-        "srcDir": "./src/core",
-        "distDir": "./dist/svg",
-        "srcType": "svg",
-        "distType": "svg",
-        "svgoConfig": {
-            "mergePaths": true,
-            "plugins": [
-                {
-                    "name": "preset-default",
-                    "params": {
-                        "overrides": {
-                            "removeViewBox": false
+        "flows": [{
+            "id": "optimise-core-svgs",
+            "target": "./src/core/**/*.*",
+            "destination": "./dist/svg",
+            "format": {
+                "type": "OPTIMIZED_SVG",
+                "config": {
+                    "mergePaths": true,
+                    "plugins": [
+                        {
+                            "name": "preset-default",
+                            "params": {
+                                "overrides": {
+                                    "removeViewBox": false
+                                }
+                            }
+                        },
+                        {
+                            "name": "removeAttrs",
+                            "params": {
+                              "attrs": "(fill|stroke)"
+                            }
                         }
-                    }
-                },
-                {
-                    "name": "removeAttrs",
-                    "params": {
-                      "attrs": "(fill|stroke)"
-                    }
+                    ]
                 }
-            ]
-        },
-        "type": "assets"
-    }, {
-        "buildName": "Optimize Brand & Colored SVGs",
-        "srcDir": "./src/{colored,brand}",
-        "distDir": "./dist/svg",
-        "srcType": "svg",
-        "distType": "svg",
-        "svgoConfig": {
-            "mergePaths": true,
-            "plugins": [
-                {
-                    "name": "preset-default",
-                    "params": {
-                        "overrides": {
-                            "removeViewBox": false
+            }
+        }, {
+            "id": "optimise-brand-colored-svgs",
+            "target": "./src/{colored,brand}/**/*.*",
+            "destination": "./dist/svg",
+            "format": {
+                "type": "OPTIMIZED_SVG",
+                "config": {
+                    "mergePaths": true,
+                    "plugins": [
+                        {
+                            "name": "preset-default",
+                            "params": {
+                                "overrides": {
+                                    "removeViewBox": false
+                                }
+                            }
                         }
-                    }
+                    ]
                 }
-            ]
-        },
+            }
+        }],
         "type": "assets"
     }]
 }

--- a/packages/@momentum-design/illustrations/config/momentum.json
+++ b/packages/@momentum-design/illustrations/config/momentum.json
@@ -1,23 +1,28 @@
 {
     "definitions": [{
-        "buildName": "Optimize SVGs",
-        "srcDir": "./src",
-        "distDir": "./dist/svg",
-        "srcType": "svg",
-        "distType": "svg",
-        "svgoConfig": {
-            "mergePaths": true,
-            "plugins": [
-                {
-                    "name": "preset-default",
-                    "params": {
-                        "overrides": {
-                            "removeViewBox": false
+        "flows": [{
+            "id": "optimise-svgs",
+            "target": "./src/**/*.*",
+            "destination": "./dist/svg",
+            "format": {
+                "type": "OPTIMIZED_SVG",
+                "config": {
+                    "mergePaths": true,
+                    "plugins": [
+                        {
+                            "name": "preset-default",
+                            "params": {
+                                "overrides": {
+                                    "removeViewBox": false
+                                }
+                            }
                         }
-                    }
+                    ]
                 }
-            ]
-        },
+            }
+        }],
         "type": "assets"
     }]
 }
+
+


### PR DESCRIPTION
# Description

- Changed assets builder to allow flows
- Flows are running in series, such that they can be chained in the future in the config to convert svg -> css -> scss -> font etc.
- Added async utils for running promises in series
- Added Flow class abstraction for easier use

**Note:**
To test locally, build the builder and then build the icons package. 

**Upcoming work:**
- Add renaming step
- Extend Transformer class to allow different transforms, like SVG to CSS, etc.

