### PR TITLE
fix: resolve outside click event on popover

### DIFF
--- a/packages/components/src/components/popover/popover.component.ts
+++ b/packages/components/src/components/popover/popover.component.ts
@@ -496,7 +496,9 @@ class Popover extends FocusTrapMixin(Component) {
       }
       PopoverEventManager.onShowPopover(this);
     } else {
-      popoverStack.pop();
+      if (popoverStack.peek() === this) {
+        popoverStack.pop();
+      }
 
       if (this.backdropElement) {
         this.backdropElement?.remove();

--- a/packages/components/src/components/popover/popover.stories.ts
+++ b/packages/components/src/components/popover/popover.stories.ts
@@ -476,3 +476,42 @@ export const popoverWithSelect: StoryObj = {
   `,
   ...hideAllControls(),
 };
+
+export const MultipleSingleLevelPopovers: StoryObj = {
+  render: () => html`
+    <style>
+      .container {
+        display: flex;
+        width: 150rem;
+        height: 15rem;
+        align-items: center;
+      }
+      .child {
+        display: flex;
+        width: 10rem;
+        height: 2rem;
+        justify-content: center;
+      }
+    </style>
+    <div class="container">
+      <div class="child">
+        <mdc-button id="popover-trigger-1">Click me!</mdc-button>
+        <mdc-popover triggerID="popover-trigger-1" hide-on-outside-click>
+          <mdc-text>Popover Level 1 Trigger 1</mdc-text>
+        </mdc-popover>
+      </div>
+      <div class="child">
+        <mdc-button id="popover-trigger-2">Click me!</mdc-button>
+        <mdc-popover triggerID="popover-trigger-2" hide-on-outside-click>
+          <mdc-text>Popover Level 1 Trigger 2</mdc-text>
+        </mdc-popover>
+      </div>
+      <div class="child">
+        <mdc-button id="popover-trigger-3">Click me!</mdc-button>
+        <mdc-popover triggerID="popover-trigger-3" hide-on-outside-click>
+          <mdc-text>Popover Level 1 Trigger 3</mdc-text>
+        </mdc-popover>
+      </div>
+    </div>
+  `,
+};


### PR DESCRIPTION
### Description

- When there is more than 1 popover on the screen and if the user clicks on the 2nd popover trigger element then the 1st popover should be closed (if open).
- But the 1st popover is not getting closed and being added to the popover stack.
- The reason for such behaviour is due to the `visible` property of the popover being set to `true` on showPopover method which is triggering a second lifecycle update, which is causing this issue.
- Due to the events getting bubbled up, we are unable to close the popover, as the value in `this` and `popoverStack.peek()` are different and we are unable to determine the same value to pop the previous popover stack out.
- After several trial and errors, multiple ways, I've found a simple way to close the active popover when the user clicks on outside (outside could be another popover trigger element) of the element.
