### PR TITLE
fix(popover): stop isOpenUpdated from running on initial render

### DIFF
--- a/packages/components/src/components/popover/popover.component.ts
+++ b/packages/components/src/components/popover/popover.component.ts
@@ -447,7 +447,7 @@ class Popover extends FocusTrapMixin(Component) {
    * @param newValue - The new value of the visible property.
    */
   private async isOpenUpdated(oldValue: boolean, newValue: boolean) {
-    if (oldValue === newValue || !this.triggerElement) {
+    if ((oldValue || false) === newValue || !this.triggerElement) {
       return;
     }
 

--- a/packages/components/src/components/popover/popover.component.ts
+++ b/packages/components/src/components/popover/popover.component.ts
@@ -357,7 +357,7 @@ class Popover extends FocusTrapMixin(Component) {
     super.updated(changedProperties);
 
     if (changedProperties.has('visible')) {
-      const oldValue = changedProperties.get('visible') as boolean;
+      const oldValue = (changedProperties.get('visible') as boolean | undefined) || false;
       await this.isOpenUpdated(oldValue, this.visible);
     }
     if (changedProperties.has('placement')) {
@@ -447,7 +447,7 @@ class Popover extends FocusTrapMixin(Component) {
    * @param newValue - The new value of the visible property.
    */
   private async isOpenUpdated(oldValue: boolean, newValue: boolean) {
-    if ((oldValue || false) === newValue || !this.triggerElement) {
+    if (oldValue === newValue || !this.triggerElement) {
       return;
     }
 


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

fix bug where onHide events were firing on initial render by updating `isOpenUpdated` logic


