### PR TITLE
chore(badge): build badge component of all types

### DIFF
--- a/packages/components/src/components/badge/badge.component.ts
+++ b/packages/components/src/components/badge/badge.component.ts
@@ -1,44 +1,22 @@
 import { CSSResult, html } from 'lit';
 import { property } from 'lit/decorators.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
-import { StyleInfo, styleMap } from 'lit/directives/style-map.js';
 import { Component } from '../../models';
-import { DEFAULTS, WARNING_ICON_NAME } from './badge.constants';
+import { DEFAULTS } from './badge.constants';
 import styles from './badge.styles';
-import type { BadgeType } from './badge.types';
+import type { BadgeType, BadgeVariant } from './badge.types';
 
 /**
- * @slot - This is a default/unnamed slot
- *
- * @summary This is MyElement
- *
  * @tagname mdc-badge
  */
 class Badge extends Component {
   /**
    * Type of the badge
-   * Can be `regular`, `icon`, `text` or `warning`
+   * Can be `notification`, `icon`, `counter` and `text`
    *
-   * Default: `regular`
+   * Default: `notification`
    */
   @property({ type: String, reflect: true })
   type?: BadgeType = DEFAULTS.TYPE;
-
-  /**
-   * Scale of the badge (works in combination with length unit)
-   *
-   * Default: `1`
-   */
-  @property({ type: Number })
-  size?: number = DEFAULTS.SIZE;
-
-  /**
-   * Length unit attribute for scale
-   *
-   * Default: `rem`
-   */
-  @property({ type: String, attribute: 'length-unit' })
-  lengthUnit?: string = DEFAULTS.LENGTH_UNIT;
 
   /**
    * If `type` is set to `icon`, attribute `iconName` can
@@ -56,63 +34,40 @@ class Badge extends Component {
   @property({ type: String })
   text?: string;
 
-  private updateSize() {
-    // if (this.scale && this.lengthUnit) {
-    //   const value = `${this.scale}${this.lengthUnit}`;
-    //   this.style.height = value;
-    //   if (this.type !== 'text') {
-    //     this.style.width = value;
-    //   }
-    // }
-  }
+  /**
+   * badge variant
+   */
+  @property({ type: String })
+  variant?: BadgeVariant;
 
-  override updated(changedProperties: Map<string, any>) {
-    super.updated(changedProperties);
-    if (changedProperties.has('size') || changedProperties.has('lengthUnit')) {
-      this.updateSize();
+  @property({ type: Number })
+  counter?: number;
+
+  @property({ type: Number, attribute: 'max-counter' })
+  maxCounter?: number;
+
+  @property({ type: Boolean })
+  overlay?: boolean;
+
+  /**
+   * Aria-label attribute to be set for accessibility
+   */
+  @property({ type: String, attribute: 'aria-label' })
+  override ariaLabel: string | null = null;
+
+  private getBadgeContentBasedOnType() {
+    switch (this.type) {
+      default:
+        return html``;
     }
-  }
-
-  iconTemplate() {
-    return html`<div class="mdc-badge-icon-container">
-      <mdc-icon name=${ifDefined(this.iconName)} size="100" length-unit="%"></mdc-icon>
-    </div>`;
-  }
-
-  textTemplate() {
-    return html`${this.text}`;
-  }
-
-  warningTemplate() {
-    return html` <mdc-icon name="${WARNING_ICON_NAME}" class="mdc-badge-warning"></mdc-icon> `;
   }
 
   public override render() {
-    let content;
-    const size = `${this.size}${this.lengthUnit}`;
-    let sizeStyles: StyleInfo = { width: size, height: size };
-
-    switch (this.type) {
-      case 'regular':
-        content = html``;
-        break;
-      case 'icon':
-        content = this.iconTemplate();
-        break;
-      case 'text':
-        content = this.textTemplate();
-        // make width flexible when text -> only set the height:
-        sizeStyles = { height: sizeStyles.height };
-        break;
-      case 'warning':
-        content = this.warningTemplate();
-        break;
-      default:
-        content = html``;
-        break;
-    }
-
-    return html`<div class="mdc-badge-container" style=${styleMap(sizeStyles)}>${content}</div>`;
+    return html`
+      <div class="mdc-badge-container">
+        ${this.getBadgeContentBasedOnType()}
+      </div>
+    `;
   }
 
   public static override styles: Array<CSSResult> = [...Component.styles, ...styles];

--- a/packages/components/src/components/badge/badge.constants.ts
+++ b/packages/components/src/components/badge/badge.constants.ts
@@ -6,6 +6,8 @@ const DEFAULTS = {
   TYPE: 'notification' as const,
   SIZE: 1,
   LENGTH_UNIT: 'rem',
+  MAX_COUNTER: 99,
+  VARIANT: 'secure' as const,
 };
 
 export {

--- a/packages/components/src/components/badge/badge.constants.ts
+++ b/packages/components/src/components/badge/badge.constants.ts
@@ -1,13 +1,17 @@
 import utils from '../../utils/tag-name';
+import { BadgeType, BadgeVariant } from './badge.types';
 
 const TAG_NAME = utils.constructTagName('badge');
 
 const DEFAULTS = {
-  TYPE: 'notification' as const,
+  TYPE: BadgeType.NOTIFICATION,
   SIZE: 1,
   LENGTH_UNIT: 'rem',
   MAX_COUNTER: 99,
-  VARIANT: 'secure' as const,
+  VARIANT: BadgeVariant.SECURE,
+  ICON_NAME: 'shape-circle-filled',
+  ICON_SIZE: 1,
+  NOTIFICATION_ICON_SIZE_IN_REM: 0.75,
 };
 
 export {

--- a/packages/components/src/components/badge/badge.constants.ts
+++ b/packages/components/src/components/badge/badge.constants.ts
@@ -2,10 +2,8 @@ import utils from '../../utils/tag-name';
 
 const TAG_NAME = utils.constructTagName('badge');
 
-const WARNING_ICON_NAME = 'warning-badge-filled';
-
 const DEFAULTS = {
-  TYPE: 'regular' as const,
+  TYPE: 'notification' as const,
   SIZE: 1,
   LENGTH_UNIT: 'rem',
 };
@@ -13,5 +11,4 @@ const DEFAULTS = {
 export {
   TAG_NAME,
   DEFAULTS,
-  WARNING_ICON_NAME,
 };

--- a/packages/components/src/components/badge/badge.stories.ts
+++ b/packages/components/src/components/badge/badge.stories.ts
@@ -10,6 +10,10 @@ const render = (args: Args) => html`
     size="${args.size}"
     length-unit="${args.lengthUnit}"
     text="${args.text}"
+    counter="${args.counter}"
+    maxCounter="${args.maxCounter}"
+    variant="${args.variant}"
+    overlay="${args.overlay}"
   ></mdc-badge>
 `;
 
@@ -33,5 +37,9 @@ export const Primary: StoryObj = {
     size: 1,
     lengthUnit: 'rem',
     text: '99+',
+    counter: 1,
+    maxCounter: 99,
+    variant: 'secure',
+    overlay: 'false',
   },
 };

--- a/packages/components/src/components/badge/badge.stories.ts
+++ b/packages/components/src/components/badge/badge.stories.ts
@@ -13,7 +13,6 @@ const render = (args: Args) => html`
     counter="${args.counter}"
     maxCounter="${args.maxCounter}"
     variant="${args.variant}"
-    overlay="${args.overlay}"
   ></mdc-badge>
 `;
 
@@ -33,13 +32,12 @@ export default meta;
 export const Primary: StoryObj = {
   args: {
     type: DEFAULTS.TYPE,
-    iconName: 'accessibility-regular',
+    iconName: 'error-legacy-filled',
     size: 1,
     lengthUnit: 'rem',
     text: '99+',
     counter: 1,
     maxCounter: 99,
-    variant: 'secure',
-    overlay: 'false',
+    variant: DEFAULTS.VARIANT,
   },
 };

--- a/packages/components/src/components/badge/badge.styles.ts
+++ b/packages/components/src/components/badge/badge.styles.ts
@@ -4,23 +4,16 @@ import { hostFitContentStyles } from '../../utils/styles';
 const styles = [
   hostFitContentStyles,
   css`
-    :host {
-      --mdc-badge-icon-background-color: var(--mds-color-theme-background-accent-normal);
-      --mdc-badge-icon-color: var(--mds-color-theme-common-text-primary-normal);
-    }
-
     .mdc-badge-container {
+      max-height: 1rem;
       display: flex;
       justify-content: center;
       align-items: center;
       border-radius: 9999px;
-      background-color: var(--mdc-badge-icon-background-color);
-      color: var(--mdc-badge-icon-color);
     }
-
-    .mdc-badge-icon-container {
-      height: 80%;
-      width: 80%;
+    .mdc-badge-base {
+      padding: 8px;
+      height: 12px;
     }
   `,
 ];

--- a/packages/components/src/components/badge/badge.styles.ts
+++ b/packages/components/src/components/badge/badge.styles.ts
@@ -9,11 +9,17 @@ const styles = [
       display: flex;
       justify-content: center;
       align-items: center;
-      border-radius: 9999px;
+      border-radius: 100%;
     }
-    .mdc-badge-base {
-      padding: 8px;
-      height: 12px;
+    .mdc-badge-overlay {
+      border: 1px solid black;
+    }
+    .mdc-badge-text {
+      padding: 0 4px;
+      border-radius: 6.25rem;
+      line-height: 1px;
+      color: var(--mds-color-theme-text-primary-normal);
+      background-color: var(--mds-color-theme-indicator-secure);
     }
   `,
 ];

--- a/packages/components/src/components/badge/badge.types.ts
+++ b/packages/components/src/components/badge/badge.types.ts
@@ -1,1 +1,2 @@
-export type BadgeType = 'regular' | 'text' | 'icon' | 'warning';
+export type BadgeType = 'notification' | 'icon' | 'counter' | 'text';
+export type BadgeVariant = 'secure' | 'locked' | 'stable' | 'unstable' | 'attention' | 'caution';

--- a/packages/components/src/components/badge/badge.types.ts
+++ b/packages/components/src/components/badge/badge.types.ts
@@ -1,2 +1,15 @@
-export type BadgeType = 'notification' | 'icon' | 'counter' | 'text';
-export type BadgeVariant = 'secure' | 'locked' | 'stable' | 'unstable' | 'attention' | 'caution';
+export enum BadgeType {
+  NOTIFICATION = 'notification',
+  ICON = 'icon',
+  COUNTER = 'counter',
+  TEXT = 'text'
+}
+
+export enum BadgeVariant {
+  SECURE = 'secure',
+  LOCKED = 'locked',
+  STABLE = 'stable',
+  UNSTABLE = 'unstable',
+  ATTENTION = 'attention',
+  CAUTION = 'caution',
+}


### PR DESCRIPTION
# Description

- There are 4 types of badges:
  - notifcation
  - icons
  - counter
  - text
- The notification badge contains an icon of circle shape.
- Only the first 4 characters of the text will be displayed, rest will be hidden.
- The `counter` and `text` types were build using `mdc-text` component.
- The `notification` and `icons` types were build using `mdc-icon` component.

## Links

JIRA: [MOMENTUM-381](https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-381)

## Screenshots:
- All screenshot were shot in 400x zoom.

#### notification type:
<img width="547" alt="image" src="https://github.com/user-attachments/assets/b0debcae-d857-4132-9833-ceba6aa7ed62">

#### icons type:
<img width="547" alt="image" src="https://github.com/user-attachments/assets/ff783923-eea7-4ac0-a160-575777335335">

#### counter type:
<img width="547" alt="image" src="https://github.com/user-attachments/assets/ad1fff52-cd20-4cd7-8780-690d9e6088c1">

#### text type:
<img width="547" alt="image" src="https://github.com/user-attachments/assets/5bedfddb-87ea-4799-9aed-186f34d45a97">


