### PR TITLE
fix: dialog card footer styling fix

### DIFF
--- a/packages/components/src/utils/mixins/CardAndDialogFooterMixin.ts
+++ b/packages/components/src/utils/mixins/CardAndDialogFooterMixin.ts
@@ -106,19 +106,20 @@ export const CardAndDialogFooterMixin = <T extends Constructor<LitElement>>(supe
      * @returns The footer element
      */
     protected renderFooter() {
-      return html`<div part="footer">
+      return html`
         <slot name="footer">
-          <slot name="footer-link" @slotchange=${() => this.handleFooterSlot(DEFAULTS.LINK)}></slot>
-          <slot
-            name="footer-button-secondary"
-            @slotchange=${() => this.handleFooterSlot(DEFAULTS.BUTTON, BUTTON_VARIANTS.SECONDARY)}
-          ></slot>
-          <slot
-            name="footer-button-primary"
-            @slotchange=${() => this.handleFooterSlot(DEFAULTS.BUTTON, BUTTON_VARIANTS.PRIMARY)}
-          ></slot>
-        </slot>
-      </div>`;
+          <div part="footer">
+            <slot name="footer-link" @slotchange=${() => this.handleFooterSlot(DEFAULTS.LINK)}></slot>
+            <slot
+              name="footer-button-secondary"
+              @slotchange=${() => this.handleFooterSlot(DEFAULTS.BUTTON, BUTTON_VARIANTS.SECONDARY)}
+            ></slot>
+            <slot
+              name="footer-button-primary"
+              @slotchange=${() => this.handleFooterSlot(DEFAULTS.BUTTON, BUTTON_VARIANTS.PRIMARY)}
+            ></slot>
+          </div>
+        </slot>`;
     }
   }
   // Cast return type to your mixin's interface intersected with the superClass type


### PR DESCRIPTION
### Description

- Small fix to keep footer styling only when footer-link or footer-buttons are provided. If footer slot is set, styling will be done by consumer.
