### PR TITLE
fix: several button & tab fixes

### DIFF
--- a/packages/components/src/components/button/button.component.ts
+++ b/packages/components/src/components/button/button.component.ts
@@ -52,13 +52,13 @@ class Button extends Buttonsimple {
    * The name of the icon to display as a prefix.
    * The icon is displayed on the left side of the button.
    */
-  @property({ type: String, attribute: 'prefix-icon', reflect: true }) prefixIcon?: string;
+  @property({ type: String, attribute: 'prefix-icon', reflect: true }) prefixIcon?: IconNames;
 
   /**
    * The name of the icon to display as a postfix.
    * The icon is displayed on the right side of the button.
    */
-  @property({ type: String, attribute: 'postfix-icon', reflect: true }) postfixIcon?: string;
+  @property({ type: String, attribute: 'postfix-icon', reflect: true }) postfixIcon?: IconNames;
 
   /**
    * There are 3 variants of button: primary, secondary, tertiary. They are styled differently.
@@ -99,12 +99,12 @@ class Button extends Buttonsimple {
   /**
    * @internal
    */
-  private prevPrefixIcon?: string;
+  private prevPrefixIcon?: IconNames;
 
   /**
    * @internal
    */
-  private prevPostfixIcon?: string;
+  private prevPostfixIcon?: IconNames;
 
   public override update(changedProperties: PropertyValues): void {
     super.update(changedProperties);
@@ -138,15 +138,15 @@ class Button extends Buttonsimple {
    *
    * @param active - The active state.
    */
-  private modifyIconName(active: boolean) {
+  private modifyIconName(active?: boolean) {
     if (active) {
       if (this.prefixIcon) {
         this.prevPrefixIcon = this.prefixIcon;
-        this.prefixIcon = `${getIconNameWithoutStyle(this.prefixIcon)}-filled`;
+        this.prefixIcon = `${getIconNameWithoutStyle(this.prefixIcon)}-filled` as IconNames;
       }
       if (this.postfixIcon) {
         this.prevPostfixIcon = this.postfixIcon;
-        this.postfixIcon = `${getIconNameWithoutStyle(this.postfixIcon)}-filled`;
+        this.postfixIcon = `${getIconNameWithoutStyle(this.postfixIcon)}-filled` as IconNames;
       }
     } else {
       if (this.prevPrefixIcon) {
@@ -208,8 +208,7 @@ class Button extends Buttonsimple {
     const slot = this.shadowRoot
       ?.querySelector('slot')
       ?.assignedNodes()
-      .filter((node) => node.nodeType !== Node.TEXT_NODE || node.textContent?.trim())
-      .length;
+      .filter((node) => node.nodeType !== Node.TEXT_NODE || node.textContent?.trim()).length;
     if (slot && (this.prefixIcon || this.postfixIcon)) {
       this.typeInternal = BUTTON_TYPE_INTERNAL.PILL_WITH_ICON;
       this.setAttribute('data-btn-type', 'pill-with-icon');
@@ -224,22 +223,10 @@ class Button extends Buttonsimple {
 
   public override render() {
     return html`
-      ${this.prefixIcon
-    ? html` <mdc-icon
-            name="${this.prefixIcon as IconNames}"
-            part="prefix-icon"
-            length-unit="rem"
-          >
-          </mdc-icon>`
-    : ''}
+      ${this.prefixIcon ? html` <mdc-icon name="${this.prefixIcon as IconNames}" part="prefix-icon"></mdc-icon>` : ''}
       <slot @slotchange=${this.inferButtonType}></slot>
       ${this.postfixIcon
-    ? html` <mdc-icon
-            name="${this.postfixIcon as IconNames}"
-            part="postfix-icon"
-            length-unit="rem"
-          >
-          </mdc-icon>`
+    ? html` <mdc-icon name="${this.postfixIcon as IconNames}" part="postfix-icon"></mdc-icon>`
     : ''}
     `;
   }

--- a/packages/components/src/components/button/button.utils.ts
+++ b/packages/components/src/components/button/button.utils.ts
@@ -1,10 +1,12 @@
+import type { IconNames } from '../icon/icon.types';
+
 /**
  * Returns the name of the icon without the style suffix.
  *
  * @param iconName - The name of the icon.
  * @returns The name of the icon without the suffix.
  */
-const getIconNameWithoutStyle = (iconName: string): string => {
+const getIconNameWithoutStyle = (iconName: IconNames): string => {
   const iconParts = iconName.split('-');
   const variants = ['bold', 'filled', 'regular', 'light'];
   return iconParts.filter((part) => !variants.includes(part)).join('-');

--- a/packages/components/src/components/buttonsimple/buttonsimple.component.ts
+++ b/packages/components/src/components/buttonsimple/buttonsimple.component.ts
@@ -25,9 +25,12 @@ class Buttonsimple extends TabIndexMixin(DisabledMixin(Component)) {
    * The button's active state indicates whether it is currently toggled on (active) or off (inactive).
    * When the active state is true, the button is considered to be in an active state, meaning it is toggled on.
    * Conversely, when the active state is false, the button is in an inactive state, indicating it is toggled off.
-   * @default false
+   *
+   * This attribute is used to set the provided `ariaStateKey` to true or false.
+   * @default undefined
    */
-  @property({ type: Boolean, reflect: true }) active = false;
+  @property({ type: Boolean, reflect: true })
+  active?: boolean;
 
   /**
    * Indicates whether the button is soft disabled.
@@ -37,15 +40,17 @@ class Buttonsimple extends TabIndexMixin(DisabledMixin(Component)) {
    * **Important:** When using soft disabled, consumers must ensure that
    * the button behaves like a disabled button, allowing only focus and
    * preventing any interactions (clicks or keyboard actions) from triggering unintended actions.
-   * @default false
+   * @default undefined
    */
-  @property({ type: Boolean, attribute: 'soft-disabled' }) softDisabled = false;
+  @property({ type: Boolean, attribute: 'soft-disabled' })
+  softDisabled?: boolean;
 
   /**
    * Simplebutton size is a super set of all the sizes supported by children components.
    * @default 32
    */
-  @property({ type: Number, reflect: true }) size: ButtonSize = DEFAULTS.SIZE;
+  @property({ type: Number, reflect: true })
+  size: ButtonSize = DEFAULTS.SIZE;
 
   /**
    * This property defines the ARIA role for the element. By default, it is set to 'button'.
@@ -54,7 +59,23 @@ class Buttonsimple extends TabIndexMixin(DisabledMixin(Component)) {
    * - Custom behaviors are implemented that require a specific ARIA role for accessibility purposes.
    * @default button
    */
-  @property({ type: String, reflect: true }) override role = DEFAULTS.ROLE;
+  @property({ type: String, reflect: true })
+  override role = DEFAULTS.ROLE;
+
+  /**
+   * This property defines the ARIA state key, which will be toggled when the
+   * Button is set to `active`.
+   * The default value is 'aria-pressed', which is commonly used for toggle buttons.
+   *
+   * Consumers can override this property to use a different ARIA state key if needed.
+   * In case multiple aria attributes should be toggled, they can be passed in as
+   * a comma separated string.
+   * For example: `aria-pressed,aria-expanded`
+   *
+   * @default 'aria-pressed'
+   */
+  @property({ type: String, reflect: true })
+  ariaStateKey = DEFAULTS.ARIA_STATE_KEY;
 
   /**
    * This property defines the type attribute for the button element.
@@ -118,15 +139,26 @@ class Buttonsimple extends TabIndexMixin(DisabledMixin(Component)) {
   }
 
   /**
-   * Sets the aria-pressed attribute based on the active state of the button.
+   * Sets the ariaStateKey attributes based on the active state of the button.
    * @param element - The button element
    * @param active - The active state of the element
    */
-  protected setActive(element: HTMLElement, active: boolean) {
-    if (active) {
-      element.setAttribute('aria-pressed', 'true');
-    } else {
-      element.removeAttribute('aria-pressed');
+  protected setActive(element: HTMLElement, active?: boolean) {
+    if (this.ariaStateKey) {
+      const ariaStateKeys = this.ariaStateKey.split(',');
+
+      ariaStateKeys
+        .filter((key) => key.trim().startsWith('aria-'))
+        .forEach((key) => {
+          if (active === true) {
+            element.setAttribute(key.trim(), 'true');
+          } else if (active === false) {
+            element.setAttribute(key.trim(), 'false');
+          } else {
+            // If the active state is not a boolean, remove the attribute
+            element.removeAttribute(key.trim());
+          }
+        });
     }
   }
 
@@ -138,7 +170,7 @@ class Buttonsimple extends TabIndexMixin(DisabledMixin(Component)) {
    * @param element - The button element.
    * @param softDisabled - The soft-disabled state.
    */
-  private setSoftDisabled(element: HTMLElement, softDisabled: boolean) {
+  private setSoftDisabled(element: HTMLElement, softDisabled?: boolean) {
     if (softDisabled) {
       element.setAttribute('aria-disabled', 'true');
     } else {
@@ -225,9 +257,7 @@ class Buttonsimple extends TabIndexMixin(DisabledMixin(Component)) {
   }
 
   public override render() {
-    return html`
-      <slot></slot>
-    `;
+    return html` <slot></slot> `;
   }
 
   public static override styles: Array<CSSResult> = [...Component.styles, ...styles];

--- a/packages/components/src/components/buttonsimple/buttonsimple.constants.ts
+++ b/packages/components/src/components/buttonsimple/buttonsimple.constants.ts
@@ -26,6 +26,7 @@ const DEFAULTS = {
   SIZE: BUTTON_SIZES[32],
   TYPE: BUTTON_TYPE.BUTTON,
   ROLE: 'button',
+  ARIA_STATE_KEY: 'aria-pressed',
 };
 
 export {

--- a/packages/components/src/components/buttonsimple/buttonsimple.e2e-test.ts
+++ b/packages/components/src/components/buttonsimple/buttonsimple.e2e-test.ts
@@ -60,10 +60,10 @@ test('mdc-buttonsimple', async ({ componentsPage }) => {
   });
 
   /**
- * ATTRIBUTES
- */
+   * ATTRIBUTES
+   */
   await test.step('attributes', async () => {
-  // Disabled button
+    // Disabled button
     await test.step('attribute disabled should be present on button', async () => {
       await componentsPage.setAttributes(buttonsimple, {
         disabled: '',
@@ -82,12 +82,34 @@ test('mdc-buttonsimple', async ({ componentsPage }) => {
     });
 
     // Active button
-    await test.step('attribute active should be present on button', async () => {
+    await test.step('attribute active should be present on button & aria-pressed toggled by default', async () => {
       await componentsPage.setAttributes(buttonsimple, {
         active: '',
       });
       await expect(buttonsimple).toHaveAttribute('active');
+      await expect(buttonsimple).toHaveAttribute('aria-pressed', 'true');
+
       await componentsPage.removeAttribute(buttonsimple, 'active');
+      await expect(buttonsimple).toHaveAttribute('aria-pressed', 'false');
+
+      // cleanup:
+      await componentsPage.removeAttribute(buttonsimple, 'aria-pressed');
+    });
+
+    await test.step('attribute aria-expanded should be toggled if ariastatekey passed', async () => {
+      await componentsPage.setAttributes(buttonsimple, {
+        active: '',
+        ariastatekey: 'aria-expanded',
+      });
+      await expect(buttonsimple).toHaveAttribute('active');
+      await expect(buttonsimple).toHaveAttribute('aria-expanded', 'true');
+      await expect(buttonsimple).not.toHaveAttribute('aria-pressed');
+
+      await componentsPage.removeAttribute(buttonsimple, 'active');
+      await expect(buttonsimple).toHaveAttribute('aria-expanded', 'false');
+
+      // cleanup:
+      await componentsPage.removeAttribute(buttonsimple, 'aria-expanded');
     });
 
     // Active Disabled button

--- a/packages/components/src/components/buttonsimple/buttonsimple.styles.ts
+++ b/packages/components/src/components/buttonsimple/buttonsimple.styles.ts
@@ -5,6 +5,7 @@ const styles = [hostFitContentStyles, css`
   :host {
     border: 0.0625rem solid transparent;
     cursor: pointer;
+    user-select: none;
     
     background-color: var(--mds-color-theme-text-primary-normal); 
     color: var(--mds-color-theme-inverted-text-secondary-normal);

--- a/packages/components/src/components/tab/tab.component.ts
+++ b/packages/components/src/components/tab/tab.component.ts
@@ -109,6 +109,20 @@ import { IconNameMixin } from '../../utils/mixins/IconNameMixin';
  */
 class Tab extends IconNameMixin(Buttonsimple) {
   /**
+   * The tab's active state indicates whether it is currently toggled on (active) or off (inactive).
+   * When the active state is true, the tab is considered to be in an active state, meaning it is toggled on.
+   * Conversely, when the active state is false, the tab is in an inactive state, indicating it is toggled off.
+   *
+   * This attribute also controls the "aria-selected" attribute of the tab.
+   * When the tab is active, "aria-selected" is set to true, indicating that the tab is selected.
+   * When the tab is inactive, "aria-selected" is set to false, indicating that the tab is not selected.
+   *
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true })
+  override active?: boolean = DEFAULTS.ACTIVE;
+
+  /**
    * Text to be displayed in the tab.
    * If no `text` is provided, no text will be rendered,
    * `aria-label` should be set on the tab.
@@ -148,6 +162,8 @@ class Tab extends IconNameMixin(Buttonsimple) {
     this.softDisabled = undefined as unknown as boolean;
     this.size = undefined as unknown as ButtonSize;
     this.type = undefined as unknown as ButtonType;
+
+    this.ariaStateKey = 'aria-selected';
 
     if (!this.tabId && this.onerror) {
       this.onerror('tab id is required');
@@ -190,7 +206,7 @@ class Tab extends IconNameMixin(Buttonsimple) {
    *
    * @param active - The active state of the tab.
    */
-  private handleTabActiveChange = (active: boolean): void => {
+  private handleTabActiveChange = (active?: boolean): void => {
     const event = new CustomEvent('activechange', {
       detail: { tabId: this.tabId, active },
       bubbles: true,
@@ -207,7 +223,7 @@ class Tab extends IconNameMixin(Buttonsimple) {
    * @param active - The active state of the tab.
    */
   protected override setActive(element: HTMLElement, active: boolean) {
-    element.setAttribute('aria-selected', active ? 'true' : 'false');
+    super.setActive(element, active);
     this.modifyIconName(active);
   }
 

--- a/packages/components/src/components/tab/tab.constants.ts
+++ b/packages/components/src/components/tab/tab.constants.ts
@@ -10,6 +10,7 @@ const TAB_VARIANTS = {
 
 const DEFAULTS = {
   VARIANT: TAB_VARIANTS.PILL,
+  ACTIVE: false,
 } as const;
 
 export { DEFAULTS, TAG_NAME, TAB_VARIANTS };

--- a/packages/components/src/components/tab/tab.styles.ts
+++ b/packages/components/src/components/tab/tab.styles.ts
@@ -95,7 +95,7 @@ const styles = [hostFitContentStyles, css`
     flex-direction: column;
   }
 
-  :host::part(text)::after{
+  :host mdc-text::after {
     content: attr(data-text);
     height: 0;
     visibility: hidden;


### PR DESCRIPTION
### Description

- Adding `ariaStateKey` attribute to buttonsimple to allow consumers to choose what to toggle when component gets set active (for cases when aria-expanded has to be set / unset instead of aria-pressed) 
- Adding proper typing for prefix- and postfixIcon attributes on mdc-button
- Making buttons / tabs non-selectable (by setting user-select: none)
- Tab: making use of the new active / ariastatekey behavior
- Tab: fixing an issue where the tab's width is changing after clicking / setting active
