### PR TITLE
fix: react event passing

### DIFF
--- a/packages/components/config/plop/templates/add/component/{{componentName}}.component.ts.hbs
+++ b/packages/components/config/plop/templates/add/component/{{componentName}}.component.ts.hbs
@@ -9,6 +9,8 @@ import { Component } from '../../models';
  *
  * @slot default - This is a default/unnamed slot
  *
+ * @event click - (React: onClick) This event is a Click Event, update the description
+ *
  * @cssprop --custom-property-name - Description of the CSS custom property
  */
 class {{sentenceCase componentName}} extends Component {

--- a/packages/components/conventions/component-tsdoc.md
+++ b/packages/components/conventions/component-tsdoc.md
@@ -38,6 +38,7 @@ Usage: can be multiple
 ### @event
 
 Describes an event that can be emitted by the component, detailing the specific actions or occurrences that can trigger it.
+Make sure to specify how the event is passed in React - see existing components for the format.
 Usage: can be multiple
 
 ### @default

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -116,6 +116,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-lit": "^1.14.0",
     "fs-extra": "^11.2.0",
+    "pascalcase": "^2.0.0",
     "plop": "^4.0.1",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",

--- a/packages/components/src/components/avatarbutton/avatarbutton.component.ts
+++ b/packages/components/src/components/avatarbutton/avatarbutton.component.ts
@@ -18,6 +18,11 @@ import styles from './avatarbutton.styles';
  *
  * @dependency mdc-avatar
  *
+ * @event click - (React: onClick) This event is dispatched when the avatarbutton is clicked.
+ * @event keydown - (React: onKeyDown) This event is dispatched when a key is pressed down on the avatarbutton.
+ * @event keyup - (React: onKeyUp) This event is dispatched when a key is released on the avatarbutton.
+ * @event focus - (React: onFocus) This event is dispatched when the avatarbutton receives focus.
+ *
  * @tagname mdc-avatarbutton
  */
 class AvatarButton extends AvatarComponentMixin(IconNameMixin(Buttonsimple)) {

--- a/packages/components/src/components/button/button.component.ts
+++ b/packages/components/src/components/button/button.component.ts
@@ -12,9 +12,7 @@ import {
   PILL_BUTTON_SIZES,
 } from './button.constants';
 import styles from './button.styles';
-import type {
-  ButtonColor, ButtonTypeInternal, ButtonVariant, IconButtonSize, PillButtonSize,
-} from './button.types';
+import type { ButtonColor, ButtonTypeInternal, ButtonVariant, IconButtonSize, PillButtonSize } from './button.types';
 import { getIconNameWithoutStyle, getIconSize } from './button.utils';
 
 /**
@@ -44,6 +42,11 @@ import { getIconNameWithoutStyle, getIconSize } from './button.utils';
  * The type of button is inferred based on the presence of slot and/or prefix and postfix icons.
  *
  * @dependency mdc-icon
+ *
+ * @event click - (React: onClick) This event is dispatched when the button is clicked.
+ * @event keydown - (React: onKeyDown) This event is dispatched when a key is pressed down on the button.
+ * @event keyup - (React: onKeyUp) This event is dispatched when a key is released on the button.
+ * @event focus - (React: onFocus) This event is dispatched when the button receives focus.
  *
  * @tagname mdc-button
  *
@@ -184,8 +187,8 @@ class Button extends Buttonsimple {
   private setSize(size: PillButtonSize | IconButtonSize) {
     const isIconType = this.typeInternal === BUTTON_TYPE_INTERNAL.ICON;
     const isValidSize = isIconType
-      ? (Object.values(ICON_BUTTON_SIZES).includes(size)
-      && !(size === ICON_BUTTON_SIZES[20] && this.variant !== BUTTON_VARIANTS.TERTIARY))
+      ? Object.values(ICON_BUTTON_SIZES).includes(size)
+        && !(size === ICON_BUTTON_SIZES[20] && this.variant !== BUTTON_VARIANTS.TERTIARY)
       : Object.values(PILL_BUTTON_SIZES).includes(size as PillButtonSize);
 
     this.setAttribute('size', isValidSize ? `${size}` : `${DEFAULTS.SIZE}`);
@@ -226,21 +229,25 @@ class Button extends Buttonsimple {
 
   public override render() {
     return html`
-      ${this.prefixIcon ? html`
-        <mdc-icon
-          name="${this.prefixIcon as IconNames}" 
-          part="prefix-icon" 
-          size=${this.iconSize} 
-          length-unit="rem">
-        </mdc-icon>` : ''}
+      ${this.prefixIcon
+    ? html` <mdc-icon
+            name="${this.prefixIcon as IconNames}"
+            part="prefix-icon"
+            size=${this.iconSize}
+            length-unit="rem"
+          >
+          </mdc-icon>`
+    : ''}
       <slot @slotchange=${this.inferButtonType}></slot>
-      ${this.postfixIcon ? html`
-        <mdc-icon
-          name="${this.postfixIcon as IconNames}" 
-          part="postfix-icon" 
-          size=${this.iconSize} 
-          length-unit="rem">
-        </mdc-icon>` : ''}
+      ${this.postfixIcon
+    ? html` <mdc-icon
+            name="${this.postfixIcon as IconNames}"
+            part="postfix-icon"
+            size=${this.iconSize}
+            length-unit="rem"
+          >
+          </mdc-icon>`
+    : ''}
     `;
   }
 

--- a/packages/components/src/components/buttonsimple/buttonsimple.component.ts
+++ b/packages/components/src/components/buttonsimple/buttonsimple.component.ts
@@ -13,6 +13,11 @@ import type { ButtonSize, ButtonType } from './buttonsimple.types';
  * It is used as an internal component and is not intended to be used directly by consumers.
  * Consumers should use the `mdc-button` component instead.
  *
+ * @event click - (React: onClick) This event is dispatched when the button is clicked.
+ * @event keydown - (React: onKeyDown) This event is dispatched when a key is pressed down on the button.
+ * @event keyup - (React: onKeyUp) This event is dispatched when a key is released on the button.
+ * @event focus - (React: onFocus) This event is dispatched when the button receives focus.
+ *
  * @tagname mdc-buttonsimple
  */
 class Buttonsimple extends TabIndexMixin(DisabledMixin(Component)) {

--- a/packages/components/src/components/checkbox/checkbox.component.ts
+++ b/packages/components/src/components/checkbox/checkbox.component.ts
@@ -22,6 +22,9 @@ import styles from './checkbox.styles';
  *
  * @tagname mdc-checkbox
  *
+ * @event change - (React: onChange) Event that gets dispatched when the checkbox state changes.
+ * @event focus - (React: onFocus) Event that gets dispatched when the checkbox receives focus.
+ *
  * @cssproperty --mdc-checkbox-background-color-hover - Allows customization of the background color on hover.
  * @cssproperty --mdc-checkbox-border-color - Border color in high contrast.
  * @cssproperty --mdc-checkbox-checked-background-color - Background color for a selected checkbox.

--- a/packages/components/src/components/input/input.component.ts
+++ b/packages/components/src/components/input/input.component.ts
@@ -24,6 +24,11 @@ import { DataAriaLabelMixin } from '../../utils/mixins/DataAriaLabelMixin';
  *
  * @tagname mdc-input
  *
+ * @event input - (React: onInput) This event is dispatched when the value of the input field changes (every press).
+ * @event change - (React: onChange) This event is dispatched when the value of the input field changes (on blur).
+ * @event focus - (React: onFocus) This event is dispatched when the input receives focus.
+ * @event blur - (React: onBlur) This event is dispatched when the input loses focus.
+ *
  * @dependency mdc-icon
  * @dependency mdc-text
  * @dependency mdc-button

--- a/packages/components/src/components/radio/radio.component.ts
+++ b/packages/components/src/components/radio/radio.component.ts
@@ -17,6 +17,9 @@ import { DEFAULTS as FORMFIELD_DEFAULTS } from '../formfieldwrapper/formfieldwra
  *
  * @tagname mdc-radio
  *
+ * @event change - (React: onChange) Event that gets dispatched when the radio state changes.
+ * @event focus - (React: onFocus) Event that gets dispatched when the radio receives focus.
+ *
  * @cssproperty --mdc-radio-inner-circle-size - size of the inner circle
  * @cssproperty --mdc-radio-text-disabled-color - color of the label when disabled
  * @cssproperty --mdc-radio-disabled-border-color - color of the radio button border when disabled

--- a/packages/components/src/components/tab/tab.component.ts
+++ b/packages/components/src/components/tab/tab.component.ts
@@ -27,6 +27,11 @@ import { IconNameMixin } from '../../utils/mixins/IconNameMixin';
  * @dependency mdc-icon
  * @dependency mdc-text
  *
+ * @event click - (React: onClick) This event is dispatched when the tab is clicked.
+ * @event keydown - (React: onKeyDown) This event is dispatched when a key is pressed down on the tab.
+ * @event keyup - (React: onKeyUp) This event is dispatched when a key is released on the tab.
+ * @event focus - (React: onFocus) This event is dispatched when the tab receives focus.
+ *
  * @tagname mdc-tab
  *
  * @cssproperty --mdc-tab-content-gap - Gap between the badge(if provided), icon and text.

--- a/packages/components/src/components/toggle/toggle.component.ts
+++ b/packages/components/src/components/toggle/toggle.component.ts
@@ -25,6 +25,9 @@ import { DataAriaLabelMixin } from '../../utils/mixins/DataAriaLabelMixin';
  *
  * @tagname mdc-toggle
  *
+ * @event change - (React: onChange) Event that gets dispatched when the toggle state changes.
+ * @event focus - (React: onFocus) Event that gets dispatched when the toggle receives focus.
+ *
  * @cssproperty --mdc-toggle-width - width of the toggle
  * @cssproperty --mdc-toggle-height - height of the toggle
  * @cssproperty --mdc-toggle-width-compact - width of the toggle when it's size is compact

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
@@ -19,6 +19,8 @@ import { SetListDataProps, VirtualizerProps } from './virtualizedlist.types';
  *
  * @tagname mdc-virtualizedlist
  *
+ * @event onscroll - (React: onScroll) Event that gets called when user scrolls inside of list.
+ *
  * @slot - Client side List with nested list items.
  */
 class VirtualizedList extends Component {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2373,6 +2373,7 @@ __metadata:
     eslint-plugin-lit: ^1.14.0
     fs-extra: ^11.2.0
     lit: ^3.2.0
+    pascalcase: ^2.0.0
     plop: ^4.0.1
     prettier: ^3.3.3
     rimraf: ^6.0.1
@@ -5392,7 +5393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^6.2.0":
+"camelcase@npm:^6.2.0, camelcase@npm:^6.2.1":
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
   checksum: 8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
@@ -13007,6 +13008,15 @@ __metadata:
     no-case: ^3.0.4
     tslib: ^2.0.3
   checksum: ba98bfd595fc91ef3d30f4243b1aee2f6ec41c53b4546bfa3039487c367abaa182471dcfc830a1f9e1a0df00c14a370514fa2b3a1aacc68b15a460c31116873e
+  languageName: node
+  linkType: hard
+
+"pascalcase@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "pascalcase@npm:2.0.0"
+  dependencies:
+    camelcase: ^6.2.1
+  checksum: 8c91259ecee8c7bd7138021ca08fc09c52beecd994954fcd82fb25c788106ee5400cb76e551e13487b576c64148f00c771e07791e4b2ee9a6fe1b98279d31548
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- Extended the `makeReact` script to pass in the events from the CEM to the React component
- Updating the CEM (Custom Elements Manifest) Analyzer config to pass through the event from the TS Doc
- Updated all components to specify the most commonly used events for now on them to do the mapping.
