### PR TITLE
feat(ignore): add figma plugin dist dir to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,11 +121,7 @@ tests-out/
 
 ### SPECIAL CASES ###
 
-# figma plugin so that Design doesn't have to run a build
-# this means that we will have to build and push
-# not part of pipeline as of now
-!packages/@momentum-design/figma-plugin-assets-export/dist
-
+packages/@momentum-design/figma-plugin-assets-export/dist
 packages/@momentum-design/components/config/storybook/public/icons
 
 # MAC system File


### PR DESCRIPTION
# Description

- Ignore `dist/**` directory in `figma-plugin-assets-export` package.

<img width="321" alt="Screenshot 2024-08-05 at 2 16 49 PM" src="https://github.com/user-attachments/assets/fb142fbf-db84-4a4d-a89c-3277fc49210e">
