### PR TITLE
fix: buttonsimple-aria-pressed

### DIFF
--- a/packages/components/src/components/button/button.stories.ts
+++ b/packages/components/src/components/button/button.stories.ts
@@ -2,28 +2,31 @@ import type { Meta, StoryObj, Args } from '@storybook/web-components';
 import '.';
 import { html } from 'lit';
 import { action } from '@storybook/addon-actions';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { BUTTON_COLORS, PILL_BUTTON_SIZES, BUTTON_VARIANTS, ICON_BUTTON_SIZES, BUTTON_TYPE } from './button.constants';
 import { classArgType, styleArgType } from '../../../config/storybook/commonArgTypes';
 
-const render = (args: Args) => html`
-  <mdc-button 
-  @click="${action('onclick')}"
-  @keydown="${action('onkeydown')}"
-  @keyup="${action('onkeyup')}"
-  @focus="${action('onfocus')}"
-  ?active="${args.active}"
-  ?disabled="${args.disabled}"
-  ?soft-disabled="${args['soft-disabled']}"
-  variant="${args.variant}"
-  size="${args.size}"
-  color="${args.color}"
-  prefix-icon="${args['prefix-icon']}"
-  postfix-icon="${args['postfix-icon']}"
-  type="${args.type}"
-  role="${args.role}"
-  tabIndex="${args.tabIndex}"
-  aria-label="${args['aria-label']}"
-  >${args.children}</mdc-button>`;
+const render = (args: Args) =>
+  html` <mdc-button
+    @click="${action('onclick')}"
+    @keydown="${action('onkeydown')}"
+    @keyup="${action('onkeyup')}"
+    @focus="${action('onfocus')}"
+    ?active="${args.active}"
+    ?disabled="${args.disabled}"
+    ?soft-disabled="${args['soft-disabled']}"
+    variant="${args.variant}"
+    size="${args.size}"
+    color="${args.color}"
+    prefix-icon="${args['prefix-icon']}"
+    postfix-icon="${args['postfix-icon']}"
+    type="${args.type}"
+    role="${args.role}"
+    tabIndex="${args.tabIndex}"
+    aria-label="${args['aria-label']}"
+    ariaStateKey="${ifDefined(args.ariaStateKey)}"
+    >${args.children}</mdc-button
+  >`;
 
 const meta: Meta = {
   title: 'Components/button',
@@ -68,6 +71,9 @@ const meta: Meta = {
     type: {
       control: 'select',
       options: Object.values(BUTTON_TYPE),
+    },
+    ariaStateKey: {
+      control: 'text',
     },
     ...classArgType,
     ...styleArgType,

--- a/packages/components/src/components/buttonsimple/buttonsimple.component.ts
+++ b/packages/components/src/components/buttonsimple/buttonsimple.component.ts
@@ -72,10 +72,10 @@ class Buttonsimple extends TabIndexMixin(DisabledMixin(Component)) {
    * a comma separated string.
    * For example: `aria-pressed,aria-expanded`
    *
-   * @default 'aria-pressed'
+   * @default 'aria-pressed' (when)
    */
   @property({ type: String, reflect: true })
-  ariaStateKey = DEFAULTS.ARIA_STATE_KEY;
+  ariaStateKey?: string;
 
   /**
    * This property defines the type attribute for the button element.
@@ -124,6 +124,10 @@ class Buttonsimple extends TabIndexMixin(DisabledMixin(Component)) {
       this.setSoftDisabled(this, this.softDisabled);
     }
     if (changedProperties.has('active')) {
+      if (this.active) {
+        // if active is true and no ariaStateKey is provided, set it to the default (= aria-pressed)
+        this.ariaStateKey = this.ariaStateKey || DEFAULTS.ARIA_STATE_KEY;
+      }
       this.setActive(this, this.active);
     }
   }

--- a/packages/components/src/components/buttonsimple/buttonsimple.e2e-test.ts
+++ b/packages/components/src/components/buttonsimple/buttonsimple.e2e-test.ts
@@ -42,8 +42,8 @@ const setup = async (args: SetupOptions) => {
 };
 
 test('mdc-buttonsimple', async ({ componentsPage }) => {
-  const buttonsimple = await setup({ componentsPage });
   await test.step('default attributes for button', async () => {
+    const buttonsimple = await setup({ componentsPage });
     // Default values for button
     await test.step('attributes size should be present on component by default', async () => {
       await expect(buttonsimple).toHaveAttribute('size', DEFAULTS.SIZE.toString());
@@ -63,6 +63,12 @@ test('mdc-buttonsimple', async ({ componentsPage }) => {
    * ATTRIBUTES
    */
   await test.step('attributes', async () => {
+    const buttonsimple = await setup({ componentsPage });
+
+    await test.step('if active is not set aria-pressed should not be applied', async () => {
+      await expect(buttonsimple).not.toHaveAttribute('aria-pressed');
+    });
+
     // Disabled button
     await test.step('attribute disabled should be present on button', async () => {
       await componentsPage.setAttributes(buttonsimple, {

--- a/packages/components/src/components/buttonsimple/buttonsimple.stories.ts
+++ b/packages/components/src/components/buttonsimple/buttonsimple.stories.ts
@@ -2,23 +2,26 @@ import type { Meta, StoryObj, Args } from '@storybook/web-components';
 import '.';
 import { html } from 'lit';
 import { action } from '@storybook/addon-actions';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { classArgType, styleArgType } from '../../../config/storybook/commonArgTypes';
 import { BUTTON_SIZES, BUTTON_TYPE, DEFAULTS } from './buttonsimple.constants';
 
-const render = (args: Args) => html`
-  <mdc-buttonsimple 
-  @click="${action('onclick')}"
-  @keydown="${action('onkeydown')}"
-  @keyup="${action('onkeyup')}"
-  @focus="${action('onfocus')}"
-  ?active="${args.active}"
-  ?disabled="${args.disabled}"
-  ?soft-disabled="${args['soft-disabled']}"
-  size="${args.size}"
-  type="${args.type}"
-  role="${args.role}"
-  tabIndex="${args.tabIndex}"
-  >${args.children}</mdc-buttonsimple>`;
+const render = (args: Args) =>
+  html` <mdc-buttonsimple
+    @click="${action('onclick')}"
+    @keydown="${action('onkeydown')}"
+    @keyup="${action('onkeyup')}"
+    @focus="${action('onfocus')}"
+    ?active="${args.active}"
+    ?disabled="${args.disabled}"
+    ?soft-disabled="${args['soft-disabled']}"
+    size="${args.size}"
+    type="${args.type}"
+    role="${args.role}"
+    tabIndex="${args.tabIndex}"
+    ariaStateKey="${ifDefined(args.ariaStateKey)}"
+    >${args.children}</mdc-buttonsimple
+  >`;
 
 const meta: Meta = {
   title: 'Internal/buttonsimple',
@@ -31,6 +34,9 @@ const meta: Meta = {
   argTypes: {
     children: {
       description: 'Text label for the button.',
+      control: 'text',
+    },
+    ariaStateKey: {
       control: 'text',
     },
     active: {


### PR DESCRIPTION
### Description

- By default aria-pressed should not be set on a button if its not a "active" button, this change will fix that
- Adding ariaStateKey to storybook to test it properly there
- Updated buttonsimple test to check that aria-pressed is not set by default if active is unset.
