### PR TITLE
fix: increase timeout of playwright from 30 to 35ms

### DIFF
--- a/packages/components/config/playwright/docker/playwright.docker.config.ts
+++ b/packages/components/config/playwright/docker/playwright.docker.config.ts
@@ -32,7 +32,7 @@ const config: PlaywrightTestConfig = {
   testDir: '../../../src',
   testMatch: /.*\.e2e-test\.ts/,
   /* Maximum time one test can run for. */
-  timeout: 30 * 1000,
+  timeout: 35 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/packages/components/config/playwright/playwright.config.ts
+++ b/packages/components/config/playwright/playwright.config.ts
@@ -26,7 +26,7 @@ const config: PlaywrightTestConfig = {
   testDir: '../../src',
   testMatch: /.*\.e2e-test\.ts/,
   /* Maximum time one test can run for. */
-  timeout: 30 * 1000,
+  timeout: 35 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.


### PR DESCRIPTION
# Description

- The `mdc-text` component e2e spec is getting failed due to time limit of playwright.
- This PR will fix this issue by increasing the time from 30ms to 35ms.

## Links

- NA