### PR TITLE
feat(script): add build scripts for components package

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "brand-visuals": "yarn workspace @momentum-design/brand-visuals",
     "fonts": "yarn workspace @momentum-design/fonts",
     "components": "yarn workspace @momentum-design/components",
+    "components:build": "yarn workspaces foreach -pR --topological-dev --from @momentum-design/components run build",
     "assets-export": "yarn workspace @momentum-design/figma-plugin-assets-export",
     "utils": "yarn workspace @momentum-design/utils"
   },


### PR DESCRIPTION
# Description

- Every time when we want to build the components package locally, we have to run a list of all the packages to build which is hard to remember and it costs time.
- This new script will help simplify the build process by only running the "yarn components:build".
- Current way to build components:
```
    yarn telemetry build
    yarn token-builder build
    yarn tokens build
    yarn common build
    yarn builder build
    yarn fonts build
    yarn icons build
```
- New way to build components:
```
    yarn components:build
```
