### PR TITLE
fix: buttonsimple active fallback including false

### DIFF
--- a/packages/components/src/components/buttonsimple/buttonsimple.component.ts
+++ b/packages/components/src/components/buttonsimple/buttonsimple.component.ts
@@ -124,8 +124,10 @@ class Buttonsimple extends TabIndexMixin(DisabledMixin(Component)) {
       this.setSoftDisabled(this, this.softDisabled);
     }
     if (changedProperties.has('active')) {
-      if (this.active) {
-        // if active is true and no ariaStateKey is provided, set it to the default (= aria-pressed)
+      if (this.active !== undefined) {
+        // if active is not undefined and no ariaStateKey is provided, set it to the default (= aria-pressed)
+        // this will make sure that if active is set to true or false regardless
+        // the ariaStateKey fallback will still work
         this.ariaStateKey = this.ariaStateKey || DEFAULTS.ARIA_STATE_KEY;
       }
       this.setActive(this, this.active);


### PR DESCRIPTION
### Description

- Small fix on button simple to also set fallback of ariaStateKey when active is false (only on undefined no fallback will be applied)
