### PR TITLE
chore: update focus ring styles for specific id

### DIFF
--- a/packages/components/src/components/avatarbutton/avatarbutton.styles.ts
+++ b/packages/components/src/components/avatarbutton/avatarbutton.styles.ts
@@ -8,6 +8,6 @@ const styles = [hostFitContentStyles, css`
     outline: none;
     border-radius: 0.25rem;
   }
-`, hostFocusRingStyles];
+`, ...hostFocusRingStyles()];
 
 export default styles;

--- a/packages/components/src/components/buttonsimple/buttonsimple.styles.ts
+++ b/packages/components/src/components/buttonsimple/buttonsimple.styles.ts
@@ -57,6 +57,6 @@ const styles = [hostFitContentStyles, css`
   :host([size="20"]){
     height: var(--mdc-button-height-size-20);
   }
-`, hostFocusRingStyles];
+`, ...hostFocusRingStyles()];
 
 export default styles;

--- a/packages/components/src/stories/FocusRing/subcomponent-focusring.styles.ts
+++ b/packages/components/src/stories/FocusRing/subcomponent-focusring.styles.ts
@@ -8,7 +8,7 @@ const styles = [
       outline: none;
     }
   `,
-  hostFocusRingStyles,
+  ...hostFocusRingStyles(),
 ];
 
 export default styles;

--- a/packages/components/src/utils/styles/index.ts
+++ b/packages/components/src/utils/styles/index.ts
@@ -1,4 +1,4 @@
-import { css, unsafeCSS } from 'lit';
+import { css } from 'lit';
 
 const hostFitContentStyles = css`
   :host {
@@ -10,7 +10,7 @@ const hostFitContentStyles = css`
   }
 `;
 
-const hostFocusRingStyles = (className?: string) => {
+const hostFocusRingStyles = (applyFocusRingOnClass = false) => {
   const baseHostStyleVariables = css`
     :host {
       --mdc-focus-ring-inner-color: var(--mds-color-theme-focus-default-0);
@@ -29,23 +29,23 @@ const hostFocusRingStyles = (className?: string) => {
     0 0 0 var(--mdc-focus-ring-middle-width) var(--mdc-focus-ring-middle-color),
     0 0 0 var(--mdc-focus-ring-outer-width) var(--mdc-focus-ring-outer-color)
   `;
-  if (className) {
+  if (applyFocusRingOnClass) {
     return [
       baseHostStyleVariables,
       css`
-        .${unsafeCSS(className)}:focus-visible {
+        .mdc-focus-ring:focus-visible {
           outline: none;
         }
-        :host([disabled]) .${unsafeCSS(className)}:focus {
+        :host([disabled]) .mdc-focus-ring:focus {
           box-shadow: none;
         }
-        .${unsafeCSS(className)}:focus-within {
+        .mdc-focus-ring:focus-within {
           position: relative;
           box-shadow: ${boxShadow};
         }
         /* High Contrast Mode */
         @media (forced-colors: active) {
-          .${unsafeCSS(className)}:focus-within {
+          .mdc-focus-ring:focus-within {
             outline: 0.125rem solid var(--mds-color-theme-focus-default-0);
           }
         }

--- a/packages/components/src/utils/styles/index.ts
+++ b/packages/components/src/utils/styles/index.ts
@@ -1,4 +1,4 @@
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
 
 const hostFitContentStyles = css`
   :host {
@@ -10,36 +10,54 @@ const hostFitContentStyles = css`
   }
 `;
 
-const hostFocusRingStyles = css`
-  :host {
-    --mdc-focus-ring-inner-color: var(--mds-color-theme-focus-default-0);
-    --mdc-focus-ring-middle-color: var(--mds-color-theme-focus-default-1);
-    --mdc-focus-ring-outer-color: var(--mds-color-theme-focus-default-2); 
+const hostFocusRingStyles = (className?: string) => {
+  const baseHostStyleVariables = css`
+    :host {
+      --mdc-focus-ring-inner-color: var(--mds-color-theme-focus-default-0);
+      --mdc-focus-ring-middle-color: var(--mds-color-theme-focus-default-1);
+      --mdc-focus-ring-outer-color: var(--mds-color-theme-focus-default-2);
 
-    --mdc-focus-ring-inner-width: 0.125rem;
-    --mdc-focus-ring-middle-width: calc(2 * var(--mdc-focus-ring-inner-width));
-    --mdc-focus-ring-outer-width: calc(0.0625rem + var(--mdc-focus-ring-middle-width));
+      --mdc-focus-ring-inner-width: 0.125rem;
+      --mdc-focus-ring-middle-width: calc(2 * var(--mdc-focus-ring-inner-width));
+      --mdc-focus-ring-outer-width: calc(0.0625rem + var(--mdc-focus-ring-middle-width));
 
-    --mdc-focus-ring-middle-offset: var(--mdc-focus-ring-inner-width);
-    --mdc-focus-ring-outer-offset: calc(var(--mdc-focus-ring-inner-width) + var(--mdc-focus-ring-middle-width));
-  }
-  :host([disabled]:focus) {
-    box-shadow: none;
-  }
-  :host(:focus) {
-    position: relative;
-    box-shadow: 
-        0 0 0 var(--mdc-focus-ring-inner-width) var(--mdc-focus-ring-inner-color),
-        0 0 0 var(--mdc-focus-ring-middle-width) var(--mdc-focus-ring-middle-color),
-        0 0 0 var(--mdc-focus-ring-outer-width) var(--mdc-focus-ring-outer-color);
-  }
-
-  /* High Contrast Mode */
-  @media (forced-colors: active) {
-    :host(:focus) {
-      outline: 0.125rem solid var(--mds-color-theme-focus-default-0);
+      --mdc-focus-ring-middle-offset: var(--mdc-focus-ring-inner-width);
+      --mdc-focus-ring-outer-offset: calc(var(--mdc-focus-ring-inner-width) + var(--mdc-focus-ring-middle-width));
     }
+  `;
+  const boxShadow = css`0 0 0 var(--mdc-focus-ring-inner-width) var(--mdc-focus-ring-inner-color),
+    0 0 0 var(--mdc-focus-ring-middle-width) var(--mdc-focus-ring-middle-color),
+    0 0 0 var(--mdc-focus-ring-outer-width) var(--mdc-focus-ring-outer-color)
+  `;
+  if (className) {
+    return [
+      baseHostStyleVariables,
+      css`
+        .${unsafeCSS(className)}:focus-visible {
+          outline: none;
+        }
+        :host([disabled]) .${unsafeCSS(className)}:focus {
+          box-shadow: none;
+        }
+        .${unsafeCSS(className)}:focus {
+          position: relative;
+          box-shadow: ${boxShadow};
+        }
+      `,
+    ];
   }
-`;
+  return [
+    baseHostStyleVariables,
+    css`
+      :host([disabled]:focus) {
+        box-shadow: none;
+      }
+      :host(:focus) {
+        position: relative;
+        box-shadow: ${boxShadow};
+      }
+    `,
+  ];
+};
 
 export { hostFitContentStyles, hostFocusRingStyles };

--- a/packages/components/src/utils/styles/index.ts
+++ b/packages/components/src/utils/styles/index.ts
@@ -39,9 +39,15 @@ const hostFocusRingStyles = (className?: string) => {
         :host([disabled]) .${unsafeCSS(className)}:focus {
           box-shadow: none;
         }
-        .${unsafeCSS(className)}:focus {
+        .${unsafeCSS(className)}:focus-within {
           position: relative;
           box-shadow: ${boxShadow};
+        }
+        /* High Contrast Mode */
+        @media (forced-colors: active) {
+          .${unsafeCSS(className)}:focus-within {
+            outline: 0.125rem solid var(--mds-color-theme-focus-default-0);
+          }
         }
       `,
     ];
@@ -55,6 +61,12 @@ const hostFocusRingStyles = (className?: string) => {
       :host(:focus) {
         position: relative;
         box-shadow: ${boxShadow};
+      }
+      /* High Contrast Mode */
+      @media (forced-colors: active) {
+        :host(:focus) {
+          outline: 0.125rem solid var(--mds-color-theme-focus-default-0);
+        }
       }
     `,
   ];


### PR DESCRIPTION
# Description

### Problem:
- The current implementation of focus ring focus the entire element.
- In the input type components such as input, checkbox, radio, we need to focus only on a specific section of the element instead of the entire element.

### Solution:
- We can now add a `className` to the focus group, and the focus ring will get attached only to that specific class instead of the entire element.

>  in `XXX.component.ts` file
```
<input  class="mdc-focus-ring"/>
```
> in `XXX.styles.ts` file,
```
...hostFocusRingStyles(true);
```
- If we want the focus ring for the entire element, then we don't need to specify any classname and it will be applied to the entire element.
```
...hostFocusRingStyles();
```

https://github.com/user-attachments/assets/2dc3698f-eff9-4b8c-adac-2b4abfe24c56


## Links

- https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-476
