### PR TITLE
fix: figma-plugin-assets-export-settings-update

### DIFF
--- a/packages/tools/figma-plugins/assets-export/config/figma-plugin-settings-default.json
+++ b/packages/tools/figma-plugins/assets-export/config/figma-plugin-settings-default.json
@@ -83,35 +83,35 @@
         "mapPagesToFolder": [
           {
             "page": "✅ Solid Illustrations",
-            "folder": "src/core"
+            "folder": "core"
           },
           {
             "page": "✅ Marketing Illustrations",
-            "folder": "src/colored"
+            "folder": "colored"
           },
           {
             "page": "✅ Error Resolution",
-            "folder": "src/colored"
+            "folder": "colored"
           },
           {
             "page": "✅ Technical Illustrations",
-            "folder": "src/colored"
+            "folder": "colored"
           },
           {
             "page": "✅ Multi-step Flows",
-            "folder": "src/colored"
+            "folder": "colored"
           },
           {
             "page": "✅ Empty States",
-            "folder": "src/colored"
+            "folder": "colored"
           },
           {
             "page": "✅ Hero States",
-            "folder": "src/colored"
+            "folder": "colored"
           },
           {
             "page": "✅ People",
-            "folder": "src/colored"
+            "folder": "colored"
           }
         ],
         "exclude": {
@@ -148,7 +148,7 @@
           "prTitle": "fix: Automated Illustrations Export 2023-07-07T21:07:54.936Z",
           "prCommitMsg": "feat(assets/illustrations): Export 2023-07-07T21:07:54.936Z",
           "prMessage": "feat(assets/illustrations): Export 2023-07-07T21:07:54.936Z",
-          "gitRepoFilePath": "packages/assets/illustrations"
+          "gitRepoFilePath": "packages/assets/illustrations/src"
         }
       }
     },


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- Updated Figma Plugin Assets Exports Settings to match new folder structure
