### PR TITLE
fix: minor change to the command

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -69,7 +69,7 @@
     "test:e2e:docker:build": "docker build --platform linux/amd64 -f ./config/playwright/docker/utils/Dockerfile.test.postbuild -t ghcr.io/momentum-design/momentum-design/docker-playwright:v1.52.0 .",
     "test:e2e:docker:serve": "docker run --platform linux/amd64 -p 3000:3000 --rm --init --add-host=hostmachine:host-gateway ghcr.io/momentum-design/momentum-design/docker-playwright:v1.52.0",
     "test:e2e:podman:serve": "podman run --platform linux/amd64 -p 3000:3000 --rm --init ghcr.io/momentum-design/momentum-design/docker-playwright:v1.52.0",
-    "test:e2e:docker:update-snapshot": "yarn test:e2e:docker --update-snapshots",
+    "test:e2e:docker:update-snapshot": "yarn test:e2e:docker --update-snapshots -- ",
     "test:e2e:docker:update-snapshot:chrome": "yarn test:e2e:docker --update-snapshots --project='chrome'",
     "test:e2e:docker:update-snapshot:firefox": "yarn test:e2e:docker --update-snapshots --project='firefox'",
     "test:e2e:docker:update-snapshot:webkit": "yarn test:e2e:docker --update-snapshots --project='webkit'",


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

* After updating playwright version, `test:e2e:docker:update-snapshot` command was running for all the components irrespective of whether a file name was provided.
* This fix helps us get the desired result without creating any issue.
