### PR TITLE
fix: fixing popover cannot find trigger in shadow dom

### DIFF
--- a/packages/components/src/components/popover/popover.component.ts
+++ b/packages/components/src/components/popover/popover.component.ts
@@ -293,7 +293,7 @@ class Popover extends FocusTrapMixin(Component) {
   private setupTriggerListener() {
     if (!this.triggerID) return;
 
-    this.triggerElement = document.getElementById(this.triggerID);
+    this.triggerElement = (this.getRootNode() as Document | ShadowRoot).querySelector(`#${this.triggerID}`);
     if (!this.triggerElement) return;
 
     if (this.trigger === 'mouseenter') {


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

Fix popover cannot find the trigger element in shadow dom.

