### PR TITLE
docs: fix illustrations bg inverted

### DIFF
--- a/packages/documentation/src/components/IllustrationTable/IllustrationTable.css
+++ b/packages/documentation/src/components/IllustrationTable/IllustrationTable.css
@@ -6,23 +6,27 @@
 }
 
 .grid320 {
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
 }
 
 .grid192 {
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(192px, 1fr));
 }
 
 .grid120 {
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
 }
 
 .grid60 {
-  grid-template-columns: repeat(8, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
 }
 
 .illustrationWrapper {
   justify-self: center;
+}
+
+.illustration-bg-inverted {
+  filter :var(--illustrations-filter);
 }
 
 .nameAnchor {

--- a/packages/documentation/src/components/IllustrationTable/IllustrationTable.tsx
+++ b/packages/documentation/src/components/IllustrationTable/IllustrationTable.tsx
@@ -25,11 +25,13 @@ export const IllustrationTable = ({ illustrations, size }: Props) => {
 
   const render = useMemo(
     () => (
-      <div className={`illustrationGrid grid${getSize(size)}`}>
+      <div className={`illustrationGrid grid${size}`}>
         {Object.entries(illustrations).map(([key, path]) => {
           const finalPath = `${path.replace('./svg', '/momentum-design/illustrations')}`;
+          const isInverted = key.includes('default');
           return (
-            <div className="illustrationWrapper">
+            <div className={isInverted
+              ? ['illustrationWrapper', 'illustration-bg-inverted'].join(' ') : 'illustrationWrapper'}>
               <img
                 style={{ maxWidth: `${getSize(key)}px` }}
                 src={finalPath}

--- a/packages/documentation/src/styles/theme.css
+++ b/packages/documentation/src/styles/theme.css
@@ -79,6 +79,7 @@
 	--theme-selection-color: hsla(var(--color-blue), 1);
 	--theme-selection-bg: hsla(var(--color-blue), var(--theme-accent-opacity));
 	--icons-filter: invert(0);
+	--illustrations-filter: invert(0);
 
 }
 
@@ -120,6 +121,7 @@ body {
 	--docsearch-footer-shadow: inset 0 2px 10px #000;
 	--docsearch-modal-shadow: inset 0 0 8px #000;
 	--icons-filter: invert(1);
+	--illustrations-filter: invert(1);
 }
 
 ::selection {


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

# Description

- Regular Illustrations were invisible due to black color, fixing it with invert 
- Made grid better for illustrations to change depending on size

