### PR TITLE
chore: added brand visuals ts logos

### DIFF
--- a/packages/assets/brand-visuals/config/momentum.json
+++ b/packages/assets/brand-visuals/config/momentum.json
@@ -6,7 +6,7 @@
         {
           "id": "optimise-svgs-logos",
           "target": "./src/logos/*.svg",
-          "destination": "./dist/logos",
+          "destination": "./dist/logos/svg",
           "fileNameReplacePatterns": [
             {
               "searchValue": "_",
@@ -131,6 +131,18 @@
               "hbsPath": "./config/templates/types.d.ts.hbs",
               "name": "BrandVisualNames",
               "manifestPath": "../manifest.json"
+            }
+          }
+        },
+        { 
+          "id": "lit-brand-visuals",
+          "target": "./dist/logos/svg/**/*.*",
+          "destination": "./dist/logos/ts",
+          "format": {
+            "type": "LIT",
+            "config": {
+              "partName": "brandvisual",
+              "hbsPath": "./config/templates/lit.ts.hbs"
             }
           }
         }

--- a/packages/assets/brand-visuals/config/templates/lit.ts.hbs
+++ b/packages/assets/brand-visuals/config/templates/lit.ts.hbs
@@ -1,0 +1,6 @@
+import { html } from 'lit';
+
+const icon = () =>
+  html`{{{svgData}}}`;
+
+export default icon;

--- a/packages/assets/icons/config/momentum.json
+++ b/packages/assets/icons/config/momentum.json
@@ -297,6 +297,7 @@
           "format": {
             "type": "LIT",
             "config": {
+              "partName": "icon",
               "hbsPath": "./config/templates/lit.ts.hbs"
             }
           }

--- a/packages/tools/builder/src/assets/builder/transformer/lit-transformer.ts
+++ b/packages/tools/builder/src/assets/builder/transformer/lit-transformer.ts
@@ -20,13 +20,13 @@ class LitTransformer extends Transformer {
    * @param name - name of the svg
    * @returns modified svg string
    */
-  public addAttributesToSvg(svg: string, name: string): string {
+  public addAttributesToSvg(svg: string, name: string, partName: string = 'element'): string {
     // Important: all the added attributes are important and cause issues if modified.
     // part="icon" is required for the icon to be styled
     // (if modified icon component will not be styled correctly)
     // aria-hidden="true" is required for accessibility
     // data-name is used to identify the svg in tests etc
-    return svg.replace('<svg', `<svg aria-hidden="true" part="icon" data-name="${name}"`);
+    return svg.replace('<svg', `<svg aria-hidden="true" part="${partName}" data-name="${name}"`);
   }
 
   /**
@@ -45,7 +45,7 @@ class LitTransformer extends Transformer {
         ...file,
         distPath: path.join(this.destination, `${fileName}.ts`),
         data: template({
-          svgData: this.addAttributesToSvg(file.data, fileName),
+          svgData: this.addAttributesToSvg(file.data, fileName, this.format.config.partName),
         }),
       }))
       .catch((error) => {

--- a/packages/tools/builder/src/assets/builder/transformer/lit-transformer.unit.test.ts
+++ b/packages/tools/builder/src/assets/builder/transformer/lit-transformer.unit.test.ts
@@ -5,7 +5,7 @@ import * as Utils from '../utils';
 
 describe('@momentum-design/builder - Lit Transformer', () => {
   let transformer: LitTransformer;
-  const FORMAT: Formats = { config: { hbsPath: '' }, type: 'LIT' } as LitFormat;
+  const FORMAT: Formats = { config: { hbsPath: '', partName: 'icon' }, type: 'LIT' } as LitFormat;
 
   beforeEach(() => {
     transformer = new LitTransformer(FORMAT, '/dist');
@@ -28,8 +28,8 @@ describe('@momentum-design/builder - Lit Transformer', () => {
     it('should add attributes to the svg string', () => {
       const svg = '<svg></svg>';
       const name = 'test';
-      const result = transformer.addAttributesToSvg(svg, name);
-      expect(result).toBe('<svg aria-hidden="true" part="icon" data-name="test"></svg>');
+      const result = transformer.addAttributesToSvg(svg, name, 'test-part-name');
+      expect(result).toBe('<svg aria-hidden="true" part="test-part-name" data-name="test"></svg>');
     });
   });
 

--- a/packages/tools/builder/src/assets/builder/types.ts
+++ b/packages/tools/builder/src/assets/builder/types.ts
@@ -110,7 +110,7 @@ export interface SvgGlyphsFormat {
 
 export interface LitFormat {
   type: typeof CONSTANTS.FORMATS.LIT;
-  config: { hbsPath: string };
+  config: { hbsPath: string, partName: string };
 }
 
 /**


### PR DESCRIPTION
### Description

- Enable builder config to export Brand Visuals as Typescript Lit Template files
- Enhanced builder tooling to support passing partName to lit transformer
- Added unit testing

**NOTE:** Brand Visual Logos are now in separate `svg` & `ts` folders, this PR might break your import of logos - when upgrading to this version, make sure to check your import paths.
