### PR TITLE
fix: dialog footer slot

### DIFF
--- a/packages/components/src/components/card/card.component.ts
+++ b/packages/components/src/components/card/card.component.ts
@@ -40,6 +40,8 @@ import { CardAndDialogFooterMixin } from '../../utils/mixins/CardAndDialogFooter
  * `mdc-button` component within the footer section.
  * @slot footer-button-secondary - This slot is for passing secondary variant of `mdc-button` component
  * within the footer section.
+ * @slot footer -  This slot is for passing custom footer content. Only use this if really needed,
+ * using the footer-link and footer-button slots is preferred.
  *
  * @tagname mdc-card
  *

--- a/packages/components/src/components/dialog/dialog.component.ts
+++ b/packages/components/src/components/dialog/dialog.component.ts
@@ -56,7 +56,8 @@ import { CardAndDialogFooterMixin } from '../../utils/mixins/CardAndDialogFooter
  * within the footer section.
  * @slot footer-button-primary - This slot is for passing primary variant of
  * `mdc-button` component within the footer section.
- *
+ * @slot footer -  This slot is for passing custom footer content. Only use this if really needed,
+ * using the footer-link and footer-button slots is preferred
  */
 class Dialog extends FocusTrapMixin(CardAndDialogFooterMixin(Component)) {
   /**

--- a/packages/components/src/components/dialog/dialog.styles.ts
+++ b/packages/components/src/components/dialog/dialog.styles.ts
@@ -81,7 +81,8 @@ const styles = css`
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    height: 100%
+    height: 100%;
+    width: 100%;
   }
 
   :host::part(footer) {

--- a/packages/components/src/utils/mixins/CardAndDialogFooterMixin.ts
+++ b/packages/components/src/utils/mixins/CardAndDialogFooterMixin.ts
@@ -107,15 +107,17 @@ export const CardAndDialogFooterMixin = <T extends Constructor<LitElement>>(supe
      */
     protected renderFooter() {
       return html`<div part="footer">
-        <slot name="footer-link" @slotchange=${() => this.handleFooterSlot(DEFAULTS.LINK)}></slot>
-        <slot
-          name="footer-button-secondary"
-          @slotchange=${() => this.handleFooterSlot(DEFAULTS.BUTTON, BUTTON_VARIANTS.SECONDARY)}
-        ></slot>
-        <slot
-          name="footer-button-primary"
-          @slotchange=${() => this.handleFooterSlot(DEFAULTS.BUTTON, BUTTON_VARIANTS.PRIMARY)}
-        ></slot>
+        <slot name="footer">
+          <slot name="footer-link" @slotchange=${() => this.handleFooterSlot(DEFAULTS.LINK)}></slot>
+          <slot
+            name="footer-button-secondary"
+            @slotchange=${() => this.handleFooterSlot(DEFAULTS.BUTTON, BUTTON_VARIANTS.SECONDARY)}
+          ></slot>
+          <slot
+            name="footer-button-primary"
+            @slotchange=${() => this.handleFooterSlot(DEFAULTS.BUTTON, BUTTON_VARIANTS.PRIMARY)}
+          ></slot>
+        </slot>
       </div>`;
     }
   }


### PR DESCRIPTION
### Description

- Wrapping a footer slot around the existing slots in both dialog and card component, to provide a way to override the footer. This should only be used if really necessary - otherwise use the existing footer-button slots.
- Added width: 100% to dialog-body. This will remove the need for a div wrapping content.
