### PR TITLE
fix: add activeType to update the class only after the icon loads

### DIFF
--- a/packages/components/src/components/presence/presence.component.ts
+++ b/packages/components/src/components/presence/presence.component.ts
@@ -40,12 +40,6 @@ class Presence extends Component {
   type: PresenceType = DEFAULTS.TYPE;
 
   /**
-   * State to track the active type (previous type until the new icon is loaded)
-   */
-  @state()
-  private activeType: PresenceType = DEFAULTS.TYPE;
-
-  /**
    * Acceptable values include:
    * - XX_SMALL
    * - X_SMALL
@@ -61,6 +55,13 @@ class Presence extends Component {
    */
   @property({ type: String, reflect: true })
   size: PresenceSize = DEFAULTS.SIZE;
+
+  /**
+   * @internal
+   * State to track the active type (previous type until the new icon is loaded)
+   */
+  @state()
+  private currentIconType: PresenceType = DEFAULTS.TYPE;
 
   /**
    * Get the size of the presence icon based on the given size type
@@ -97,24 +98,26 @@ class Presence extends Component {
 
   /**
     * Handles the successful load of an icon.
-    * Sets the `activeType` property to match the `type` property.
+    * Sets the `currentIconType` property to match the `type` property.
   */
   private handleOnLoad(): void {
-    this.activeType = this.type;
+    this.currentIconType = this.type;
   }
 
   /**
    * Handles an error that occurs when loading an icon.
   */
-  private handleOnError(error: Event): void {
-    console.error(`Failed to load icon: ${this.icon} - ${error}`);
+  private handleOnError(): void {
+    if (this.onerror) {
+      this.onerror('There was a problem while fetching the icon. Please check the icon name and try again.');
+    }
   }
 
   public override render() {
     return html`
       <div class="mdc-presence mdc-presence__${this.size}">
         <mdc-icon
-          class="mdc-presence-icon mdc-presence-icon__${this.activeType}"
+          class="mdc-presence-icon mdc-presence-icon__${this.currentIconType}"
           name="${this.icon}"
           size="${this.iconSize}"
           @load="${this.handleOnLoad}"

--- a/packages/components/src/components/presence/presence.component.ts
+++ b/packages/components/src/components/presence/presence.component.ts
@@ -1,5 +1,5 @@
 import { CSSResult, html } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import { Component } from '../../models';
 import { DEFAULTS, SIZE } from './presence.constants';
 import styles from './presence.styles';
@@ -38,6 +38,12 @@ class Presence extends Component {
    */
   @property({ type: String, reflect: true })
   type: PresenceType = DEFAULTS.TYPE;
+
+  /**
+   * State to track the active type (previous type until the new icon is loaded)
+   */
+  @state()
+  private activeType: PresenceType = DEFAULTS.TYPE;
 
   /**
    * Acceptable values include:
@@ -89,13 +95,30 @@ class Presence extends Component {
     return iconName;
   }
 
+  /**
+    * Handles the successful load of an icon.
+    * Sets the `activeType` property to match the `type` property.
+  */
+  private handleOnLoad(): void {
+    this.activeType = this.type;
+  }
+
+  /**
+   * Handles an error that occurs when loading an icon.
+  */
+  private handleOnError(error: Event): void {
+    console.error(`Failed to load icon: ${this.icon} - ${error}`);
+  }
+
   public override render() {
     return html`
       <div class="mdc-presence mdc-presence__${this.size}">
         <mdc-icon
-          class="mdc-presence-icon mdc-presence-icon__${this.type}"
+          class="mdc-presence-icon mdc-presence-icon__${this.activeType}"
           name="${this.icon}"
           size="${this.iconSize}"
+          @load="${this.handleOnLoad}"
+          @error="${this.handleOnError}"
         ></mdc-icon>
       </div>
     `;

--- a/packages/components/src/components/presence/presence.component.ts
+++ b/packages/components/src/components/presence/presence.component.ts
@@ -58,7 +58,7 @@ class Presence extends Component {
 
   /**
    * @internal
-   * State to track the active type (previous type until the new icon is loaded)
+   * State to track the current icon type (previous type until the new icon is loaded)
    */
   @state()
   private currentIconType: PresenceType = DEFAULTS.TYPE;


### PR DESCRIPTION


# Description
1. Added activeType state to retain the previous type/class until the new icon associated with the updated type is successfully loaded.
2. Implemented handlers for the load and error events to manage the icon loading process.
3. Upon the load event, the activeType state is updated, which subsequently updates the corresponding CSS class.



https://github.com/user-attachments/assets/fa19f06e-fa96-4c1e-b489-4aed6defd019



## Links

https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-441