### PR TITLE
fix(spec): add req packages to build for test setup

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -347,7 +347,14 @@ jobs:
         run: yarn
         
       - name: Test - Postbuild
-        run: yarn workspace ${{ matrix.package }} test:postbuild
+        run: |
+          if [ ${{ matrix.package }} == '@momentum-design/components' ]; then
+            yarn workspaces foreach -pR --topological-dev --from @momentum-design/components run build
+            yarn workspace @momentum-design/components test:postbuild
+          else
+            yarn workspace ${{ matrix.package }} test:postbuild
+          fi
+
 
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Description

- Problem: The PR pipeline fails randomly due to a weird error. Ex: [failure action](https://github.com/momentum-design/momentum-design/actions/runs/10683196872/job/29610843997)
 <img width="669" alt="image" src="https://github.com/user-attachments/assets/f7b4cf1d-b108-4bf8-a9d4-2003afce7d93">

- After research, we found that to run this below script, we need the necessary packages to be `build` before to run this.
- https://github.com/momentum-design/momentum-design/blob/0e45a7bf8f646476012297d8c22a0507ebfd6901/packages/components/package.json#L43
- As github workflows run parallelly, there is no guarantee that the build will execute just before this script gets started.
- This PR will fix this issue by adding a mandatory `build step` so that it will build all the needed packages to run before `playwright` runs the above step.
- Here is the successful output:
![Screenshot 2024-09-12 at 9 24 48 PM](https://github.com/user-attachments/assets/0b142105-9a7e-471e-a3ea-5bdde2b2b383)

##### Credits to `act` by https://github.com/nektos/act.
##### With the help of this, we were able to find the reason behind this error.

## Links

- [JIRA Ticket](https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-250)