### PR TITLE
fix: move typography out of themeprovider

### DIFF
--- a/packages/components/config/playwright/public/index.html
+++ b/packages/components/config/playwright/public/index.html
@@ -1,30 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Momentum Components Dev Page</title>
+        <script type="module" src="/dist/index.js"></script>
+        <script type="module" src="/dist/components/themeprovider/themeprovider.e2e-test.utils.js"></script>
+        <script type="module" src="/dist/components/iconprovider/iconprovider.e2e-test.utils.js"></script>
+        <link rel="stylesheet" href="index.css">
+        <link rel="stylesheet" href="/dist/fonts/css/fonts.css">
+        <link rel="stylesheet" href="/dist/complete.css">
+        <link rel="stylesheet" href="/dist/dark-stable.css">
+        <link rel="stylesheet" href="/dist/light-stable.css">
+    </head>
 
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Momentum Components Dev Page</title>
-    <script type="module" src="/dist/index.js"></script>
-    <script type="module" src="/dist/components/themeprovider/themeprovider.e2e-test.utils.js"></script>
-    <script type="module" src="/dist/components/iconprovider/iconprovider.e2e-test.utils.js"></script>
-    <link rel="stylesheet" href="index.css">
-    <link rel="stylesheet" href="/dist/fonts/css/fonts.css">
-    <link rel="stylesheet" href="/dist/complete.css">
-    <link rel="stylesheet" href="/dist/dark-stable.css">
-    <link rel="stylesheet" href="/dist/light-stable.css">
-</head>
-
-<body>
-    <main>
-        <mdc-themeprovider themeclass="mds-theme-stable-darkWebex">
-            <mdc-iconprovider url="/dist/icons/svg">
-                <div id="root">
-                </div>
-            </mdc-iconprovider>
-        </mdc-themeprovider>
-    </main>
-</body>
-
+    <body class="mds-typography">
+        <main>
+            <mdc-themeprovider themeclass="mds-theme-stable-darkWebex">
+                <mdc-iconprovider url="/dist/icons/svg">
+                    <div id="root">
+                    </div>
+                </mdc-iconprovider>
+            </mdc-themeprovider>
+        </main>
+    </body>
 </html>

--- a/packages/components/config/storybook/provider/themeProvider.js
+++ b/packages/components/config/storybook/provider/themeProvider.js
@@ -30,6 +30,7 @@ export const withThemeProvider = (story, context) => {
   const body = document.querySelector('body.sb-show-main');
   clearStyles(body);
   applyStyle(body, themeObject.className);
+  applyStyle(body, 'mds-typography');
 
   // This will set the all canvas in "Docs" with the current theme background color
   setCanvasBackgroundOnDocs(themeObject.backgroundColor);

--- a/packages/components/src/Consumption.mdx
+++ b/packages/components/src/Consumption.mdx
@@ -19,22 +19,50 @@ or
 yarn add @momentum-design/components
 ``` 
 
+## PreRequisites 
+
+* The following stylesheets need to be included:
+
+    ```javascript
+    import '@momentum-design/fonts/dist/css/fonts.css';
+    import '@momentum-design/tokens/dist/css/typography/complete.css';
+    import '@momentum-design/tokens/dist/css/theme/webex/dark-stable.css';
+    import '@momentum-design/tokens/dist/css/theme/webex/light-stable.css';
+    ```
+* `mds-typography` class needs to be set on the root element for proper font usage.
+* Providers (like ThemeProvider, IconProvider) need to wrap Momentum Design Components for proper usage.
+* Your build config needs to be able to have file loaders for CSS and WOFF2.
+
+
+**Example:**
+
+```html
+<html>
+    <head>
+        <link rel="stylesheet" href="@momentum-design/fonts/dist/css/fonts.css">
+        <link rel="stylesheet" href="@momentum-design/tokens/dist/css/typography/complete.css">
+        <link rel="stylesheet" href="@momentum-design/tokens/dist/css/theme/webex/dark-stable.css">
+        <link rel="stylesheet" href="@momentum-design/tokens/dist/css/theme/webex/light-stable.css">
+    </head>
+    <!-- mds-typography needs to be set on the root for proper Font usage -->
+    <body class="mds-typography">
+        <!-- Providers need to be used to use the Components -->
+        <mdc-themeprovider ...>
+            <mdc-iconprovider ...>
+                <!-- Momentum Design Components -->
+                <mdc-component-name .../>
+                ...
+            </mdc-iconprovider>
+        </mdc-themeprovider>
+    </body>
+</html>
+```
+
 ## Compatibility
 
 * Webpack 4 (refer to [**Best Practices**](https://lit.dev/docs/releases/upgrade/#using-lit-3-with-webpack-4))
 
 * TypeScript > 4.7 (refer to [**Best Practices**](https://stackoverflow.com/a/70020984))
-
-## PreRequisites 
-
-```javascript
-import '@momentum-design/fonts/dist/css/fonts.css';
-import '@momentum-design/tokens/dist/css/typography/complete.css';
-import '@momentum-design/tokens/dist/css/theme/webex/dark-stable.css';
-import '@momentum-design/tokens/dist/css/theme/webex/light-stable.css';
-``` 
-
-* Your build config needs to be able to have file loaders for CSS and WOFF2.
 
 ## Usage 
 

--- a/packages/components/src/components/themeprovider/themeprovider.component.ts
+++ b/packages/components/src/components/themeprovider/themeprovider.component.ts
@@ -63,13 +63,6 @@ class ThemeProvider extends Provider<ThemeProviderContext> {
   @property({ type: String })
   themeclass: string = DEFAULTS.THEMECLASS;
 
-  override connectedCallback(): void {
-    super.connectedCallback();
-
-    // Set the default typography class
-    this.classList.add(DEFAULTS.TYPOGRAPHYCLASS);
-  }
-
   protected override updated(changedProperties: Map<string, any>) {
     super.updated(changedProperties);
 

--- a/packages/components/src/components/themeprovider/themeprovider.constants.ts
+++ b/packages/components/src/components/themeprovider/themeprovider.constants.ts
@@ -5,7 +5,6 @@ const TAG_NAME = utils.constructTagName('themeprovider');
 
 const DEFAULTS = {
   THEMECLASS: 'mds-theme-stable-darkWebex' as const,
-  TYPOGRAPHYCLASS: 'mds-typography' as const,
 };
 
 export { DEFAULTS, TAG_NAME };


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

# Description

- Due to recent conversations on the Lit discord we will now move the `mds-typography` class out to the consumer to set on the root. This will make sure its present and not changing (which was an issue).
- Made that change to the component, storybook and Playwright to be reflected like that.
- Updated Consumption guide.

