### PR TITLE
fix(icons): clean-css-cli by moving to subpackage

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",
     "astro-eslint-parser": "^0.9.0",
-    "clean-css-cli": "^4.2.1",
     "esbuild": "^0.23.0",
     "eslint": "^8.27.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/packages/assets/icons/package.json
+++ b/packages/assets/icons/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@momentum-design/builder": "workspace:^",
+    "clean-css-cli": "^5.6.3",
     "rimraf": "^6.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,6 +3825,7 @@ __metadata:
   resolution: "@momentum-design/icons@workspace:packages/assets/icons"
   dependencies:
     "@momentum-design/builder": "workspace:^"
+    clean-css-cli: ^5.6.3
     rimraf: ^6.0.1
   languageName: unknown
   linkType: soft
@@ -6851,7 +6852,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.6.0":
+"chokidar@npm:^3.5.2, chokidar@npm:^3.6.0":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -6907,25 +6908,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clean-css-cli@npm:^4.2.1":
-  version: 4.3.0
-  resolution: "clean-css-cli@npm:4.3.0"
+"clean-css-cli@npm:^5.6.3":
+  version: 5.6.3
+  resolution: "clean-css-cli@npm:5.6.3"
   dependencies:
-    clean-css: ^4.2.1
-    commander: 2.x
-    glob: 7.x
+    chokidar: ^3.5.2
+    clean-css: ^5.3.3
+    commander: 7.x
+    glob: ^7.1.6
   bin:
-    cleancss: ./bin/cleancss
-  checksum: c0d794b8a0ec200eb49f1bd1a877d42404495c7ffd967cabe8425fc5da4d639ec99cf903d7523b3882fbaa23a4664a633e376c52a15dd29d833c75584e304acd
+    cleancss: bin/cleancss
+  checksum: 1b8452c76eaeaa6eca6900e2135dd1ffac62bd67c058c6320b8f2f0b932904eb3e772d13c77b340e21e35bb655b8911bf9ce96104424836db8d71d0eaa4cad2d
   languageName: node
   linkType: hard
 
-"clean-css@npm:^4.2.1":
-  version: 4.2.4
-  resolution: "clean-css@npm:4.2.4"
+"clean-css@npm:^5.3.3":
+  version: 5.3.3
+  resolution: "clean-css@npm:5.3.3"
   dependencies:
     source-map: ~0.6.0
-  checksum: 045ff6fcf4b5c76a084b24e1633e0c78a13b24080338fc8544565a9751559aa32ff4ee5886d9e52c18a644a6ff119bd8e37bc58e574377c05382a1fb7dbe39f8
+  checksum: 941987c14860dd7d346d5cf121a82fd2caf8344160b1565c5387f7ccca4bbcaf885bace961be37c4f4713ce2d8c488dd89483c1add47bb779790edbfdcc79cbc
   languageName: node
   linkType: hard
 
@@ -7154,10 +7156,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:2.x":
-  version: 2.20.3
-  resolution: "commander@npm:2.20.3"
-  checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
+"commander@npm:7.x, commander@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "commander@npm:7.2.0"
+  checksum: 53501cbeee61d5157546c0bef0fedb6cdfc763a882136284bed9a07225f09a14b82d2a84e7637edfd1a679fb35ed9502fd58ef1d091e6287f60d790147f68ddc
   languageName: node
   linkType: hard
 
@@ -7165,13 +7167,6 @@ __metadata:
   version: 6.2.1
   resolution: "commander@npm:6.2.1"
   checksum: d7090410c0de6bc5c67d3ca41c41760d6d268f3c799e530aafb73b7437d1826bbf0d2a3edac33f8b57cc9887b4a986dce307fa5557e109be40eadb7c43b21742
-  languageName: node
-  linkType: hard
-
-"commander@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "commander@npm:7.2.0"
-  checksum: 53501cbeee61d5157546c0bef0fedb6cdfc763a882136284bed9a07225f09a14b82d2a84e7637edfd1a679fb35ed9502fd58ef1d091e6287f60d790147f68ddc
   languageName: node
   linkType: hard
 
@@ -10189,20 +10184,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:7.x, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.2.0":
-  version: 7.2.3
-  resolution: "glob@npm:7.2.3"
-  dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^3.1.1
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
-  checksum: 29452e97b38fa704dabb1d1045350fb2467cf0277e155aa9ff7077e90ad81d1ea9d53d3ee63bd37c05b09a065e90f16aec4a65f5b8de401d1dac40bc5605d133
-  languageName: node
-  linkType: hard
-
 "glob@npm:^11.0.0":
   version: 11.0.0
   resolution: "glob@npm:11.0.0"
@@ -10216,6 +10197,20 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 8a2dd914d5776987be5244624d9491bbcaf19f2387e06783737003ff696ebfd2264190c47014f8709c1c02d8bc892f17660cf986c587b107e194c0a3151ab333
+  languageName: node
+  linkType: hard
+
+"glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.2.0":
+  version: 7.2.3
+  resolution: "glob@npm:7.2.3"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^3.1.1
+    once: ^1.3.0
+    path-is-absolute: ^1.0.0
+  checksum: 29452e97b38fa704dabb1d1045350fb2467cf0277e155aa9ff7077e90ad81d1ea9d53d3ee63bd37c05b09a065e90f16aec4a65f5b8de401d1dac40bc5605d133
   languageName: node
   linkType: hard
 
@@ -14137,7 +14132,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.43.0
     "@typescript-eslint/parser": ^5.43.0
     astro-eslint-parser: ^0.9.0
-    clean-css-cli: ^4.2.1
     esbuild: ^0.23.0
     eslint: ^8.27.0
     eslint-config-airbnb-base: ^15.0.0


### PR DESCRIPTION
# Description

- clean-css-cli is installed in root, should be installed in subpackage.

This will have no affect on the output of icons, purely development related.