### PR TITLE
fix: custom timeout for mobile chrome device on text test cases

### DIFF
--- a/packages/components/src/components/text/text.e2e-test.ts
+++ b/packages/components/src/components/text/text.e2e-test.ts
@@ -6,6 +6,13 @@ import StickerSheet from '../../../config/playwright/setup/utils/Stickersheet';
 import { DEFAULTS, TYPE, VALID_TEXT_TAGS } from './text.constants';
 import type { TextType, TagName } from './text.types';
 
+// Custom timeout for mobile chrome device only on text component test suite
+const setTimeoutForMobileChrome = () => {
+  if (test.info().project.name === 'mobile chrome') {
+    test.setTimeout(45000);
+  }
+};
+
 type SetupOptions = {
   componentsPage: ComponentsPage;
   type?: TextType;
@@ -60,6 +67,7 @@ test.describe('mdc-text', () => {
    * VISUAL REGRESSION
    */
   test('visual-regression & accessibility', async ({ componentsPage }) => {
+    setTimeoutForMobileChrome();
     const textStickerSheet = new StickerSheet(componentsPage, 'mdc-text');
     await test.step('add text component with different types to sheet', async () => {
       textStickerSheet.setChildren(textContent);


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

Increase the timeout value for "mobile chrome" device specifically on Text component test suite.

### Links

https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-488
