### PR TITLE
fix: iconprovider consume ts icons

### DIFF
--- a/packages/components/config/playwright/public/index.html
+++ b/packages/components/config/playwright/public/index.html
@@ -22,7 +22,7 @@
 <body class="mds-typography">
     <main>
         <mdc-themeprovider themeclass="mds-theme-stable-darkWebex">
-            <mdc-iconprovider icon-set="custom-icons" cache-strategy="js-cache" cache-name="momentum" url="/dist/icons/svg">
+            <mdc-iconprovider icon-set="custom-icons" cache-strategy="in-memory-cache" cache-name="momentum" url="/dist/icons/svg">
                 <div id="root">
                 </div>
             </mdc-iconprovider>

--- a/packages/components/config/playwright/public/index.html
+++ b/packages/components/config/playwright/public/index.html
@@ -22,7 +22,7 @@
 <body class="mds-typography">
     <main>
         <mdc-themeprovider themeclass="mds-theme-stable-darkWebex">
-            <mdc-iconprovider cache-strategy="js-cache" cache-name="momentum" url="/dist/icons/svg">
+            <mdc-iconprovider icon-set="custom-icons" cache-strategy="js-cache" cache-name="momentum" url="/dist/icons/svg">
                 <div id="root">
                 </div>
             </mdc-iconprovider>

