### PR TITLE
fix: multiple focus ring shown at once

### DIFF
--- a/packages/components/src/components/input/input.component.ts
+++ b/packages/components/src/components/input/input.component.ts
@@ -367,7 +367,7 @@ class Input extends DataAriaLabelMixin(ValueMixin(NameMixin(FormfieldWrapper))) 
       return html`
       <mdc-button 
         part='trailing-button'
-        class='not-focusable ${!this.value ? 'hidden' : ''}'
+        class='own-focus-ring ${!this.value ? 'hidden' : ''}'
         prefix-icon='${DEFAULTS.CLEAR_BUTTON_ICON}'
         variant='${DEFAULTS.CLEAR_BUTTON_VARIANT}'
         size="${DEFAULTS.CLEAR_BUTTON_SIZE}"
@@ -388,7 +388,7 @@ class Input extends DataAriaLabelMixin(ValueMixin(NameMixin(FormfieldWrapper))) 
         <slot name="input">
           <input 
             aria-label="${this.dataAriaLabel ?? ''}"
-            class='input focusable'
+            class='input'
             part='input'
             id="${this.id}"
             name="${this.name}"

--- a/packages/components/src/components/input/input.component.ts
+++ b/packages/components/src/components/input/input.component.ts
@@ -367,7 +367,7 @@ class Input extends DataAriaLabelMixin(ValueMixin(NameMixin(FormfieldWrapper))) 
       return html`
       <mdc-button 
         part='trailing-button'
-        class='${!this.value ? 'hidden' : ''}'
+        class='not-focusable ${!this.value ? 'hidden' : ''}'
         prefix-icon='${DEFAULTS.CLEAR_BUTTON_ICON}'
         variant='${DEFAULTS.CLEAR_BUTTON_VARIANT}'
         size="${DEFAULTS.CLEAR_BUTTON_SIZE}"
@@ -388,7 +388,7 @@ class Input extends DataAriaLabelMixin(ValueMixin(NameMixin(FormfieldWrapper))) 
         <slot name="input">
           <input 
             aria-label="${this.dataAriaLabel ?? ''}"
-            class='input'
+            class='input focusable'
             part='input'
             id="${this.id}"
             name="${this.name}"

