### PR TITLE
fix(clean): add clean dist dir for utils package

### DIFF
--- a/packages/assets/utils/package.json
+++ b/packages/assets/utils/package.json
@@ -21,6 +21,7 @@
     "build": "yarn build:module",
     "build:module": "tsc",
     "clean": "yarn clean:dist",
+    "clean:dist": "rimraf ./dist",
     "docs": "echo \"script 'docs' has not been implemented\"",
     "prepublishOnly": "yarn clean && yarn build",
     "publish": "yarn publish:npmjs",


### PR DESCRIPTION
# Description

- On root, when we run `yarn clean`, then its getting failed due to a failure in `utils` package for [yarn clean](https://github.com/momentum-design/momentum-design/blob/9e615782540b8a5175844fd68ffbee5866da6a1c/packages/assets/utils/package.json#L23)
- This PR will add the missing `clean:dist` script in the `utils` package.

### Before
<img width="1589" alt="image" src="https://github.com/user-attachments/assets/2a35baeb-e859-4f6a-9643-eeb6b090a75a">

### After
<img width="1589" alt="image" src="https://github.com/user-attachments/assets/9e452030-a947-4c28-b883-73afb58e2996">


## Links

- https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-269