### PR TITLE
refactor: add custom events for icon component

### DIFF
--- a/packages/components/src/components/icon/icon.component.ts
+++ b/packages/components/src/components/icon/icon.component.ts
@@ -134,7 +134,7 @@ class Icon extends Component {
     // update iconData state once fetched:
     this.iconData = iconHtml;
 
-    // when icon got fetched, set role and aria-label and trigger icon load event:
+    // when icon is fetched successfully, set the role, aria-label and invoke function to trigger icon load event.
     this.setRoleOnIcon();
     this.setAriaLabelOnIcon();
     this.setAriaHiddenOnIcon();

--- a/packages/components/src/components/icon/icon.component.ts
+++ b/packages/components/src/components/icon/icon.component.ts
@@ -89,6 +89,18 @@ class Icon extends Component {
   }
 
   /**
+   * Dispatches a 'load' event on the component once the icon has been successfully loaded.
+   * This event bubbles and is cancelable.
+   */
+  private triggerIconLoaded(): void {
+    const loadEvent = new Event('load', {
+      bubbles: true,
+      cancelable: true,
+    });
+    this.dispatchEvent(loadEvent);
+  }
+
+  /**
    * Get Icon Data function which will fetch the icon (currently only svg)
    * and sets state and attributes once fetched successfully
    *
@@ -111,6 +123,7 @@ class Icon extends Component {
         this.setRoleOnIcon();
         this.setAriaLabelOnIcon();
         this.setAriaHiddenOnIcon();
+        this.triggerIconLoaded();
       }
     }
   }


### PR DESCRIPTION
# Description

- This PR will add `load` and `error` event for icon component.
- When the icon gets fetched, the `load` event will be emitted.
- When the icon fetch gets failed, then the `error` event will be emitted.
- Example code:
```
<mdc-icon
    ...
    @load="${this.handleLoad}"
    @error="${this.handleError}"
    ...
>
</mdc-icon>
```
- These two new events will help handle the states of the icon.

https://github.com/user-attachments/assets/96eb3843-2199-4666-b45b-dc442b13970d



## Links

- https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-454
