### PR TITLE
Feat/illustrations/initial publish

### DIFF
--- a/packages/@momentum-design/icons/package.json
+++ b/packages/@momentum-design/icons/package.json
@@ -12,6 +12,7 @@
     "build:core": "md-builder -- --definition --icons --config ./config/momentum.json",
     "clean": "yarn clean:dist",
     "clean:dist": "rimraf ./dist",
+    "prepublishOnly": "yarn clean && yarn build",
     "docs": "echo \"script 'docs' has not been implemented\"",
     "publish": "yarn publish:npmjs",
     "publish:npmjs": "yarn npm publish --access=public",

--- a/packages/@momentum-design/illustrations/package.json
+++ b/packages/@momentum-design/illustrations/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@momentum-design/illustrations",
   "packageManager": "yarn@3.2.4",
-  "private": true,
   "files": [
-    "./dist/*"
+    "./dist/"
   ],
   "scripts": {
     "analyze": "yarn analyze:prebuild && yarn analyze:postbuild",
@@ -13,9 +12,10 @@
     "build:core": "md-builder -- --definition --icons --config ./config/momentum.json",
     "clean": "yarn clean:dist",
     "clean:dist": "rimraf ./dist",
+    "prepublishOnly": "yarn clean && yarn build",
     "docs": "echo \"script 'docs' has not been implemented\"",
     "publish": "yarn publish:npmjs",
-    "publish:npmjs": "echo \"script 'publish:npmjs' has not been implemented\"",
+    "publish:npmjs": "yarn npm publish --access=public",
     "test": "yarn test:prebuild && yarn test:postbuild",
     "test:postbuild": "echo \"script 'test:prebuild' has not been implemented\"",
     "test:prebuild": "echo \"script 'test:prebuild' has not been implemented\""


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to initialize the publishing flows for illustrations package. This also includes a small fix to the `prepublish` script for `icons`.