### PR TITLE
fix: removed tooltip show arrow override

### DIFF
--- a/packages/components/src/components/tooltip/tooltip.component.ts
+++ b/packages/components/src/components/tooltip/tooltip.component.ts
@@ -52,7 +52,6 @@ class Tooltip extends Popover {
     this.offset = DEFAULTS.OFFSET;
     this.placement = DEFAULTS.PLACEMENT;
     this.role = 'tooltip';
-    this.showArrow = true;
     this.trigger = 'mouseenter focusin';
 
     this.enabledFocusTrap = false;

--- a/packages/components/src/components/tooltip/tooltip.e2e-test.ts
+++ b/packages/components/src/components/tooltip/tooltip.e2e-test.ts
@@ -78,7 +78,7 @@ const attributeTestCases = async (componentsPage: ComponentsPage) => {
     await expect(tooltip).toHaveAttribute('offset', '4');
     await expect(tooltip).toHaveAttribute('placement', 'top');
     await expect(tooltip).toHaveAttribute('role', 'tooltip');
-    await expect(tooltip).toHaveAttribute('show-arrow');
+    await expect(tooltip).not.toHaveAttribute('show-arrow');
     await expect(tooltip).toHaveAttribute('trigger', 'mouseenter focusin');
     await expect(tooltip).toHaveAttribute('tooltip-type', 'description');
 


### PR DESCRIPTION
### Description
 Pr:
   Removed show arrow override from tooltip to respect the consumer intent, whether consumer wants it or not.
   
   Link
   [Ticket](https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-627)