### PR TITLE
fix: reflect spinner variant property and export types

### DIFF
--- a/packages/components/src/components/spinner/spinner.component.ts
+++ b/packages/components/src/components/spinner/spinner.component.ts
@@ -78,7 +78,7 @@ class Spinner extends Component {
   * icon or label text.
   * @default standalone
   */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   variant: SpinnerVariant = DEFAULTS.VARIANT;
 
   override updated(changedProperties: Map<string, any>) {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -22,6 +22,7 @@ import { inMemoryCache, webAPIIconsCache } from './utils/icon-cache';
 import Spinner from './components/spinner';
 
 import type { TextType } from './components/text/text.types';
+import type { SpinnerSize, SpinnerVariant } from './components/spinner/spinner.types';
 
 export {
   ThemeProvider,
@@ -49,6 +50,8 @@ export {
 
 export type {
   TextType,
+  SpinnerSize,
+  SpinnerVariant,
 };
 
 export { inMemoryCache, webAPIIconsCache };


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

When using the react component for ```spinner``` changing the variant was not reflected in the styling as it was not being reflected back to the associated attribute. This PR fixes that.

Also, export Spinner types to be used in MRV2.