--- a/packages/components/config/storybook/main.js
+++ b/packages/components/config/storybook/main.js
@@ -1,3 +1,5 @@
+import dynamicImport from 'vite-plugin-dynamic-import';
+
 const config = {
   stories: ['../../src/**/*.mdx', '../../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
   addons: [
@@ -6,7 +8,7 @@ const config = {
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',
     '@geometricpanda/storybook-addon-badges',
-    'storybook-addon-rtl'
+    'storybook-addon-rtl',
   ],
   framework: {
     name: '@storybook/web-components-vite',
@@ -14,6 +16,16 @@ const config = {
   },
   core: {
     disableTelemetry: true, // 👈 Disables telemetry
+  },
+  async viteFinal(config) {
+    // Merge custom configuration into the default config
+    const { mergeConfig } = await import('vite');
+
+    return mergeConfig(config, {
+      // adding dynamic import to support dynamic icon import
+      // in icon component
+      plugins: [dynamicImport({})],
+    });
   },
   docs: {
     autodocs: 'tag',

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -121,6 +121,7 @@
     "rimraf": "^6.0.1",
     "storybook": "^8.2.5",
     "storybook-addon-rtl": "^1.0.1",
-    "typescript": "^4.8.4"
+    "typescript": "^4.8.4",
+    "vite-plugin-dynamic-import": "^1.6.0"
   }
 }

--- a/packages/components/src/components/icon/icon.utils.ts
+++ b/packages/components/src/components/icon/icon.utils.ts
@@ -46,7 +46,7 @@ const fetchIcon = async (request: Request): Promise<Response> =>
  * @returns Response string from the fetch
  * @throws Error if the response is not ok
  */
-const dynamicSVGImport = async ({
+const svgFetch = async ({
   url,
   name,
   fileExtension,
@@ -100,4 +100,4 @@ const dynamicSVGImport = async ({
       }));
 };
 
-export { dynamicSVGImport };
+export { svgFetch };

--- a/packages/components/src/components/iconprovider/iconprovider.constants.ts
+++ b/packages/components/src/components/iconprovider/iconprovider.constants.ts
@@ -16,6 +16,7 @@ const DEFAULTS = {
   LENGTH_UNIT: 'em',
   SIZE: LENGTH_UNIT_SIZE.em,
   SHOULD_CACHE: false,
+  ICON_SET: 'momentum-icons',
 } as const;
 
 export { TAG_NAME, DEFAULTS, ALLOWED_FILE_EXTENSIONS, ALLOWED_LENGTH_UNITS, LENGTH_UNIT_SIZE };

--- a/packages/components/src/components/iconprovider/iconprovider.context.ts
+++ b/packages/components/src/components/iconprovider/iconprovider.context.ts
@@ -1,8 +1,11 @@
 import { createContext } from '@lit/context';
 
 import { TAG_NAME } from './iconprovider.constants';
+import type { IconSet, CacheStrategy } from './iconprovider.types';
 
 class IconProviderContext {
+  public iconSet?: IconSet;
+
   public fileExtension?: string;
 
   public url?: string;
@@ -13,7 +16,7 @@ class IconProviderContext {
 
   public cacheName?: string;
 
-  public cacheStrategy?: 'in-memory-cache' | 'web-cache-api';
+  public cacheStrategy?: CacheStrategy;
 
   // create typed lit context as part of the IconProviderContext
   public static readonly context = createContext<IconProviderContext>(TAG_NAME);

--- a/packages/components/src/components/iconprovider/iconprovider.e2e-test.ts
+++ b/packages/components/src/components/iconprovider/iconprovider.e2e-test.ts
@@ -15,6 +15,7 @@ const setup = async (args: SetupOptions) => {
   const { componentsPage, ...restArgs } = args;
   const renderIconProvider = (children: string = '') => `
     <mdc-iconprovider 
+      icon-set="custom-icons"
       url="${restArgs.url}" 
       id="local" 
       ${restArgs.fileExtension ? `file-extension="${restArgs.fileExtension}"` : ''}
@@ -31,6 +32,7 @@ const setup = async (args: SetupOptions) => {
     await componentsPage.mount({
       html: renderIconProvider(`
       <mdc-iconprovider 
+        icon-set="custom-icons"
         url="${restArgs.url}" 
         id="nested" 
         ${restArgs.fileExtension ? `file-extension="${restArgs.fileExtension}"` : ''}
@@ -90,6 +92,7 @@ const testToRun = async (componentsPage: ComponentsPage, type: string) => {
    */
   await test.step('attributes', async () => {
     await test.step('should have default attributes when no attributes are passed', async () => {
+      await expect(iconprovider).toHaveAttribute('icon-set', 'custom-icons');
       await expect(iconprovider).toHaveAttribute('url', url);
       await expect(iconprovider).toHaveAttribute('file-extension', DEFAULTS.FILE_EXTENSION);
       await expect(iconprovider).toHaveAttribute('length-unit', DEFAULTS.LENGTH_UNIT);
@@ -165,8 +168,10 @@ const testToRun = async (componentsPage: ComponentsPage, type: string) => {
     });
   });
 
+  // note: we are only able to test the caching feature with the custom icons,
+  // as the momentum-icons are not available in the test environment (would need separate build tooling for that)
   await test.step('caching', async () => {
-    await test.step('caching turned off', async () => {
+    await test.step('caching turned off (custom icons fetch)', async () => {
       if (type === 'standalone') {
         await componentsPage.setAttributes(iconprovider, {
           'file-extension': 'svg',

--- a/packages/components/src/components/iconprovider/iconprovider.stories.ts
+++ b/packages/components/src/components/iconprovider/iconprovider.stories.ts
@@ -8,6 +8,7 @@ import { hideControls } from '../../../config/storybook/utils';
 const render = (args: Args) => html`
 <mdc-iconprovider 
   url=${args.url}
+  icon-set=${args['icon-set']}
   file-extension=${args['file-extension']}
   cache-strategy=${args['cache-strategy']}
   cache-name=${args['cache-name']}
@@ -26,6 +27,10 @@ const meta: Meta = {
     badges: ['stable'],
   },
   argTypes: {
+    'icon-set': {
+      control: 'select',
+      options: ['momentum-icons', 'custom-icons'],
+    },
     'file-extension': {
       options: ALLOWED_FILE_EXTENSIONS,
       control: { type: 'radio' },
@@ -53,6 +58,7 @@ export default meta;
 
 export const Example: StoryObj = {
   args: {
+    'icon-set': 'momentum-icons',
     url: './icons/svg',
     'file-extension': 'svg',
     'length-unit': 'em',

--- a/packages/components/src/components/iconprovider/iconprovider.stories.utils.ts
+++ b/packages/components/src/components/iconprovider/iconprovider.stories.utils.ts
@@ -16,6 +16,7 @@ class SubComponentIconProvider extends Component {
 
   override render() {
     return html`
+      <p>Icon Set: ${this.iconProviderContext.value?.iconSet}</p>
       <p>URL: ${this.iconProviderContext.value?.url}</p>
       <p>File Extension: ${this.iconProviderContext.value?.fileExtension}</p>
       <p>Length Unit: ${this.iconProviderContext.value?.lengthUnit}</p>

--- a/packages/components/src/components/iconprovider/iconprovider.types.ts
+++ b/packages/components/src/components/iconprovider/iconprovider.types.ts
@@ -1,0 +1,4 @@
+type IconSet = 'momentum-icons' | 'custom-icons';
+type CacheStrategy = 'in-memory-cache' | 'web-cache-api';
+
+export type { IconSet, CacheStrategy };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2380,6 +2380,7 @@ __metadata:
     storybook-addon-rtl: ^1.0.1
     typescript: ^4.8.4
     uuid: ^11.0.5
+    vite-plugin-dynamic-import: ^1.6.0
   languageName: unknown
   linkType: soft
 
@@ -6924,6 +6925,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^1.5.4":
+  version: 1.6.0
+  resolution: "es-module-lexer@npm:1.6.0"
+  checksum: 4413a9aed9bf581de62b98174f3eea3f23ce2994fb6832df64bdd6504f6977da1a3b5ebd3c10f75e3c2f214dcf1a1d8b54be5e62c71b7110e6ccedbf975d2b7d
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:^1.0.0":
   version: 1.0.0
   resolution: "es-object-atoms@npm:1.0.0"
@@ -11061,6 +11069,15 @@ __metadata:
   dependencies:
     "@jridgewell/sourcemap-codec": ^1.5.0
   checksum: e041649453c9a3f31d2e731fc10e38604d50e20d3585cd48bc7713a6e2e1a3ad3012105929ca15750d59d0a3f1904405e4b95a23b7e69dc256db3c277a73a3ca
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.11":
+  version: 0.30.17
+  resolution: "magic-string@npm:0.30.17"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.5.0
+  checksum: f4b4ed17c5ada64f77fc98491847302ebad64894a905c417c943840c0384662118c9b37f9f68bb86add159fa4749ff6f118c4627d69a470121b46731f8debc6d
   languageName: node
   linkType: hard
 
@@ -16218,6 +16235,18 @@ __metadata:
     unist-util-stringify-position: ^3.0.0
     vfile-message: ^3.0.0
   checksum: 642cce703afc186dbe7cabf698dc954c70146e853491086f5da39e1ce850676fc96b169fcf7898aa3ff245e9313aeec40da93acd1e1fcc0c146dc4f6308b4ef9
+  languageName: node
+  linkType: hard
+
+"vite-plugin-dynamic-import@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "vite-plugin-dynamic-import@npm:1.6.0"
+  dependencies:
+    acorn: ^8.12.1
+    es-module-lexer: ^1.5.4
+    fast-glob: ^3.3.2
+    magic-string: ^0.30.11
+  checksum: 46b009c80db82a8ed935c6ec7c08a8d3d7e5d3118fbfb1b4e18f13e4e9c34db6b3f28fa697d7f78d3f36edae69479a0ba2dfae1b76d2b2ca8e3e06dcf1e9870c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- Allowing consumers to change the way icons are imported through the iconprovider. This allows to change the iconSet, by default when using `momentum-icons` Icons are going to be dynamically imported via JS. The already existing approach of fetching svgs from the backend is still available as before, without changes to that (and the provided caching options).
- The newly added dynamic js import requires changes in the consumers build tooling to allow for dynamic imports (there are plugins available for build tooling or built-in support).
