### PR TITLE
ci: simplify cache by not using runner.os in cache key

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -63,7 +63,7 @@ jobs:
           path: |
             node_modules
             packages/**/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install Dependencies
         if: steps.validate-dependencies.outputs.cache-hit != 'true'
@@ -76,7 +76,7 @@ jobs:
           path: |
             node_modules
             packages/**/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
   generate-package-matrix:
     name: Generate Package Matrix
@@ -99,22 +99,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
           
-      - name: Build Telemetry
-        run: yarn && yarn telemetry build
-
-      - name: Cache Telemetry Dist
-        uses: actions/cache@v3
-        with:
-          path: 'packages/@momentum-design/telemetry/dist'
-          key: momentum-design-telemetry-dist-${{ runner.os }}-${{ env.rid }} # this will need to be updated to match the os matrix
-
       - name: Uncache Dependencies
         uses: actions/cache@v3
         with:
           path: |
             node_modules
             packages/**/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Synchronize Packages
         run: yarn
@@ -157,7 +148,7 @@ jobs:
           path: |
             node_modules
             packages/**/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Synchronize Packages
         run: yarn
@@ -171,7 +162,13 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '**/dist'
-          key: dist-${{ runner.os }}-${{ env.rid }}
+          key: dist-${{ env.rid }}
+
+      - name: Cache Telemetry Dist
+        uses: actions/cache@v3
+        with:
+          path: 'packages/@momentum-design/telemetry/dist'
+          key: momentum-design-telemetry-dist-${{ env.rid }}
 
   analyze-root:
     name: Analyze Root
@@ -197,7 +194,7 @@ jobs:
           path: |
             node_modules
             packages/**/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Synchronize Packages
         run: yarn
@@ -234,13 +231,13 @@ jobs:
           path: |
             node_modules
             packages/**/node_modules
-          key: node-modules-${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Uncache Telemetry Dist
         uses: actions/cache@v3
         with:
           path: 'packages/@momentum-design/telemetry/dist'
-          key: momentum-design-telemetry-dist-${{ matrix.os }}-${{ env.rid }}
+          key: momentum-design-telemetry-dist-${{ env.rid }}
 
       - name: Synchronize Packages
         run: yarn
@@ -277,13 +274,13 @@ jobs:
           path: |
             node_modules
             packages/**/node_modules
-          key: node-modules-${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
       
       - name: Uncache Telemetry Dist
         uses: actions/cache@v3
         with:
           path: 'packages/@momentum-design/telemetry/dist'
-          key: momentum-design-telemetry-dist-${{ matrix.os }}-${{ env.rid }}
+          key: momentum-design-telemetry-dist-${{ env.rid }}
 
       - name: Synchronize Packages
         run: yarn
@@ -320,13 +317,13 @@ jobs:
           path: |
             node_modules
             packages/**/node_modules
-          key: node-modules-${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Uncache Dist
         uses: actions/cache@v3
         with:
           path: '**/dist'
-          key: dist-${{ matrix.os }}-${{ env.rid }}
+          key: dist-${{ env.rid }}
 
       - name: Synchronize Packages
         run: yarn
@@ -363,13 +360,13 @@ jobs:
           path: |
             node_modules
             packages/**/node_modules
-          key: node-modules-${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Uncache Dist
         uses: actions/cache@v3
         with:
           path: '**/dist'
-          key: dist-${{ matrix.os }}-${{ env.rid }}
+          key: dist-${{ env.rid }}
 
       - name: Synchronize Packages
         run: yarn


### PR DESCRIPTION
# Description

- Simplify cache by not using runner.os / matrix.os in cache key
- Should fix issue with build
- This PR has no affect on consumables