### PR TITLE
docs: added storybook badges addon

### DIFF
--- a/packages/components/config/plop/templates/add/component/{{componentName}}.component.ts.hbs
+++ b/packages/components/config/plop/templates/add/component/{{componentName}}.component.ts.hbs
@@ -3,13 +3,12 @@ import styles from './{{componentName}}.styles';
 import { Component } from '../../models';
 
 /**
- * @slot - This is a default/unnamed slot
- * @summary - Description of the component
- * @tag {{componentName}}
+ * {{componentName}} component, which ...
+ *
  * @tagname {{componentName}}
- * @prop [type] propertyName - Description of the custom property
- * @attr [type] attributeName - Description of the custom attribute
- * @fires eventName - Description of the custom event
+ *
+ * @slot default - This is a default/unnamed slot
+ *
  * @cssprop --custom-property-name - Description of the CSS custom property
  */
 class {{sentenceCase componentName}} extends Component {

--- a/packages/components/config/plop/templates/add/component/{{componentName}}.stories.ts.hbs
+++ b/packages/components/config/plop/templates/add/component/{{componentName}}.stories.ts.hbs
@@ -10,6 +10,9 @@ const meta: Meta = {
   title: 'Work In Progress/{{componentName}}',
   component: '{{prefix}}{{separator}}{{componentName}}',
   render,
+  parameters: {
+    badges: ['wip'],
+  },
   argTypes: { 
     ...classArgType,
     ...styleArgType

--- a/packages/components/config/storybook/main.js
+++ b/packages/components/config/storybook/main.js
@@ -5,6 +5,7 @@ const config = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',
+    '@geometricpanda/storybook-addon-badges',
   ],
   framework: {
     name: '@storybook/web-components-vite',

--- a/packages/components/config/storybook/preview.js
+++ b/packages/components/config/storybook/preview.js
@@ -21,13 +21,74 @@ const preview = {
         },
       },
     },
+    actions: { argTypesRegex: '^on[A-Z].*' },
     backgrounds: {
       disable: true,
       grid: {
         disable: true,
       },
     },
-    actions: { argTypesRegex: '^on[A-Z].*' },
+    badgesConfig: {
+      wip: {
+        styles: {
+          backgroundColor: '#30240D',
+          borderColor: '#D6B220',
+          color: '#FFFFFFF2',
+        },
+        title: 'Work In Progress',
+        tooltip: {
+          title: 'This Component is Work In Progress',
+          desc: 'Keep an eye on the Release history for updates or provide feedback.',
+          links: [
+            { title: 'Release history', href: 'https://github.com/momentum-design/momentum-design/releases' },
+            {
+              title: 'Leave feedback',
+              href: 'https://github.com/momentum-design/momentum-design/issues',
+            },
+          ],
+        },
+      },
+      stable: {
+        styles: {
+          backgroundColor: '#416116',
+          borderColor: '#93C437',
+          color: '#FFFFFFF2',
+        },
+        title: 'Stable',
+        tooltip: {
+          title: 'This Component is Stable',
+          desc: 'Ready for use.',
+          links: [
+            // TODO: update once available
+            { title: 'Consumption guide', href: 'https://github.com/momentum-design/momentum-design' },
+            { title: 'Release history', href: 'https://github.com/momentum-design/momentum-design/releases' },
+            {
+              title: 'Leave feedback',
+              href: 'https://github.com/momentum-design/momentum-design/issues',
+            },
+          ],
+        },
+      },
+      deprecated: {
+        styles: {
+          backgroundColor: '#4F0E10',
+          borderColor: '#FC8B98',
+          color: '#FFFFFFF2',
+        },
+        title: 'Deprecated',
+        tooltip: {
+          title: 'This Component is Deprecated',
+          desc: 'Check the Release history for more information about deprecation or provide feedback.',
+          links: [
+            { title: 'Release history', href: 'https://github.com/momentum-design/momentum-design/releases' },
+            {
+              title: 'Leave feedback',
+              href: 'https://github.com/momentum-design/momentum-design/issues',
+            },
+          ],
+        },
+      },
+    },
     controls: {
       disableSaveFromUI: true,
       expanded: true,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -82,6 +82,7 @@
     "@axe-core/playwright": "^4.9.1",
     "@custom-elements-manifest/analyzer": "^0.10.3",
     "@estruyf/github-actions-reporter": "^1.9.2",
+    "@geometricpanda/storybook-addon-badges": "^2.0.4",
     "@momentum-design/fonts": "workspace:*",
     "@momentum-design/icons": "workspace:*",
     "@momentum-design/tokens": "workspace:*",

--- a/packages/components/src/components/avatar/avatar.stories.ts
+++ b/packages/components/src/components/avatar/avatar.stories.ts
@@ -11,6 +11,9 @@ const meta: Meta = {
   title: 'Work In Progress/avatar',
   component: 'mdc-avatar',
   render,
+  parameters: {
+    badges: ['wip'],
+  },
   argTypes: {},
 };
 

--- a/packages/components/src/components/badge/badge.stories.ts
+++ b/packages/components/src/components/badge/badge.stories.ts
@@ -18,6 +18,9 @@ const meta: Meta = {
   tags: ['autodocs'],
   component: 'mdc-badge',
   render,
+  parameters: {
+    badges: ['wip'],
+  },
   argTypes: {},
 };
 

--- a/packages/components/src/components/icon/icon.stories.ts
+++ b/packages/components/src/components/icon/icon.stories.ts
@@ -12,6 +12,9 @@ const meta: Meta = {
   tags: ['autodocs'],
   component: 'mdc-icon',
   render,
+  parameters: {
+    badges: ['wip'],
+  },
   argTypes: {},
 };
 

--- a/packages/components/src/components/iconprovider/iconprovider.stories.ts
+++ b/packages/components/src/components/iconprovider/iconprovider.stories.ts
@@ -18,6 +18,9 @@ const meta: Meta = {
   tags: ['autodocs'],
   component: 'mdc-iconprovider',
   render,
+  parameters: {
+    badges: ['wip'],
+  },
   argTypes: {},
 };
 

--- a/packages/components/src/components/text/text.stories.ts
+++ b/packages/components/src/components/text/text.stories.ts
@@ -12,6 +12,9 @@ const meta: Meta = {
   tags: ['autodocs'],
   component: 'mdc-text',
   render,
+  parameters: {
+    badges: ['wip'],
+  },
   argTypes: {
     type: {
       control: 'radio',

--- a/packages/components/src/components/themeprovider/themeprovider.stories.ts
+++ b/packages/components/src/components/themeprovider/themeprovider.stories.ts
@@ -45,6 +45,9 @@ const meta: Meta = {
   tags: ['autodocs'],
   component: 'mdc-themeprovider',
   render,
+  parameters: {
+    badges: ['wip'],
+  },
   argTypes: {
     themeclass: {
       options: THEMES,

--- a/packages/components/src/tsdoc.json
+++ b/packages/components/src/tsdoc.json
@@ -2,11 +2,6 @@
     "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
     "tagDefinitions": [
       {
-        "tagName": "@summary",
-        "syntaxKind": "block",
-        "allowMultiple": false
-      },
-      {
         "tagName": "@cssproperty",
         "syntaxKind": "modifier",
         "allowMultiple": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,6 +1677,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@geometricpanda/storybook-addon-badges@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@geometricpanda/storybook-addon-badges@npm:2.0.4"
+  peerDependencies:
+    "@storybook/blocks": ^8.3.0
+    "@storybook/components": ^8.3.0
+    "@storybook/core-events": ^8.3.0
+    "@storybook/manager-api": ^8.3.0
+    "@storybook/preview-api": ^8.3.0
+    "@storybook/theming": ^8.3.0
+    "@storybook/types": ^8.3.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 962e37dcaf7085b7e0253fe18f521e70cd76176a3bec53ab05dc09675a0029844b228b4c98797625de9589d649334517f32d49c676f271ffc2f99e026bb57d88
+  languageName: node
+  linkType: hard
+
 "@github/catalyst@npm:^1.6.0":
   version: 1.6.0
   resolution: "@github/catalyst@npm:1.6.0"
@@ -2325,6 +2347,7 @@ __metadata:
     "@axe-core/playwright": ^4.9.1
     "@custom-elements-manifest/analyzer": ^0.10.3
     "@estruyf/github-actions-reporter": ^1.9.2
+    "@geometricpanda/storybook-addon-badges": ^2.0.4
     "@lit/context": ^1.1.2
     "@lit/react": ^1.0.5
     "@momentum-design/fonts": "workspace:*"


### PR DESCRIPTION
# Description

- Added storybook addon "badges"
- Defined "wip", "stable", "deprecated" badge
- Set "wip" on all of them (once we release Themeprovider, will set it to stable - separate PR)
- Updated plop script templates
