### PR TITLE
feat(animations): export manifest.json of animations package

### DIFF
--- a/packages/@momentum-design/animations/config/momentum.json
+++ b/packages/@momentum-design/animations/config/momentum.json
@@ -1,0 +1,21 @@
+{
+  "definitions": [
+    {
+      "buildName": "Animations",
+      "flows": [
+        {
+          "id": "Manifest",
+          "target": "./dist/lottie/**/*.*",
+          "destination": "./dist/",
+          "format": {
+            "type": "MANIFEST",
+            "config": {
+              "fileName": "manifest.json"
+            }
+          }
+        }
+      ],
+      "type": "assets"
+    }
+  ]
+}

--- a/packages/@momentum-design/animations/package.json
+++ b/packages/@momentum-design/animations/package.json
@@ -8,7 +8,8 @@
     "analyze": "yarn analyze:prebuild && yarn analyze:postbuild",
     "analyze:postbuild": "echo \"script 'analyze:postbuild' has not been implemented\"",
     "analyze:prebuild": "echo \"script 'analyze:prebuild' has not been implemented\"",
-    "build": "ncp src dist",
+    "build": "ncp src dist && yarn build:manifest",
+    "build:manifest": "md-builder -- --definition --animations --config ./config/momentum.json",
     "clean": "echo \"script 'clean' has not been implemented\"",
     "docs": "echo \"script 'docs' has not been implemented\"",
     "publish": "yarn publish:npmjs",
@@ -18,6 +19,7 @@
     "test:prebuild": "echo \"script 'test:prebuild' has not been implemented\""
   },
   "devDependencies": {
+    "@momentum-design/builder": "workspace:^",
     "ncp": "^2.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2021,6 +2021,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@momentum-design/animations@workspace:packages/@momentum-design/animations"
   dependencies:
+    "@momentum-design/builder": "workspace:^"
     ncp: ^2.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
# Description

- This change is making sure we also export a `manifest.json` file as part of the animations package, which can be used by consumers to easier import animations in a automated process by consuming this JSON file.
- This will not change the existing animations, but only adds a new `manifest.json` file in the root.
