### PR TITLE
ci: mergeable pipeline dont run on label change

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -12,7 +12,7 @@ mergeable:
           enabled: true
           message: 'Description matters and should not be empty. Provide detail with **what** was changed, **why** it was changed and **how** it will impact our consumers.'
 
-  - when: pull_request.opened, pull_request.reopened, pull_request.edited
+  - when: pull_request.opened, pull_request.reopened
     name: 'Pull Request / Core Team'
     filter:
       - do: author

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,7 +5,8 @@ on:
   pull_request_target:
     branches:
       - main
-    types: [opened, labeled, reopened, synchronize]
+      # do not add "labeled" type here, it will trigger the workflow on every label change (double run cause of mergeable.yml)
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 env:
@@ -31,10 +32,10 @@ jobs:
 
           if [[ $FROM_BASE == 1 || $VALIDATED == 1 ]]
           then
-            echo 'pull request is validated, running tests'
+            echo 'Pull request is validated, continuing.'
             exit 0
           else
-            echo 'pull request is not validated, exiting'
+            echo 'Pull request is not validated, exiting. To validate, add the "validated" label or reach out to the Core Team and re-run the workflow.'
             exit 1
           fi
 


### PR DESCRIPTION
# Description

- Currently mergeable adds labels depending on the changeset, which then triggers the pipeline another time. We do not want that.
- From now on, if the validated label has been missing and it get added after, the pipeline will not automatically run, but we have to run it manually. This will make sure that we don't run the pipeline too often on commits (commit triggers it and the label change triggered it).