### PR TITLE
fix: text-fixes-default-tagname

### DIFF
--- a/packages/components/src/components/text/fonts.styles.ts
+++ b/packages/components/src/components/text/fonts.styles.ts
@@ -1,7 +1,7 @@
 import { css } from 'lit';
 
 export const fontsStyles = css`
-  :host([tagname])::part(text) {
+  :host::part(text) {
     font-size: unset;
     font-weight: unset;
     line-height: unset;

--- a/packages/components/src/components/text/text.e2e-test.ts
+++ b/packages/components/src/components/text/text.e2e-test.ts
@@ -132,6 +132,7 @@ test.describe('mdc-text ellipsis', () => {
     await setupEllipsis({
       componentsPage,
       children: textContent,
+      tagname: 'p',
     });
 
     /**

--- a/packages/components/src/components/text/text.stories.ts
+++ b/packages/components/src/components/text/text.stories.ts
@@ -1,12 +1,13 @@
 import type { Meta, StoryObj, Args } from '@storybook/web-components';
 import '.';
 import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { DEFAULTS, TYPE, VALID_TEXT_TAGS } from './text.constants';
 import { disableControls } from '../../../config/storybook/utils';
 import { classArgType, styleArgType } from '../../../config/storybook/commonArgTypes';
 
 const render = (args: Args) => html`
-<mdc-text type="${args.type}" tagname="${args.tagname}">${args.children}</mdc-text>
+<mdc-text type="${args.type}" tagname="${ifDefined(args.tagname)}">${args.children}</mdc-text>
 `;
 
 const meta: Meta = {
@@ -43,7 +44,7 @@ export default meta;
 export const Example: StoryObj = {
   args: {
     type: DEFAULTS.TYPE,
-    tagname: '',
+    tagname: null,
     children: DEFAULTS.CHILDREN,
   },
 };


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- Fixing an issue in the font styles where the default setting of text part was not correct, due to the css selector
- Fixed storybook of Text component to reflect a none set tagname correctly.
