### PR TITLE
fix: remove fill on colored icons

### DIFF
--- a/packages/@momentum-design/icons/config/momentum.json
+++ b/packages/@momentum-design/icons/config/momentum.json
@@ -58,6 +58,12 @@
                       "removeViewBox": false
                     }
                   }
+                },
+                {
+                  "name": "removeAttrs",
+                  "params": {
+                    "attrs": "path:fill:#0F0F0F"
+                  }
                 }
               ]
             }


### PR DESCRIPTION
# Description
Right now colored icons coming in have a fill on both the standard paths (black/white) and on the colored paths.
In momentum-design we do not remove the fill of colored icons so far, so that restricts consumers in color-theming also multi-colored icons.
This PR is removing the fill of paths, where the fill has the value "#0F0F0F", such that we can override that fill with theme colors in Momentum React v2.

This should also make sure only the hard coded colored parts are being kept on the svg, but not the themable colors.