### PR TITLE
feat(popover): add disable-aria-expanded attribute

### DIFF
--- a/packages/components/src/components/popover/popover.component.ts
+++ b/packages/components/src/components/popover/popover.component.ts
@@ -237,6 +237,13 @@ class Popover extends FocusTrapMixin(Component) {
   @property({ type: String, reflect: true, attribute: 'aria-describedby' })
   ariaDescribedby: string | null = null;
 
+  /**
+   * Disable aria-expanded attribute on trigger element.
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'disable-aria-expanded' })
+  disableAriaExpanded: boolean = DEFAULTS.DISABLE_ARIA_EXPANDED;
+
   public arrowElement: HTMLElement | null = null;
 
   /** @internal */
@@ -473,7 +480,9 @@ class Popover extends FocusTrapMixin(Component) {
         document.addEventListener('keydown', this.onEscapeKeydown);
       }
 
-      this.triggerElement.setAttribute('aria-expanded', 'true');
+      if (!this.disableAriaExpanded) {
+        this.triggerElement.setAttribute('aria-expanded', 'true');
+      }
       if (this.interactive) {
         this.triggerElement.setAttribute(
           'aria-haspopup',
@@ -502,7 +511,9 @@ class Popover extends FocusTrapMixin(Component) {
       }
 
       this.deactivateFocusTrap?.();
-      this.triggerElement.removeAttribute('aria-expanded');
+      if (!this.disableAriaExpanded) {
+        this.triggerElement.removeAttribute('aria-expanded');
+      }
       if (this.interactive) {
         this.triggerElement.removeAttribute('aria-haspopup');
       }

--- a/packages/components/src/components/popover/popover.constants.ts
+++ b/packages/components/src/components/popover/popover.constants.ts
@@ -50,6 +50,7 @@ const DEFAULTS = {
   DELAY: '0,0',
   ROLE: 'dialog',
   Z_INDEX: 1000,
+  DISABLE_ARIA_EXPANDED: false,
 } as const;
 
 export { TAG_NAME, POPOVER_PLACEMENT, COLOR, TRIGGER, DEFAULTS };

--- a/packages/components/src/components/popover/popover.stories.ts
+++ b/packages/components/src/components/popover/popover.stories.ts
@@ -34,6 +34,7 @@ const createPopover = (args: Args, content: TemplateResult) => html`
     aria-labelledby="${args['aria-labelledby']}"
     aria-describedby="${args['aria-describedby']}"
     role="${args.role}"
+    ?disable-aria-expanded="${args['disable-aria-expanded']}"
     @popover-on-show="${action('onshow')}"
     @popover-on-hide="${action('onhide')}"
     @popover-on-created="${action('oncreated')}"
@@ -279,6 +280,9 @@ const meta: Meta = {
     },
     role: {
       control: 'text',
+    },
+    'disable-aria-expanded': {
+      control: 'boolean',
     },
     ...disableControls([
       '--mdc-popover-arrow-border-radius',


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- add a "disable-aria-expanded" attribute to the popover component
  - will be used by coachmark and tooltip
  - default is false, so we don't affect the normal behaviour for popover

popover is sitll wip and does not have e2e tests yet, so none have been added for this change

### Links

_Please replace this line with relevant links to the changes made in this Pull Request._
