### PR TITLE
fix(themeprovider): make use of typography tokens

### DIFF
--- a/packages/components/config/storybook/preview.js
+++ b/packages/components/config/storybook/preview.js
@@ -1,4 +1,3 @@
-import '@momentum-design/tokens/dist/css/core/complete.css';
 import '@momentum-design/tokens/dist/css/theme/webex/dark-stable.css';
 import '@momentum-design/tokens/dist/css/theme/webex/light-stable.css';
 import '@momentum-design/tokens/dist/css/typography/complete.css';

--- a/packages/components/config/storybook/preview.js
+++ b/packages/components/config/storybook/preview.js
@@ -1,6 +1,7 @@
 import '@momentum-design/tokens/dist/css/core/complete.css';
 import '@momentum-design/tokens/dist/css/theme/webex/dark-stable.css';
 import '@momentum-design/tokens/dist/css/theme/webex/light-stable.css';
+import '@momentum-design/tokens/dist/css/typography/complete.css';
 import '@momentum-design/fonts/dist/css/fonts.css';
 
 import { setCustomElementsManifest } from '@storybook/web-components';

--- a/packages/components/scripts/copyTokens.js
+++ b/packages/components/scripts/copyTokens.js
@@ -22,7 +22,7 @@ const copyFileToFolder = (src, destFolder) => {
   fs.copyFileSync(src, dest);
 };
 
-copyFileToFolder(complete, playwrightPublicDist);
+copyFileToFolder(typography, playwrightPublicDist);
 copyFileToFolder(dark, playwrightPublicDist);
 copyFileToFolder(light, playwrightPublicDist);
 

--- a/packages/components/scripts/copyTokens.js
+++ b/packages/components/scripts/copyTokens.js
@@ -2,7 +2,6 @@ const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
 
-const complete = require.resolve('@momentum-design/tokens/dist/css/core/complete.css');
 const typography = require.resolve('@momentum-design/tokens/dist/css/typography/complete.css');
 const dark = require.resolve('@momentum-design/tokens/dist/css/theme/webex/dark-stable.css');
 const light = require.resolve('@momentum-design/tokens/dist/css/theme/webex/light-stable.css');
@@ -18,7 +17,6 @@ const copyToFolder = (src, destFolder) => {
     });
 }
 
-copyToFolder(complete, playwrightPublicDist);
 copyToFolder(typography, playwrightPublicDist);
 copyToFolder(dark, playwrightPublicDist);
 copyToFolder(light, playwrightPublicDist);

--- a/packages/components/scripts/copyTokens.js
+++ b/packages/components/scripts/copyTokens.js
@@ -3,6 +3,7 @@ const path = require('path');
 const chalk = require('chalk');
 
 const complete = require.resolve('@momentum-design/tokens/dist/css/core/complete.css');
+const typography = require.resolve('@momentum-design/tokens/dist/css/typography/complete.css');
 const dark = require.resolve('@momentum-design/tokens/dist/css/theme/webex/dark-stable.css');
 const light = require.resolve('@momentum-design/tokens/dist/css/theme/webex/light-stable.css');
 
@@ -18,6 +19,7 @@ const copyToFolder = (src, destFolder) => {
 }
 
 copyToFolder(complete, playwrightPublicDist);
+copyToFolder(typography, playwrightPublicDist);
 copyToFolder(dark, playwrightPublicDist);
 copyToFolder(light, playwrightPublicDist);
 

--- a/packages/components/src/Consumption.mdx
+++ b/packages/components/src/Consumption.mdx
@@ -29,6 +29,7 @@ yarn add @momentum-design/components
 
 ```javascript
 import '@momentum-design/fonts/dist/css/fonts.css';
+import '@momentum-design/tokens/dist/css/typography/complete.css';
 import '@momentum-design/tokens/dist/css/theme/webex/dark-stable.css';
 import '@momentum-design/tokens/dist/css/theme/webex/light-stable.css';
 ``` 

--- a/packages/components/src/components/themeprovider/themeprovider.component.ts
+++ b/packages/components/src/components/themeprovider/themeprovider.component.ts
@@ -29,6 +29,7 @@ class ThemeProvider extends Provider<ThemeProviderContext> {
       context: ThemeProviderContext.context,
       initialValue: new ThemeProviderContext(DEFAULTS.THEMECLASS),
     });
+    this.classList.add(DEFAULTS.TYPOGRAPHYCLASS);
   }
 
   /**

--- a/packages/components/src/components/themeprovider/themeprovider.constants.ts
+++ b/packages/components/src/components/themeprovider/themeprovider.constants.ts
@@ -5,6 +5,7 @@ const TAG_NAME = utils.constructTagName('themeprovider');
 
 const DEFAULTS = {
   THEMECLASS: 'mds-theme-stable-darkWebex' as const,
+  TYPOGRAPHYCLASS: 'mds-typography' as const,
 };
 
 export { DEFAULTS, TAG_NAME };

--- a/packages/components/src/components/themeprovider/themeprovider.styles.ts
+++ b/packages/components/src/components/themeprovider/themeprovider.styles.ts
@@ -3,7 +3,7 @@ import { css } from 'lit';
 // todo: use type tokens once the full set with fallbacks is available
 const styles = css`
   :host {
-    --mdc-themeprovider-font-family: "Momentum";
+    --mdc-themeprovider-font-family: var(--mds-font-family-primary);
     --mdc-themeprovider-color-default: var(--mds-color-theme-text-primary-normal);
 
     font-family: var(--mdc-themeprovider-font-family);


### PR DESCRIPTION
# Description

- Make use of the new Typography tokens in Themeprovider component (fontFamily)
- Updated storybook to include new typography tokens
- Updated Playwright copy script to include new typography tokens
- Updated Consumption.mdx 
- Removed core theme tokens from copy scripts, since only Theme tokens should be used for colors