### PR TITLE
fix(asset): check image export settings before accepting

### DIFF
--- a/packages/@momentum-design/figma-plugin-assets-export/dist/index.js
+++ b/packages/@momentum-design/figma-plugin-assets-export/dist/index.js
@@ -1830,7 +1830,7 @@
     get asset() {
       return new Promise((resolve, reject) => {
         const { exportSettings, exportSettingsImage } = this.assetSetting.input.asset;
-        const imageExportSettings = this.isNodeContainingImage(this.node) ? exportSettingsImage : exportSettings;
+        const imageExportSettings = this.isNodeContainingImage(this.node) && exportSettingsImage ? exportSettingsImage : exportSettings;
         this.node.exportAsync(imageExportSettings).then((uint8Array) => {
           const imageData = this.isNodeContainingImage(this.node) ? import_buffer.Buffer.from(uint8Array).toString("base64") : import_buffer.Buffer.from(uint8Array).toString();
           const fileExtension = imageExportSettings.format.toLowerCase();

--- a/packages/@momentum-design/figma-plugin-assets-export/src/plugin/models/component.ts
+++ b/packages/@momentum-design/figma-plugin-assets-export/src/plugin/models/component.ts
@@ -91,7 +91,7 @@ class Component {
   get asset(): Promise<Asset> {
     return new Promise((resolve, reject) => {
       const { exportSettings, exportSettingsImage } = this.assetSetting.input.asset;
-      const imageExportSettings = this.isNodeContainingImage(this.node)
+      const imageExportSettings = this.isNodeContainingImage(this.node) && exportSettingsImage
         ? exportSettingsImage
         : exportSettings;
       this.node


### PR DESCRIPTION
# Description

- The `exportSettingsImage` is an optional variable which is mainly used to export images in Brand Visuals Library.
- When we try to export Icons and Illustrations, there is a chance of this variable being undefined which leads to plugin failure.
- This PR will fix the issue by double checking the `exportSettingsImage` variable before we consume it.
- Plus, I've added the `dist/index.js` file which is generated via `yarn build:plugin`.
