### PR TITLE
-: support for setting styles on wrapper container

### DIFF
--- a/packages/components/config/playwright/setup/utils/Stickersheet.ts
+++ b/packages/components/config/playwright/setup/utils/Stickersheet.ts
@@ -2,6 +2,10 @@
 import type { ComponentsPage } from '..';
 
 type AttributesType = Record<string, any>;
+type OptionsType = {
+  createNewRow?: boolean;
+  style?: string;
+}
 
 class StickerSheet {
   private componentPage: ComponentsPage;
@@ -79,9 +83,9 @@ class StickerSheet {
   /**
    * Creates a new row wrapper in the component sheet and appends the children to it.
    */
-  private createComponentsMarkupHTML(childrenEl?: string, createNewRow = false) {
-    if (createNewRow) {
-      this.markupHTML += `<div class="componentRowWrapper">${childrenEl}</div>`;
+  private createComponentsMarkupHTML(childrenEl: string, options: OptionsType) {
+    if (options.createNewRow) {
+      this.markupHTML += `<div class="componentRowWrapper" style='${options.style}'>${childrenEl}</div>`;
     } else {
       this.markupHTML += childrenEl;
     }
@@ -105,22 +109,32 @@ class StickerSheet {
    * Creates a wrapper for a combination of components and adds them to the sheet.
    * @param combinationArr - An array of objects representing combinations of attributes for components.
    */
-  private createWrapperForCombination(combinationArr: Array<Record<string, any>>) {
+  private createWrapperForCombination(combinationArr: Array<Record<string, any>>, wrapperStyles = '') {
     let childrenEl = '';
     for (const combination of combinationArr) {
       if (Array.isArray(combination)) {
-        this.createWrapperForCombination(combination);
+        this.createWrapperForCombination(combination, wrapperStyles);
       } else {
         this.setAttributes({ ...this.attributes, ...combination });
         childrenEl += this.addComponentToSheet();
       }
     }
-    this.createComponentsMarkupHTML(childrenEl, true);
+    this.createComponentsMarkupHTML(childrenEl, { createNewRow: true, style: wrapperStyles });
   }
 
-  public async createMarkupWithCombination(combinations: Record<string, Record<string, any>>, createNewRow = false) {
+  /**
+   *
+   * @param combinations - An object containing combinations of attributes for creating sticker sheet combination.
+   * @param options - An object containing options for creating the wrapper.
+   * - createNewRow - A boolean indicating whether to create a new row for the combination. Default is false.
+   * - style - A string representing the style to apply to the wrapper. Default is an empty string.
+   */
+  public async createMarkupWithCombination(combinations: Record<string, Record<string, any>>, options: OptionsType = {
+    createNewRow: false,
+    style: '',
+  }) {
     if (Object.keys(combinations).length === 0) {
-      this.createComponentsMarkupHTML(this.addComponentToSheet());
+      this.createComponentsMarkupHTML(this.addComponentToSheet(), options);
       return;
     }
 
@@ -132,18 +146,18 @@ class StickerSheet {
     let childrenEl = '';
     for (const combination of allCombinations) {
       if (Array.isArray(combination)) {
-        this.createWrapperForCombination(combination);
-      } else if (createNewRow) {
+        this.createWrapperForCombination(combination, options.style);
+      } else if (options.createNewRow) {
         this.setAttributes({ ...this.attributes, ...combination });
-        this.createComponentsMarkupHTML(this.addComponentToSheet(), true);
+        this.createComponentsMarkupHTML(this.addComponentToSheet(), options);
       } else {
         this.setAttributes({ ...this.attributes, ...combination });
         childrenEl += this.addComponentToSheet();
       }
     }
 
-    if (!Array.isArray(allCombinations[0]) && !createNewRow) {
-      this.createComponentsMarkupHTML(childrenEl, true);
+    if (!Array.isArray(allCombinations[0]) && !options.createNewRow) {
+      this.createComponentsMarkupHTML(childrenEl, { createNewRow: true, style: options.style });
     }
   }
 

--- a/packages/components/src/components/checkbox/checkbox.e2e-test.ts
+++ b/packages/components/src/components/checkbox/checkbox.e2e-test.ts
@@ -45,63 +45,54 @@ test('mdc-checkbox', async ({ componentsPage }) => {
     const checkboxStickerSheet = new StickerSheet(componentsPage, 'mdc-checkbox');
     checkboxStickerSheet.setAttributes({
       'data-aria-label': 'This is aria label text',
-      style: 'margin: 0.25rem',
     });
-    await checkboxStickerSheet.createMarkupWithCombination({}, true);
+    await checkboxStickerSheet.createMarkupWithCombination({}, { createNewRow: true, style: 'margin: 0.25rem' });
     checkboxStickerSheet.setAttributes({
       label: 'I agree to the terms',
-      style: 'margin: 0.25rem',
     });
-    await checkboxStickerSheet.createMarkupWithCombination({}, true);
+    await checkboxStickerSheet.createMarkupWithCombination({}, { createNewRow: true, style: 'margin: 0.25rem' });
     checkboxStickerSheet.setAttributes({
       label: 'Selected Checkbox Label',
       checked: true,
-      style: 'margin: 0.25rem',
     });
-    await checkboxStickerSheet.createMarkupWithCombination({}, true);
+    await checkboxStickerSheet.createMarkupWithCombination({}, { createNewRow: true, style: 'margin: 0.25rem' });
     checkboxStickerSheet.setAttributes({
       label: 'Indeterminate Checkbox Label',
       indeterminate: true,
-      style: 'margin: 0.25rem',
     });
-    await checkboxStickerSheet.createMarkupWithCombination({}, true);
+    await checkboxStickerSheet.createMarkupWithCombination({}, { createNewRow: true, style: 'margin: 0.25rem' });
     checkboxStickerSheet.setAttributes({
       label: 'Selected Checkbox Label',
       'help-text': 'This is a help text',
       checked: true,
-      style: 'margin: 0.25rem',
     });
-    await checkboxStickerSheet.createMarkupWithCombination({}, true);
+    await checkboxStickerSheet.createMarkupWithCombination({}, { createNewRow: true, style: 'margin: 0.25rem' });
     checkboxStickerSheet.setAttributes({
       label: 'Indeterminate Checkbox Label',
       'help-text': 'This is a help text',
       indeterminate: true,
-      style: 'margin: 0.25rem',
     });
-    await checkboxStickerSheet.createMarkupWithCombination({}, true);
+    await checkboxStickerSheet.createMarkupWithCombination({}, { createNewRow: true, style: 'margin: 0.25rem' });
     checkboxStickerSheet.setAttributes({
       label: 'Disabled Checkbox Label',
       'help-text': 'This is a help text',
       disabled: true,
-      style: 'margin: 0.25rem',
     });
-    await checkboxStickerSheet.createMarkupWithCombination({}, true);
+    await checkboxStickerSheet.createMarkupWithCombination({}, { createNewRow: true, style: 'margin: 0.25rem' });
     checkboxStickerSheet.setAttributes({
       label: 'Disabled Selected Checkbox Label',
       'help-text': 'This is a help text',
       disabled: true,
       checked: true,
-      style: 'margin: 0.25rem',
     });
-    await checkboxStickerSheet.createMarkupWithCombination({}, true);
+    await checkboxStickerSheet.createMarkupWithCombination({}, { createNewRow: true, style: 'margin: 0.25rem' });
     checkboxStickerSheet.setAttributes({
       label: 'Disabled Indeterminate Checkbox Label',
       'help-text': 'This is a help text',
       disabled: true,
       indeterminate: true,
-      style: 'margin: 0.25rem',
     });
-    await checkboxStickerSheet.createMarkupWithCombination({}, true);
+    await checkboxStickerSheet.createMarkupWithCombination({}, { createNewRow: true, style: 'margin: 0.25rem' });
     await checkboxStickerSheet.mountStickerSheet();
 
     await test.step('matches screenshot of checkbox sizes stickersheet', async () => {

--- a/packages/components/src/components/formfieldwrapper/formfieldwrapper.e2e-test.ts
+++ b/packages/components/src/components/formfieldwrapper/formfieldwrapper.e2e-test.ts
@@ -82,7 +82,7 @@ test('mdc-subcomponent-formfieldwrapper', async ({ componentsPage }) => {
       label: 'Label',
       'help-text': 'Help Text',
     });
-    await wrapperStickerSheet.createMarkupWithCombination({ 'help-text-type': VALIDATION }, true);
+    await wrapperStickerSheet.createMarkupWithCombination({ 'help-text-type': VALIDATION }, { createNewRow: true });
     await wrapperStickerSheet.setAttributes({
       id: 'test-formfieldwrapper',
       label: 'Label',
@@ -93,11 +93,10 @@ test('mdc-subcomponent-formfieldwrapper', async ({ componentsPage }) => {
     await wrapperStickerSheet.mountStickerSheet();
     await wrapperStickerSheet.getWrapperContainer();
 
-    // FIXME: Snapshots will be updated on the E2E test PR. This is done to keep the current PR not cluttered.
-    // await test.step('matches screenshot of pill-button element', async () => {
-    //   await componentsPage.visualRegression.takeScreenshot('mdc-formfieldwrapper', {
-    //     element: wrapperStickerSheet.getWrapperContainer(),
-    //   });
-    // });
+    await test.step('matches screenshot of pill-button element', async () => {
+      await componentsPage.visualRegression.takeScreenshot('mdc-formfieldwrapper', {
+        element: wrapperStickerSheet.getWrapperContainer(),
+      });
+    });
   });
 });

--- a/packages/components/src/components/radio/radio.e2e-test.ts
+++ b/packages/components/src/components/radio/radio.e2e-test.ts
@@ -66,20 +66,20 @@ test('mdc-radio', async ({ componentsPage }) => {
       });
 
       // Radio btn with label
-      await radioStickerSheet.createMarkupWithCombination({}, true);
+      await radioStickerSheet.createMarkupWithCombination({}, { createNewRow: true });
       await radioStickerSheet.setAttributes({
         label: 'Standard Plan',
       });
 
       // Checked radio btn
-      await radioStickerSheet.createMarkupWithCombination({}, true);
+      await radioStickerSheet.createMarkupWithCombination({}, { createNewRow: true });
       await radioStickerSheet.setAttributes({
         label: 'Selected Radio Label',
         checked: true,
       });
 
       // Checked radio btn with help text
-      await radioStickerSheet.createMarkupWithCombination({}, true);
+      await radioStickerSheet.createMarkupWithCombination({}, { createNewRow: true });
       await radioStickerSheet.setAttributes({
         label: 'Selected Radio Label',
         'help-text': 'This is a help text',
@@ -87,7 +87,7 @@ test('mdc-radio', async ({ componentsPage }) => {
       });
 
       // Readonly radio btn
-      await radioStickerSheet.createMarkupWithCombination({}, true);
+      await radioStickerSheet.createMarkupWithCombination({}, { createNewRow: true });
       await radioStickerSheet.setAttributes({
         label: 'Read Only Radio Label',
         'help-text': 'This is a help text',
@@ -95,7 +95,7 @@ test('mdc-radio', async ({ componentsPage }) => {
       });
 
       // Readonly but checked radio btn
-      await radioStickerSheet.createMarkupWithCombination({}, true);
+      await radioStickerSheet.createMarkupWithCombination({}, { createNewRow: true });
       await radioStickerSheet.setAttributes({
         label: 'Read Only Radio Label',
         'help-text': 'This is a help text',
@@ -104,7 +104,7 @@ test('mdc-radio', async ({ componentsPage }) => {
       });
 
       // Disabled radio btn
-      await radioStickerSheet.createMarkupWithCombination({}, true);
+      await radioStickerSheet.createMarkupWithCombination({}, { createNewRow: true });
       await radioStickerSheet.setAttributes({
         label: 'Disabled Radio Label',
         'help-text': 'This is a help text',
@@ -112,14 +112,14 @@ test('mdc-radio', async ({ componentsPage }) => {
       });
 
       // Disabled but checked radio btn
-      await radioStickerSheet.createMarkupWithCombination({}, true);
+      await radioStickerSheet.createMarkupWithCombination({}, { createNewRow: true });
       await radioStickerSheet.setAttributes({
         label: 'Disabled Selected Radio Label',
         'help-text': 'This is a help text',
         disabled: true,
         checked: true,
       });
-      await radioStickerSheet.createMarkupWithCombination({}, true);
+      await radioStickerSheet.createMarkupWithCombination({}, { createNewRow: true });
       await radioStickerSheet.mountStickerSheet();
 
       await test.step('matches screenshot of radio stickersheet', async () => {

--- a/packages/components/src/components/text/text.e2e-test.ts
+++ b/packages/components/src/components/text/text.e2e-test.ts
@@ -71,12 +71,12 @@ test.describe('mdc-text', () => {
     const textStickerSheet = new StickerSheet(componentsPage, 'mdc-text');
     await test.step('add text component with different types to sheet', async () => {
       textStickerSheet.setChildren(textContent);
-      await textStickerSheet.createMarkupWithCombination({ type: TYPE }, true);
+      await textStickerSheet.createMarkupWithCombination({ type: TYPE }, { createNewRow: true });
     });
 
     await test.step('add text component with different tagnames to sheet', async () => {
       textStickerSheet.setAttributes({ type: DEFAULTS.TYPE });
-      await textStickerSheet.createMarkupWithCombination({ tagname: VALID_TEXT_TAGS }, true);
+      await textStickerSheet.createMarkupWithCombination({ tagname: VALID_TEXT_TAGS }, { createNewRow: true });
     });
 
     await textStickerSheet.mountStickerSheet();


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

Updated `createWrapperForCombination` function to support options as 2nd argument.
options = {
  createNewRow: false, // default value
  style: '', // passing styles as a string will be applied to componentRowWrapper div
}

### Links

https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-527
