### PR TITLE
fix(ci): remove validate dependencies to avoid cache issues

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -25,13 +25,6 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
-          
-      - name: Validate Dependencies
-        id: validate-dependencies
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install Dependencies
         run: yarn

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -59,13 +59,6 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
-          
-      - name: Validate Dependencies
-        id: validate-dependencies
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: node-modules-${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install Dependencies
         run: yarn


### PR DESCRIPTION
# Description

- The validate dependencies action does cause a runtime issue, where the wrong cache is used during CI.
- This will make sure the latest dependency update is always used for the pipeline by always using the correct cache.