### PR TITLE
chore: do not enforce yarn version in consuming projects

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -4,12 +4,22 @@
     "nodeEngine": {
       "path": "engines.node",
       "strategy": "version"
+    },
+    "packageManager": {
+      "path": "packageManager",
+      "strategy": "version"
+    },
+    "yarnEngine": {
+      "path": "engines.yarn",
+      "strategy": "version"
     }
   },
   "dependencyTypes": [
     "prod",
     "dev",
-    "nodeEngine"
+    "nodeEngine",
+    "packageManager",
+    "yarnEngine"
   ],
   "semverGroups": [
     {
@@ -34,6 +44,20 @@
         "nodeEngine"
       ],
       "preferVersion": "20.0.0"
+    },
+    {
+      "label": "Ensure all package manager are in the same range",
+      "dependencyTypes": [
+        "packageManager"
+      ],
+      "pinVersion": "yarn@3.2.4"
+    },
+    {
+      "label": "Ensure all yarn engines are not set",
+      "dependencyTypes": [
+        "yarnEngine"
+      ],
+      "isBanned": true
     },
     {
       "label": "Ensure @types/node corresponds to the node engine",

--- a/config/plop/templates/add/workspace/package.json.hbs
+++ b/config/plop/templates/add/workspace/package.json.hbs
@@ -3,8 +3,7 @@
   "packageManager": "yarn@3.2.4",
   "engines": {
     "node": ">=18.0.0",
-    "npm": ">=8.0.0",
-    "yarn": ">=3.0.0"
+    "npm": ">=8.0.0"
   },
   "scripts": {
     "analyze": "yarn analyze:prebuild && yarn analyze:postbuild",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "packageManager": "yarn@3.2.4",
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=8.0.0",
-    "yarn": ">=3.0.0"
+    "npm": ">=8.0.0"
   },
   "private": true,
   "type": "commonjs",

--- a/packages/assets/utils/package.json
+++ b/packages/assets/utils/package.json
@@ -3,8 +3,7 @@
   "packageManager": "yarn@3.2.4",
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=8.0.0",
-    "yarn": ">=3.0.0"
+    "npm": ">=8.0.0"
   },
   "type": "commonjs",
   "main": "./dist/module/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -3,8 +3,7 @@
   "packageManager": "yarn@3.2.4",
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=8.0.0",
-    "yarn": ">=3.0.0"
+    "npm": ">=8.0.0"
   },
   "main": "./dist/module/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -5,8 +5,7 @@
   "private": true,
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=8.0.0",
-    "yarn": ">=3.0.0"
+    "npm": ">=8.0.0"
   },
   "scripts": {
     "dev": "astro dev",

--- a/packages/tools/automation/package.json
+++ b/packages/tools/automation/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=8.0.0",
-    "yarn": ">=3.0.0"
+    "npm": ">=8.0.0"
   },
   "type": "commonjs",
   "main": "./dist/module/index.js",

--- a/packages/tools/automation/src/models/fixtures/packages.fixture.ts
+++ b/packages/tools/automation/src/models/fixtures/packages.fixture.ts
@@ -5,6 +5,7 @@ export const packagesList = [
   '@momentum-design/icons',
   '@momentum-design/illustrations',
   '@momentum-design/tokens',
+  '@momentum-design/utils',
   '@momentum-design/components',
   '@momentum-design/docs',
   '@momentum-design/automation',

--- a/packages/tools/builder/package.json
+++ b/packages/tools/builder/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=8.0.0",
-    "yarn": ">=3.0.0"
+    "npm": ">=8.0.0"
   },
   "type": "commonjs",
   "main": "./dist/module/index.js",

--- a/packages/tools/common/package.json
+++ b/packages/tools/common/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=8.0.0",
-    "yarn": ">=3.0.0"
+    "npm": ">=8.0.0"
   },
   "type": "commonjs",
   "main": "./dist/module/index.js",

--- a/packages/tools/figma-plugins/assets-export/package.json
+++ b/packages/tools/figma-plugins/assets-export/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=8.0.0",
-    "yarn": ">=3.0.0"
+    "npm": ">=8.0.0"
   },
   "scripts": {
     "analyze": "yarn analyze:prebuild && yarn analyze:postbuild",

--- a/packages/tools/telemetry/package.json
+++ b/packages/tools/telemetry/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=8.0.0",
-    "yarn": ">=3.0.0"
+    "npm": ">=8.0.0"
   },
   "type": "commonjs",
   "main": "./dist/module/index.js",

--- a/packages/tools/token-builder/package.json
+++ b/packages/tools/token-builder/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=8.0.0",
-    "yarn": ">=3.0.0"
+    "npm": ">=8.0.0"
   },
   "type": "commonjs",
   "main": "./dist/module/index.js",


### PR DESCRIPTION
# Description

"packageManager": "yarn@3.2.4" ensures that the specified version of Yarn is used for the current project.
"engines": { "yarn": ">=3.0.0" } specifies the minimum version of Yarn required for consuming projects.

momentum-design should not dictate the the yarn version of consumers

## Links

https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-268