### PR TITLE
fix: removing internal components from build bundle

### DIFF
--- a/packages/components/config/esbuild/esbuild-e2e.config.js
+++ b/packages/components/config/esbuild/esbuild-e2e.config.js
@@ -14,6 +14,10 @@ const iife = async () => {
       // be available for e2e tests
       `${join(process.cwd(), 'src/components/themeprovider/themeprovider.e2e-test.utils.ts')}`,
       `${join(process.cwd(), 'src/components/iconprovider/iconprovider.e2e-test.utils.ts')}`,
+      `${join(process.cwd(), 'src/components/buttonsimple/index.ts')}`,
+      `${join(process.cwd(), 'src/components/modalcontainer/index.ts')}`,
+      `${join(process.cwd(), 'src/components/formfieldwrapper/index.ts')}`,
+      `${join(process.cwd(), 'src/components/iconprovider/iconprovider.e2e-test.utils.ts')}`,
       `${join(process.cwd(), 'src/stories/FocusRing/subcomponent-focusring.e2e-test.utils.ts')}`,
     ],
     outfile: undefined,

--- a/packages/components/config/playwright/public/index.html
+++ b/packages/components/config/playwright/public/index.html
@@ -7,6 +7,9 @@
         <title>Momentum Components Dev Page</title>
         <script type="module" src="/dist/index.js"></script>
         <script type="module" src="/dist/components/themeprovider/themeprovider.e2e-test.utils.js"></script>
+        <script type="module" src="/dist/components/buttonsimple/index.js"></script>
+        <script type="module" src="/dist/components/modalcontainer/index.js"></script>
+        <script type="module" src="/dist/components/formfieldwrapper/index.js"></script>
         <script type="module" src="/dist/components/iconprovider/iconprovider.e2e-test.utils.js"></script>
         <script type="module" src="/dist/stories/FocusRing/subcomponent-focusring.e2e-test.utils.js"></script>
         <link rel="stylesheet" href="index.css">

--- a/packages/components/src/components/avatarbutton/avatarbutton.component.ts
+++ b/packages/components/src/components/avatarbutton/avatarbutton.component.ts
@@ -5,7 +5,7 @@ import { AvatarComponentMixin } from '../../utils/mixins/AvatarComponentMixin';
 import { AVATAR_SIZE, DEFAULTS } from '../avatar/avatar.constants';
 import type { AvatarSize } from '../avatar/avatar.types';
 import { DEFAULTS as BUTTON_DEFAULTS } from '../button/button.constants';
-import Buttonsimple from '../buttonsimple';
+import Buttonsimple from '../buttonsimple/buttonsimple.component';
 import styles from './avatarbutton.styles';
 
 /**

--- a/packages/components/src/components/button/button.component.ts
+++ b/packages/components/src/components/button/button.component.ts
@@ -18,7 +18,7 @@ import type {
 } from './button.types';
 import { getIconNameWithoutStyle, getIconSize } from './button.utils';
 import type { IconNames } from '../icon/icon.types';
-import Buttonsimple from '../buttonsimple';
+import Buttonsimple from '../buttonsimple/buttonsimple.component';
 
 /**
  * `mdc-button` is a component that can be configured in various ways to suit different use cases.

--- a/packages/components/src/components/formfieldwrapper/formfieldwrapper.stories.ts
+++ b/packages/components/src/components/formfieldwrapper/formfieldwrapper.stories.ts
@@ -9,7 +9,6 @@ import { ValidationType } from './formfieldwrapper.types';
 const render = (args: Args) =>
   html` <mdc-formfieldwrapper
     label="${args.label}"
-    label-info-text="${args['label-info-text']}"
     help-text-type="${args['help-text-type']}"
     help-text="${args['help-text']}"
     >
@@ -37,9 +36,6 @@ const meta: Meta = {
     label: {
       control: 'text',
     },
-    'label-info-text': {
-      control: 'text',
-    },
     'help-text': {
       control: 'text',
     },
@@ -51,7 +47,6 @@ export default meta;
 export const Example: StoryObj = {
   args: {
     label: 'Label (required)',
-    'label-info-text': 'Label info text',
     'help-text': 'Helper text',
     'help-text-type': 'default',
     children: '[Child Component]',

--- a/packages/components/src/components/modalcontainer/modalcontainer.stories.ts
+++ b/packages/components/src/components/modalcontainer/modalcontainer.stories.ts
@@ -17,7 +17,7 @@ const render = (args: Args) => html`
 `;
 
 const meta: Meta = {
-  title: 'Work In Progress/modalcontainer',
+  title: 'Internal/modalcontainer',
   tags: ['autodocs'],
   component: 'mdc-modalcontainer',
   render,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -9,8 +9,6 @@ import Button from './components/button';
 import Bullet from './components/bullet';
 import Marker from './components/marker';
 import Divider from './components/divider';
-import Modalcontainer from './components/modalcontainer';
-import Buttonsimple from './components/buttonsimple';
 import Avatarbutton from './components/avatarbutton';
 
 import type { TextType } from './components/text/text.types';
@@ -27,8 +25,6 @@ export {
   Bullet,
   Marker,
   Divider,
-  Modalcontainer,
-  Buttonsimple,
   Avatarbutton,
 };
 


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

* Removed Buttonsimple, Modalcontainer and Formfieldwrapper from build bundle
* Updated their entry module for playwright to access it correctly
* Marked Modalcontainer as internal on storybook
* Removed label-info-text on Formfieldwrapper (wasn't updated in the prev PR)

### Links

https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-499
