### PR TITLE
feat: remove devDependencies and scripts before publishing components package to npm

### DIFF
--- a/packages/components/scripts/prepareForPublish.js
+++ b/packages/components/scripts/prepareForPublish.js
@@ -7,7 +7,6 @@ const main = async () => {
   const packageJson = require(packageJsonPath);
 
   const dependencies = packageJson.dependencies || {};
-  const devDependencies = packageJson.devDependencies || {};
   const peerDependencies = packageJson.peerDependencies || {};
 
   for (const dep in dependencies) {

--- a/packages/components/scripts/prepareForPublish.js
+++ b/packages/components/scripts/prepareForPublish.js
@@ -16,12 +16,6 @@ const main = async () => {
       }
   }
 
-  for (const dep in devDependencies) {
-    if (devDependencies[dep].startsWith('workspace:')) {
-        devDependencies[dep] = `*`;
-    }
-  }
-
   for (const dep in peerDependencies) {
     if (peerDependencies[dep].startsWith('workspace:')) {
         peerDependencies[dep] = `*`;

--- a/packages/components/scripts/prepareForPublish.js
+++ b/packages/components/scripts/prepareForPublish.js
@@ -28,6 +28,9 @@ const main = async () => {
     }
   }
 
+  delete packageJson.scripts;
+  delete packageJson.devDependencies;
+
   fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 };
 


### PR DESCRIPTION
# Description

- Remove devDependencies and scripts from package.json before publishing components package to npm.
- Execute the prepareForPublish.js script manually to verify that it modifies package.json as intended.
   - `node scripts/prepareForPublish.js`

## Links

https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-249