### PR TITLE
fix: export button types constants

### DIFF
--- a/packages/components/config/plop/actions/AddToComponentExports.ts
+++ b/packages/components/config/plop/actions/AddToComponentExports.ts
@@ -8,7 +8,7 @@ export const AddToComponentExports: ActionType = {
   path: `${path.posix.join(`${folders.src}`, 'index.ts')}`,
   // find the first export block, requires the index.ts file to be formatted
   // correctly
-  pattern: /(};)/,
+  pattern: /(};\n\n\/\/ Types Exports)/,
   data: {
     componentName,
   },

--- a/packages/components/config/plop/actions/AddToComponentImports.ts
+++ b/packages/components/config/plop/actions/AddToComponentImports.ts
@@ -8,7 +8,7 @@ export const AddToComponentImports: ActionType = {
   path: `${path.posix.join(`${folders.src}`, 'index.ts')}`,
   // find the first type import block, requires the index.ts file to be formatted
   // correctly
-  pattern: /(\nimport type)/,
+  pattern: /(\n\/\/ Types Imports)/,
   data: {
     componentName,
   },

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,4 @@
+// Components Imports
 import AlertChip from './components/alertchip';
 import Avatar from './components/avatar';
 import AvatarButton from './components/avatarbutton';
@@ -29,17 +30,28 @@ import ThemeProvider from './components/themeprovider';
 import Toggle from './components/toggle';
 import Tooltip from './components/tooltip';
 import VirtualizedList from './components/virtualizedlist';
-import { inMemoryCache, webAPIIconsCache } from './utils/icon-cache';
 import Progressbar from './components/progressbar';
 import Option from './components/option';
 import OptGroup from './components/optgroup';
 import Textarea from './components/textarea';
 
+// Types Imports
 import type { SpinnerSize, SpinnerVariant } from './components/spinner/spinner.types';
 import type { TextType } from './components/text/text.types';
 import type { PopoverPlacement } from './components/popover/popover.types';
 import type { BadgeType } from './components/badge/badge.types';
+import type { IconButtonSize, PillButtonSize, ButtonVariant, ButtonColor } from './components/button/button.types';
 
+// Constants / Utils Imports
+import {
+  BUTTON_COLORS,
+  BUTTON_VARIANTS,
+  ICON_BUTTON_SIZES,
+  PILL_BUTTON_SIZES,
+} from './components/button/button.constants';
+import { inMemoryCache, webAPIIconsCache } from './utils/icon-cache';
+
+// Components Exports
 export {
   AlertChip,
   Avatar,
@@ -77,11 +89,19 @@ export {
   Textarea,
   Tooltip,
 };
+
+// Types Exports
 export type {
   TextType,
   SpinnerSize,
   SpinnerVariant,
   PopoverPlacement,
   BadgeType,
+  IconButtonSize,
+  PillButtonSize,
+  ButtonVariant,
+  ButtonColor,
 };
-export { inMemoryCache, webAPIIconsCache };
+
+// Constants / Utils Exports
+export { inMemoryCache, webAPIIconsCache, BUTTON_COLORS, BUTTON_VARIANTS, ICON_BUTTON_SIZES, PILL_BUTTON_SIZES };


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- Export types and constants of Button
- Refactored index.ts file to have a better structure to identify where exports / imports should go
- Adjusted plop script to work with new index.ts file structure
