### PR TITLE
ci: moving build to es2020 instead of commonjs

### DIFF
--- a/packages/components/src/tsconfig.json
+++ b/packages/components/src/tsconfig.json
@@ -4,7 +4,7 @@
     "composite": true,
     "tsBuildInfoFile": null,
     "target": "es2019",
-    "module": "CommonJS",
+    "module": "ES2020",
     "lib": [
       "es2020",
       "DOM",
@@ -30,6 +30,7 @@
     "noImplicitOverride": true,
     "useDefineForClassFields": false,
     "removeComments": false,
+    "importHelpers": false,
     "plugins": [
       {
         "name": "ts-lit-plugin",


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

# Description

- Updated tsconfig in Components package to build output in ES2020
- Removing tslib by adding importHelpers: false
