### PR TITLE
fix(docs): docs icons & illustrations import

### DIFF
--- a/packages/@momentum-design/docs/astro.config.mjs
+++ b/packages/@momentum-design/docs/astro.config.mjs
@@ -3,13 +3,17 @@ import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
 import react from '@astrojs/react';
 import copy from 'rollup-plugin-copy';
+import { fileURLToPath } from 'url';
 // https://astro.build/config
 import mdx from '@astrojs/mdx';
 import path from 'path';
 
-// `import.meta.resolve` provides accurate, stable paths for the icons and illustrations packages, ensuring reliable path resolution for tasks like copying files, compared to using relative paths.
-const iconsDistFolder = path.dirname(import.meta.resolve('@momentum-design/icons/dist/manifest.json'));
-const illustrationsDistFolder = path.dirname(import.meta.resolve('@momentum-design/illustrations/dist/manifest.json'));
+// `import.meta.resolve` provides accurate, stable paths for the icons and illustrations packages,
+// ensuring reliable path resolution for tasks like copying files, compared to using relative paths.
+const getAssetsFolder = (manifestEntryPoint) => path.dirname(fileURLToPath(import.meta.resolve(manifestEntryPoint)));
+
+const iconsDistFolder = getAssetsFolder('@momentum-design/icons/dist/manifest.json');
+const illustrationsDistFolder = getAssetsFolder('@momentum-design/illustrations/dist/manifest.json');
 
 // https://astro.build/config
 export default defineConfig({


### PR DESCRIPTION
# Description

- Fix docs page to make sure the newly implemented import of icons and illustrations works as expected
- Tested locally and works fine
- This change will not have any impact on assets like icons, illustrations etc.