### PR TITLE
build: fix husky warning

### DIFF
--- a/config/husky/commit-msg
+++ b/config/husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "config/husky/_/husky.sh"
-
 yarn commitlint --config "./config/commitlint/commitlint.config.js" --edit "${1}"


### PR DESCRIPTION
# Description

* Fix warning on commit
```
"husky - DEPRECATED

Please remove the following two lines from config/husky/commit-msg:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0"
```



## Links

***required*** - *Links to resources related to this Pull Request*