### PR TITLE
docs: update docs with steps to start docs and fix logos path

### DIFF
--- a/packages/documentation/CONTRIBUTING.md
+++ b/packages/documentation/CONTRIBUTING.md
@@ -2,4 +2,24 @@
 
 ## Contributing
 
+### Steps to start the docs locally:
+
+- To start the documentation package, build these 3 package libraries first:
+```
+    yarn brand-visuals build
+    yarn illustrations build
+    yarn icons build
+```
+
+- Before you build these packages, please build the dependencies of the 3 packages.
+- Later, build the docs package and preview it.
+```
+    yarn docs build && yarn docs preview
+```
+> Note: When you deal with assets, you need to execute this above command for every single change.
+- To perform hot reloading on the docs package, please run
+```
+    yarn docs dev
+```
+
 This component package was generated with a script, please report any issues.

--- a/packages/documentation/src/components/BrandVisualsTable/BrandVisualsTable.tsx
+++ b/packages/documentation/src/components/BrandVisualsTable/BrandVisualsTable.tsx
@@ -21,7 +21,7 @@ export const BrandvisualsTable = ({ brandvisuals, type }: Props) => {
         {Object.entries(brandvisuals).map(([key, path]) => {
           let finalPath = `${path.replace('./backgrounds', '/momentum-design/brand-visuals')}`;
           finalPath = `${finalPath.replace('./images', '/momentum-design/brand-visuals')}`;
-          finalPath = `${finalPath.replace('./logos', '/momentum-design/brand-visuals')}`;
+          finalPath = `${finalPath.replace(/^\.\/logos\/ts\/(.*)\.ts$/, '/momentum-design/brand-visuals/$1.svg')}`;
 
           return (
             <div className="brandvisualsWrapper">


### PR DESCRIPTION
### Description

- The logos path for brand-visuals got affected due to the addition of typescript based files for logos.
- This PR fixes this issue by replacing the string with a req exp match.
- Additionally, I've added the steps to start the docs package locally.

### Screenshots
![image](https://github.com/user-attachments/assets/0c52b0c5-4ce9-4103-8f65-0b630c877bf9)


### Links

- https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-653
