### PR TITLE
fix(json): update path in figma plugin settings json for illustrations

### DIFF
--- a/packages/@momentum-design/figma-plugin-assets-export/config/figma-plugin-settings-default.json
+++ b/packages/@momentum-design/figma-plugin-assets-export/config/figma-plugin-settings-default.json
@@ -76,7 +76,7 @@
       "mode": "FULL_SYNC",
       "description": {
         "name": "Illustrations",
-        "url": "https://github.com/momentum-design/momentum-design/tree/main/packages/%40momentum-design/illustrations",
+        "url": "https://github.com/momentum-design/momentum-design/tree/main/packages/assets/illustrations",
         "urlText": "Momentum illustrations package"
       },
       "input": {
@@ -120,7 +120,7 @@
           "prTitle": "Automated Illustrations Export 2023-07-07T21:07:54.936Z",
           "prCommitMsg": "feat(assets/illustrations): Export 2023-07-07T21:07:54.936Z",
           "prMessage": "feat(assets/illustrations): Export 2023-07-07T21:07:54.936Z",
-          "gitRepoFilePath": "packages/@momentum-design/illustrations"
+          "gitRepoFilePath": "packages/assets/illustrations"
         }
       }
     },


### PR DESCRIPTION
# Description

- This PR is to update path of illustrations library in figma plugin settings json.
- This PR is a follow up of https://github.com/momentum-design/momentum-design/pull/745

- Here is the test PR created locally using these settings: https://github.com/momentum-design/momentum-design/pull/752