### PR TITLE
build: do not process png as svg

### DIFF
--- a/packages/assets/brand-visuals/config/momentum.json
+++ b/packages/assets/brand-visuals/config/momentum.json
@@ -5,7 +5,7 @@
       "flows": [
         {
           "id": "optimise-svgs",
-          "target": "./src/**/*.*",
+          "target": "./src/**/*.svg",
           "destination": "./dist/svg",
           "fileNameReplacePatterns": [
             {
@@ -31,8 +31,25 @@
           }
         },
         {
+          "id": "copy-images",
+          "target": "./src/**/*.png",
+          "destination": "./dist/images",
+          "fileNameReplacePatterns": [
+            {
+              "searchValue": "_",
+              "replaceValue": "-"
+            }
+          ],
+          "format": {
+            "type": "COPY_IMAGE",
+            "config": {
+              "mergePaths": true
+            }
+          }
+        },
+        {
           "id": "Manifest",
-          "target": "./dist/svg/**/*.*",
+          "target": "./dist/{svg,images}/**/*.*",
           "destination": "./dist/",
           "format": {
             "type": "MANIFEST",


### PR DESCRIPTION
# Description

In brand visuals svgs are being processed as part of the optimize svg build step.
Change so only svgs are processed in this stage and copy pngs to a new images folder
Update manifest to handle both locations

## Links

N/A