--- a/packages/components/src/components/input/input.styles.ts
+++ b/packages/components/src/components/input/input.styles.ts
@@ -83,7 +83,7 @@ const styles = [css`
 
   .prefix-text{
     color: var(--mdc-input-support-text-color);
-    white-space: nowrap; // restirct prefix text to be in one line
+    white-space: nowrap; // restrict prefix text to be in one line
   }
 
   :host(:not([disabled])) .input-container:hover{
@@ -92,7 +92,7 @@ const styles = [css`
 
   :host(:not([disabled])) .input-container:active, :host(:not([disabled])) .input-container:focus-within{
     background-color: var(--mdc-input-focused-background-color);
-    border-color:  var(--mdc-input-focused-border-color);
+    border-color: var(--mdc-input-focused-border-color);
   }
 
   .input::placeholder{
@@ -116,6 +116,6 @@ const styles = [css`
     opacity: 0;
     pointer-events: none;
   }
-  `, ...hostFocusRingStyles(true)];
+`, ...hostFocusRingStyles(true)];
 
 export default styles;

--- a/packages/components/src/components/link/link.component.ts
+++ b/packages/components/src/components/link/link.component.ts
@@ -134,7 +134,11 @@ class Link extends DisabledMixin(IconNameMixin(Component)) {
   }
 
   public override render() {
-    return html`<slot @slotchange=${this.updateTrailingIcon}></slot>`;
+    return html`
+      <div part='link-container' class='mdc-focus-ring'>
+        <slot @slotchange=${this.updateTrailingIcon}></slot>
+      </div>
+    `;
   }
 
   public static override styles: Array<CSSResult> = [...Component.styles, ...styles];

--- a/packages/components/src/components/link/link.stories.ts
+++ b/packages/components/src/components/link/link.stories.ts
@@ -136,3 +136,11 @@ export const InlineLinkInverted: StoryObj = {
     ...readOnlyControls(['inline', 'inverted']),
   },
 };
+
+export const Test: StoryObj = {
+  render: () => html`
+ <p>This is a paragraph with inline <mdc-link inline icon-name='placeholder-bold'>
+    <a href="#">link</a>
+  </mdc-link></p>
+  `,
+};

--- a/packages/components/src/components/link/link.stories.ts
+++ b/packages/components/src/components/link/link.stories.ts
@@ -136,11 +136,3 @@ export const InlineLinkInverted: StoryObj = {
     ...readOnlyControls(['inline', 'inverted']),
   },
 };
-
-export const Test: StoryObj = {
-  render: () => html`
- <p>This is a paragraph with inline <mdc-link inline icon-name='placeholder-bold'>
-    <a href="#">link</a>
-  </mdc-link></p>
-  `,
-};

--- a/packages/components/src/components/link/link.styles.ts
+++ b/packages/components/src/components/link/link.styles.ts
@@ -16,7 +16,9 @@ const styles = [hostFitContentStyles, css`
     --mdc-link-inverted-color-hover: var(--mds-color-theme-inverted-text-accent-hover);
     --mdc-link-inverted-color-normal: var(--mds-color-theme-inverted-text-accent-normal);
     --mdc-link-text-decoration-disabled: underline;
+  }
 
+  :host::part(link-container){
     border-radius: var(--mdc-link-border-radius);
     color: var(--mdc-link-color-normal);
   }
@@ -32,11 +34,11 @@ const styles = [hostFitContentStyles, css`
     text-underline-position: from-font;
   }
 
-  :host(:hover) {
+  :host(:hover)::part(link-container) {
     color: var(--mdc-link-color-hover);
   }
 
-  :host(:active) {
+  :host(:active)::part(link-container) {
     color: var(--mdc-link-color-active);
   }
 
@@ -44,19 +46,19 @@ const styles = [hostFitContentStyles, css`
     display: inline-flex;
   }
 
-  :host([inverted]) {
+  :host([inverted])::part(link-container) {
     color: var(--mdc-link-inverted-color-normal);
   }
 
-  :host([inverted]:hover) {
+  :host([inverted]:hover)::part(link-container) {
     color: var(--mdc-link-inverted-color-hover);
   }
 
-  :host([inverted]:active) {
+  :host([inverted]:active)::part(link-container) {
     color: var(--mdc-link-inverted-color-active);
   }
 
-  :host([size="large"]) {
+  :host([size="large"])::part(link-container) {
     font-size: var(--mds-font-apps-body-large-regular-font-size);
     font-weight: var(--mds-font-apps-body-large-regular-font-weight);
     line-height: var(--mds-font-apps-body-large-regular-line-height);
@@ -64,7 +66,7 @@ const styles = [hostFitContentStyles, css`
     text-transform: var(--mds-font-apps-body-large-regular-text-case);
   }
 
-  :host([size="midsize"]) {
+  :host([size="midsize"])::part(link-container) {
     font-size: var(--mds-font-apps-body-midsize-regular-font-size);
     font-weight: var(--mds-font-apps-body-midsize-regular-font-weight);
     line-height: var(--mds-font-apps-body-midsize-regular-line-height);
@@ -72,7 +74,7 @@ const styles = [hostFitContentStyles, css`
     text-transform: var(--mds-font-apps-body-midsize-regular-text-case);
   }
 
-  :host([size="small"]) {
+  :host([size="small"])::part(link-container) {
     font-size: var(--mds-font-apps-body-small-regular-font-size);
     font-weight: var(--mds-font-apps-body-small-regular-font-weight);
     line-height: var(--mds-font-apps-body-small-regular-line-height);
@@ -104,17 +106,17 @@ const styles = [hostFitContentStyles, css`
     text-transform: var(--mds-font-apps-body-small-regular-underline-text-case);
   }
 
-  :host([disabled]) {
+  :host([disabled])::part(link-container) {
     color: var(--mdc-link-color-disabled);
     pointer-events: none;
   }
 
-  :host([inverted][disabled]) {
+  :host([inverted][disabled])::part(link-container) {
     color: var(--mdc-link-inverted-color-disabled);
   }
-`, ...hostFocusRingStyles(),
+`, ...hostFocusRingStyles(true),
 css`
-  :host(:active) {
+  :host(:active)::part(link-container) {
     box-shadow: none;
   }
 `];

--- a/packages/components/src/components/link/link.styles.ts
+++ b/packages/components/src/components/link/link.styles.ts
@@ -82,7 +82,9 @@ const styles = [hostFitContentStyles, css`
     text-transform: var(--mds-font-apps-body-small-regular-text-case);
   }
 
-  :host([size="large"]:hover), :host([size="large"]:active), :host([size="large"][inline]) {
+  :host([size="large"]:hover)::part(link-container),
+  :host([size="large"]:active)::part(link-container),
+  :host([size="large"][inline])::part(link-container) {
     font-size: var(--mds-font-apps-body-large-regular-underline-font-size);
     font-weight: var(--mds-font-apps-body-large-regular-underline-font-weight);
     line-height: var(--mds-font-apps-body-large-regular-underline-line-height);
@@ -90,7 +92,9 @@ const styles = [hostFitContentStyles, css`
     text-transform: var(--mds-font-apps-body-large-regular-underline-text-case);
   }
 
-  :host([size="midsize"]:hover), :host([size="midsize"]:active), :host([size="midsize"][inline]) {
+  :host([size="midsize"]:hover)::part(link-container),
+  :host([size="midsize"]:active)::part(link-container),
+  :host([size="midsize"][inline])::part(link-container) {
     font-size: var(--mds-font-apps-body-midsize-regular-underline-font-size);
     font-weight: var(--mds-font-apps-body-midsize-regular-underline-font-weight);
     line-height: var(--mds-font-apps-body-midsize-regular-underline-line-height);
@@ -98,7 +102,9 @@ const styles = [hostFitContentStyles, css`
     text-transform: var(--mds-font-apps-body-midsize-regular-underline-text-case);
   }
 
-  :host([size="small"]:hover), :host([size="small"]:active), :host([size="small"][inline]) {
+  :host([size="small"]:hover)::part(link-container),
+  :host([size="small"]:active)::part(link-container),
+  :host([size="small"][inline])::part(link-container) {
     font-size: var(--mds-font-apps-body-small-regular-underline-font-size);
     font-weight: var(--mds-font-apps-body-small-regular-underline-font-weight);
     line-height: var(--mds-font-apps-body-small-regular-underline-line-height);

--- a/packages/components/src/utils/styles/index.ts
+++ b/packages/components/src/utils/styles/index.ts
@@ -36,12 +36,19 @@ const hostFocusRingStyles = (applyFocusRingOnClass = false) => {
         .mdc-focus-ring:focus-visible {
           outline: none;
         }
-        :host([disabled]) .mdc-focus-ring:focus {
+
+        /* Only show focus ring on container when child element is focused */
+        .mdc-focus-ring:has(.focusable:focus-visible) {
+          box-shadow: ${boxShadow};
+        }
+
+        /* Remove focus ring from container when other focusable elements are focused */
+        .mdc-focus-ring:has(.not-focusable:focus-visible) {
           box-shadow: none;
         }
-        .mdc-focus-ring:focus-within {
-          position: relative;
-          box-shadow: ${boxShadow};
+
+        :host([disabled]) .mdc-focus-ring:focus {
+          box-shadow: none;
         }
         /* High Contrast Mode */
         @media (forced-colors: active) {

--- a/packages/components/src/utils/styles/index.ts
+++ b/packages/components/src/utils/styles/index.ts
@@ -68,13 +68,13 @@ const hostFocusRingStyles = (applyFocusRingOnClass = false) => {
       :host([disabled]:focus) {
         box-shadow: none;
       }
-      :host(:focus), :host(:focus-within) {
+      :host(:focus) {
         position: relative;
         box-shadow: ${boxShadow};
       }
       /* High Contrast Mode */
       @media (forced-colors: active) {
-        :host(:focus), :host(:focus-within) {
+        :host(:focus) {
           outline: 0.125rem solid var(--mds-color-theme-focus-default-0);
         }
       }

--- a/packages/components/src/utils/styles/index.ts
+++ b/packages/components/src/utils/styles/index.ts
@@ -36,20 +36,20 @@ const hostFocusRingStyles = (applyFocusRingOnClass = false) => {
         .mdc-focus-ring:focus-visible {
           outline: none;
         }
-
-        /* Only show focus ring on container when child element is focused */
-        .mdc-focus-ring:has(.focusable:focus-visible) {
-          box-shadow: ${boxShadow};
-        }
-
-        /* Remove focus ring from container when other focusable elements are focused */
-        .mdc-focus-ring:has(.not-focusable:focus-visible) {
-          box-shadow: none;
-        }
-
         :host([disabled]) .mdc-focus-ring:focus {
           box-shadow: none;
         }
+        /* Add focus ring to parent when child is focused. The parent element must have class name mdc-focus-ring */
+        .mdc-focus-ring:focus-within {
+          position: relative;
+          box-shadow: ${boxShadow};
+        }
+        /* Remove focus ring from parent when children has its own focus ring.
+            The child element must have class name own-focus-ring */
+        .mdc-focus-ring:has(.own-focus-ring:focus-visible){
+          box-shadow: none;
+        }
+
         /* High Contrast Mode */
         @media (forced-colors: active) {
           .mdc-focus-ring:focus-within {


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

Fixing the issue of having multiple focus rings at once.
* If you are using focus ring on the host, there is no need to make any change. It will work as expected.
* If you are using 'mdc-focus-ring' class to apply the focus ring, then make sure to add 'own-focus-ring' on child elements that has its own focus ring. Refer to input.components.ts for understanding this use-case.

### Links

https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-554