### PR TITLE
fix: utils export, convert to cjs and exporting types

### DIFF
--- a/config/esbuild/esbuild.config.js
+++ b/config/esbuild/esbuild.config.js
@@ -60,12 +60,13 @@ const cjs = async (
   outfile = 'index.js',
   tsconfig = 'tsconfig.json',
   platform = 'node',
+  minify = false,
 ) => {
   await esbuild.build({
     bundle: true,
     entryPoints: [`${join(projectPath, entryPointPath)}`],
     format: 'cjs',
-    minify: false,
+    minify,
     outfile: `${join(projectPath, 'dist', outfile)}`,
     tsconfig: `${join(projectPath, tsconfig)}`,
     platform,

--- a/packages/assets/utils/esbuild.config.js
+++ b/packages/assets/utils/esbuild.config.js
@@ -1,4 +1,4 @@
 const { join } = require('path');
-const { esm } = require('../../../config/esbuild/esbuild.config.js');
+const { cjs } = require('../../../config/esbuild/esbuild.config.js');
 
-esm(`${join(process.cwd())}`, 'src/index.ts', 'index.js', 'tsconfig.json', 'browser', false);
+cjs(`${join(process.cwd())}`, 'src/index.ts', 'index.js', 'tsconfig.json', 'browser', false);

--- a/packages/assets/utils/package.json
+++ b/packages/assets/utils/package.json
@@ -6,7 +6,7 @@
     "npm": ">=8.0.0"
   },
   "type": "commonjs",
-  "main": "./dist/module/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
   "files": [
     "./dist"
@@ -17,8 +17,9 @@
     "analyze:syntax": "tsc --noEmit",
     "analyze:postbuild": "echo \"script 'analyze:postbuild' has not been implemented\"",
     "analyze:prebuild": "yarn analyze:lint && yarn analyze:syntax",
-    "build": "yarn build:browser",
+    "build": "yarn build:browser && yarn build:types",
     "build:browser": "node ./esbuild.config.js",
+    "build:types": "tsc --emitDeclarationOnly",
     "clean": "yarn clean:dist",
     "clean:dist": "rimraf ./dist",
     "dev:prepare": "rimraf ./src/staticSite/public && ncp ./dist ./src/staticSite/public",

--- a/packages/assets/utils/tsconfig.json
+++ b/packages/assets/utils/tsconfig.json
@@ -6,6 +6,7 @@
     "declarationDir": "./dist/types",
     "module": "ESNext",
     "target": "ES6",
+    "declarationMap": false
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

# Description

- Modified the exports in package.json to point to the right entry
- Modified build script to build output as CJS for better compatibility
- Exporting types, since they have been missing.
