### PR TITLE
ci: improve validated check

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,7 +24,7 @@ jobs:
           BASE_REPO=${{ github.event.pull_request.base.repo.full_name }}
           FROM_BASE=0; [ "$HEAD_REPO" == "$BASE_REPO" ] && FROM_BASE=1
 
-          HAS_VALIDATED_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'validated') }}
+          HAS_VALIDATED_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'validated') || contains(github.event.workflow_run.labels.*.name, 'validated') || contains(github.event.label.name, 'validated') }}
           VALIDATED=0; [ "$HAS_VALIDATED_LABEL" == "true" ] && VALIDATED=1
 
           echo from base $FROM_BASE


### PR DESCRIPTION
# Description

- Currently the validated check in the pipeline only grabs the label from the pull request event. if its not set, it should grab it from the workflow_run and label event itself as well to make sure we are actually getting the right label value (if a rerun of a workflow for example gets triggered).