### PR TITLE
fix(components): base styling to inherit box sizing

### DIFF
--- a/packages/components/config/plop/templates/add/component/{{componentName}}.component.ts.hbs
+++ b/packages/components/config/plop/templates/add/component/{{componentName}}.component.ts.hbs
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { CSSResult, html } from 'lit';
 import styles from './{{componentName}}.styles';
 import { Component } from '../../models';
 
@@ -16,7 +16,7 @@ class {{sentenceCase componentName}} extends Component {
     return html`<p>This is a dummy {{componentName}} component!</p><slot></slot>`;
   }
 
-  public static override styles = styles;
+  public static override styles: Array<CSSResult> = [...Component.styles, ...styles];
 }
 
 export default {{sentenceCase componentName}};

--- a/packages/components/config/plop/templates/add/component/{{componentName}}.styles.ts.hbs
+++ b/packages/components/config/plop/templates/add/component/{{componentName}}.styles.ts.hbs
@@ -5,4 +5,4 @@ const styles = css`
   }
 `;
 
-export default styles;
+export default [styles];

--- a/packages/components/src/components/avatar/avatar.component.ts
+++ b/packages/components/src/components/avatar/avatar.component.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { CSSResult, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './avatar.styles';
@@ -67,7 +67,7 @@ class Avatar extends Component {
     return html`${content}`;
   }
 
-  public static override styles = styles;
+  public static override styles: Array<CSSResult> = [...Component.styles, ...styles];
 }
 
 export default Avatar;

--- a/packages/components/src/components/avatar/avatar.styles.ts
+++ b/packages/components/src/components/avatar/avatar.styles.ts
@@ -17,4 +17,4 @@ const styles = css`
   }
 `;
 
-export default styles;
+export default [styles];

--- a/packages/components/src/components/badge/badge.component.ts
+++ b/packages/components/src/components/badge/badge.component.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { CSSResult, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { StyleInfo, styleMap } from 'lit/directives/style-map.js';
@@ -115,7 +115,7 @@ class Badge extends Component {
     return html`<div class="mdc-badge-container" style=${styleMap(sizeStyles)}>${content}</div>`;
   }
 
-  public static override styles = styles;
+  public static override styles: Array<CSSResult> = [...Component.styles, ...styles];
 }
 
 export default Badge;

--- a/packages/components/src/components/icon/icon.component.ts
+++ b/packages/components/src/components/icon/icon.component.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { CSSResult, html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import styles from './icon.styles';
 import { Component } from '../../models';
@@ -169,7 +169,7 @@ class Icon extends Component {
     return html` ${this.iconData} `;
   }
 
-  static override styles = styles;
+  public static override styles: Array<CSSResult> = [...Component.styles, ...styles];
 }
 
 export default Icon;

--- a/packages/components/src/components/text/text.component.ts
+++ b/packages/components/src/components/text/text.component.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { CSSResult, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import styles from './text.styles';
 import { Component } from '../../models';
@@ -44,7 +44,7 @@ class Text extends Component {
     return html`<slot></slot>`;
   }
 
-  public static override styles = styles;
+  public static override styles: Array<CSSResult> = [...Component.styles, ...styles];
 }
 
 export default Text;

--- a/packages/components/src/components/themeprovider/themeprovider.component.ts
+++ b/packages/components/src/components/themeprovider/themeprovider.component.ts
@@ -108,7 +108,7 @@ class ThemeProvider extends Provider<ThemeProviderContext> {
     }
   }
 
-  public static override styles: Array<CSSResult> = [...Provider.styles, styles];
+  public static override styles: Array<CSSResult> = [...Provider.styles, ...styles];
 }
 
 export default ThemeProvider;

--- a/packages/components/src/components/themeprovider/themeprovider.styles.ts
+++ b/packages/components/src/components/themeprovider/themeprovider.styles.ts
@@ -15,4 +15,4 @@ const styles = css`
   }
 `;
 
-export default styles;
+export default [styles];

--- a/packages/components/src/models/component/component.component.ts
+++ b/packages/components/src/models/component/component.component.ts
@@ -1,4 +1,5 @@
-import { LitElement } from 'lit';
+import { CSSResult, LitElement } from 'lit';
+import styles from './component.styles';
 
 /**
  * Core Component class to ultimately be inherited by all Web Components within
@@ -44,6 +45,11 @@ class Component extends LitElement {
 
     customElements.define(namespace, this as any);
   }
+
+  /**
+   * Styles associated with the Base Component.
+   */
+  public static override styles: Array<CSSResult> = [styles];
 }
 
 export default Component;

--- a/packages/components/src/models/component/component.styles.ts
+++ b/packages/components/src/models/component/component.styles.ts
@@ -1,0 +1,13 @@
+import { css } from 'lit';
+
+export default css`
+  :host {
+    box-sizing: border-box;
+  }
+
+  :host *,
+  :host *::before,
+  :host *::after {
+    box-sizing: inherit;
+  }
+`;

--- a/packages/components/src/models/provider/provider.component.ts
+++ b/packages/components/src/models/provider/provider.component.ts
@@ -53,7 +53,7 @@ abstract class Provider<C> extends Component {
   /**
    * Styles associated with this Provider Component.
    */
-  public static override styles: Array<CSSResult> = [styles];
+  public static override styles: Array<CSSResult> = [...Component.styles, styles];
 
   /**
    * Update the context of this Provider and trigger its consumers to update.


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

# Description

There is an issue in our components where the box sizing isn't inherited properly through when using Higher Order Components like the ThemeProvider. This PR fixes this.
- Adding styling to base Component class
- Using the subclass styling in all components (except IconProvider since IconProvider doesn't have a separate component style)
- Tested locally and with E2E tests, all fine.

## Links

More information about it:
https://dev.to/konnorrogers/revisiting-box-sizing-best-practices-3del
In general, the shadow dom is not inheriting the box-sizing as other native elements do, thats why we need to set a standard box-sizing style on each component, which in our case achieved similar to shoelace:
https://github.com/shoelace-style/shoelace/blob/next/src/styles/component.styles.ts
