### PR TITLE
fix: tech debt for icon component

### DIFF
--- a/packages/components/src/components/icon/icon.stories.ts
+++ b/packages/components/src/components/icon/icon.stories.ts
@@ -46,7 +46,11 @@ export default meta;
 
 export const Decorative: StoryObj = {
   argTypes: {
-    ...disableControls(['aria-label']),
+    'aria-label': {
+      table: {
+        disable: true,
+      },
+    },
   },
   args: {
     name: 'accessibility-regular',

--- a/packages/components/src/components/icon/icon.stories.ts
+++ b/packages/components/src/components/icon/icon.stories.ts
@@ -29,7 +29,14 @@ const meta: Meta = {
     badges: ['stable'],
   },
   argTypes: {
-    ...disableControls(['--mdc-icon-fill-color']),
+    ...disableControls([
+      'iconData',
+      'lengthUnitFromContext',
+      'sizeFromContext',
+      'iconProviderContext',
+      'computedIconSize',
+      '--mdc-icon-fill-color',
+    ]),
     ...classArgType,
     ...styleArgType,
   },
@@ -38,6 +45,9 @@ const meta: Meta = {
 export default meta;
 
 export const Decorative: StoryObj = {
+  argTypes: {
+    ...disableControls(['aria-label']),
+  },
   args: {
     name: 'accessibility-regular',
     size: 2,


### PR DESCRIPTION
# Description

- Disable all properties of icon component.
- Hide `aria-label` attribute only for "Decorative" story.

## Links

https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-380

## Screenshots

- For decorative icon, the aria-label is hidden.
<img width="1709" alt="image" src="https://github.com/user-attachments/assets/e6d2c87c-6099-4196-9dc2-b69b42ed2ed1">

- For informative icon, the aria-label is visible:
<img width="1709" alt="image" src="https://github.com/user-attachments/assets/59576523-5925-4b97-88cc-7026e8cf631b">

- Disable all props for icon component.
<img width="1709" alt="image" src="https://github.com/user-attachments/assets/cf127f8b-b8f4-4f44-8e0d-895d80949afe">

