### PR TITLE
fix: storybook sort example top

### DIFF
--- a/packages/components/config/storybook/main.js
+++ b/packages/components/config/storybook/main.js
@@ -5,7 +5,11 @@ configureSort({
   storyOrder: {
     consumption: null,
     styling: null,
-    components: null,
+    components: {
+      '**': {
+        example: null,
+      },
+    },
     'work in progress': null,
     '**': { default: null },
   },

--- a/packages/components/config/storybook/main.js
+++ b/packages/components/config/storybook/main.js
@@ -10,7 +10,11 @@ configureSort({
         example: null,
       },
     },
-    'work in progress': null,
+    'work in progress': {
+      '**': {
+        example: null,
+      },
+    },
     '**': { default: null },
   },
 });


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- Making sure "Example" stories are always appear on top in storybook
- No change to any component, just a fix for storybook
