### PR TITLE
fix: docker run cannot be killed with ctrl + c

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -66,7 +66,7 @@
     "test:postbuild": "yarn test:e2e:docker",
     "test:e2e:docker": "PW_TEST_CONNECT_WS_ENDPOINT=ws://localhost:3000/ playwright test --config './config/playwright/docker/playwright.docker.config.ts'",
     "test:e2e:docker:build": "docker build --platform linux/amd64 -f ./config/playwright/docker/utils/Dockerfile.test.postbuild -t ghcr.io/momentum-design/momentum-design/docker-playwright:v1.47.2 .",
-    "test:e2e:docker:serve": "docker run --platform linux/amd64 -p 3000:3000 --rm --init --add-host=hostmachine:host-gateway ghcr.io/momentum-design/momentum-design/docker-playwright:v1.47.2",
+    "test:e2e:docker:serve": "docker run --platform linux/amd64 -p 3000:3000 --rm --init -it --add-host=hostmachine:host-gateway ghcr.io/momentum-design/momentum-design/docker-playwright:v1.47.2",
     "test:e2e:docker:update-snapshot": "yarn test:e2e:docker --update-snapshots",
     "test:e2e": "playwright test --config './config/playwright/playwright.config.ts'",
     "test:e2e:install": "playwright install-deps && playwright install && yarn playwright install msedge",


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

# Description

small fix to kill the docker run with ctrl + c

## Links

