### PR TITLE
fix: icons and illustrations src path

### DIFF
--- a/packages/@momentum-design/docs/astro.config.mjs
+++ b/packages/@momentum-design/docs/astro.config.mjs
@@ -25,11 +25,11 @@ export default defineConfig({
           copy({
             targets: [
               {
-                src: path.join(process.cwd(), '../', 'icons/dist/svg/*.svg'),
+                src: path.join(process.cwd(), '../../', 'assets/icons/dist/svg/*.svg'),
                 dest: 'dist/icons',
               },
               {
-                src: path.join(process.cwd(), '../', 'illustrations/dist/svg/*.svg'),
+                src: path.join(process.cwd(), '../../', 'assets/illustrations/dist/svg/*.svg'),
                 dest: 'dist/illustrations',
               },
             ],

--- a/packages/@momentum-design/docs/src/components/IconTable/IconTable.tsx
+++ b/packages/@momentum-design/docs/src/components/IconTable/IconTable.tsx
@@ -16,7 +16,7 @@ export const IconTable = ({ icons }: Props) => {
     () => (
       <div className="iconGrid">
         {Object.entries(icons).map(([key, path]) => {
-          const finalPath = `${path.replace('./svg', '/momentum-design/icons')}`;
+          const finalPath = `${path.replace('./svg', '/dist/icons')}`;
           return (
             <div className="iconWrapper">
               <img className={(!key.includes('colored') && 'icon') || ''} src={finalPath} />

--- a/packages/@momentum-design/docs/src/components/IllustrationTable/IllustrationTable.tsx
+++ b/packages/@momentum-design/docs/src/components/IllustrationTable/IllustrationTable.tsx
@@ -27,7 +27,7 @@ export const IllustrationTable = ({ illustrations, size }: Props) => {
     () => (
       <div className={`illustrationGrid grid${getSize(size)}`}>
         {Object.entries(illustrations).map(([key, path]) => {
-          const finalPath = `${path.replace('./svg', '/momentum-design/illustrations')}`;
+          const finalPath = `${path.replace('./svg', '/dist/illustrations')}`;
           return (
             <div className="illustrationWrapper">
               <img


### PR DESCRIPTION
# Description

Fix Icons and Illustrations src path.
https://momentum-design.github.io/momentum-design/en/tokens/icons/ and https://momentum-design.github.io/momentum-design/en/tokens/illustrations/ are not working. This is working after this changes.