### PR TITLE
fix: make dialog controlled

### DIFF
--- a/packages/components/src/components/dialog/dialog.component.ts
+++ b/packages/components/src/components/dialog/dialog.component.ts
@@ -22,6 +22,11 @@ import { CardAndDialogFooterMixin } from '../../utils/mixins/CardAndDialogFooter
  * If a `triggerId` is provided, the dialog will manage focus with that element, otherwise it will
  * remember the previously focused element before the dialog was opened.
  *
+ * The dialog is a controlled component, meaning it does not have its own state management for visibility.
+ * Use the `visible` property to control the visibility of the dialog.
+ * Use the `onClose` event to handle the close action of the dialog (fired when Close button is clicked
+ * or Escape is pressed).
+ *
  * Dialog component have 2 variants: default and promotional.
  *
  * **Accessibility notes for consuming (have to be explicitly set when you consume the component)**
@@ -42,6 +47,8 @@ import { CardAndDialogFooterMixin } from '../../utils/mixins/CardAndDialogFooter
  * @event hidden - (React: onHidden) Dispatched when the dialog is hidden
  * @event created - (React: onCreated) Dispatched when the dialog is created (added to the DOM)
  * @event destroyed - (React: onDestroyed) Dispatched when the dialog is destroyed (removed from the DOM)
+ * @event close - (React: onClose) Dispatched when the Close Button is clicked or Escape key is pressed
+ * (this does not hide the dialog)
  *
  * @cssproperty --mdc-dialog-primary-background-color - primary background color of the dialog
  * @cssproperty --mdc-dialog-border-color - border color of the dialog
@@ -77,6 +84,8 @@ class Dialog extends PreventScrollMixin(FocusTrapMixin(CardAndDialogFooterMixin(
 
   /**
    * The visibility of the dialog
+   *
+   * Dialog is a controlled component, visible is the only property that controls the visibility of the dialog.
    * @default false
    */
   @property({ type: Boolean, reflect: true })
@@ -343,6 +352,15 @@ class Dialog extends PreventScrollMixin(FocusTrapMixin(CardAndDialogFooterMixin(
   }
 
   /**
+   * Fired when Close Button is clicked or Escape key is pressed.
+   * This method dispatches the close event. Setting visible to false
+   * has to be done by the consumer of the component.
+   */
+  private closeDialog() {
+    DialogEventManager.onCloseDialog(this, false);
+  }
+
+  /**
    * Handles the escape keydown event to close the dialog.
    * @internal
    * @param event - The keyboard event.
@@ -357,7 +375,7 @@ class Dialog extends PreventScrollMixin(FocusTrapMixin(CardAndDialogFooterMixin(
     // pressing escape on a dialog should only close the dialog, nothing else
     event.stopPropagation();
 
-    this.hideDialog();
+    this.closeDialog();
   };
 
   /**
@@ -420,22 +438,6 @@ class Dialog extends PreventScrollMixin(FocusTrapMixin(CardAndDialogFooterMixin(
     }
   }
 
-  /**
-   * Hides the dialog.
-   * @internal
-   */
-  public hideDialog = () => {
-    this.visible = false;
-  };
-
-  /**
-   * Shows the dialog.
-   * @internal
-   */
-  public showDialog = () => {
-    this.visible = true;
-  };
-
   public override render() {
     return html`
       ${this.headerText
@@ -468,7 +470,7 @@ class Dialog extends PreventScrollMixin(FocusTrapMixin(CardAndDialogFooterMixin(
         variant="${BUTTON_VARIANTS.TERTIARY}"
         size="${ICON_BUTTON_SIZES[20]}"
         aria-label="${ifDefined(this.closeButtonAriaLabel) || ''}"
-        @click="${this.hideDialog}"
+        @click="${this.closeDialog}"
       ></mdc-button>
       <div part="body">
         <slot name="dialog-body"></slot>

--- a/packages/components/src/components/dialog/dialog.events.ts
+++ b/packages/components/src/components/dialog/dialog.events.ts
@@ -7,12 +7,12 @@ export class DialogEventManager {
    * @param eventName - The name of the event.
    * @param instance - The dialog instance.
    */
-  static dispatchDialogEvent(eventName: string, instance: Dialog) {
+  static dispatchDialogEvent(eventName: string, instance: Dialog, bubbles = true) {
     instance.dispatchEvent(
       new CustomEvent(eventName, {
         detail: { show: instance.visible },
         composed: true,
-        bubbles: true,
+        bubbles,
       }),
     );
   }
@@ -33,6 +33,17 @@ export class DialogEventManager {
    */
   static onHideDialog(instance: Dialog) {
     this.dispatchDialogEvent('hidden', instance);
+  }
+
+  /**
+   * Custom event that is fired when the dialog is closed.
+   * This gets fired when the Close Button is clicked or
+   * when Escape key is pressed.
+   *
+   * @param instance - The dialog instance.
+   */
+  static onCloseDialog(instance: Dialog, bubbles = true) {
+    this.dispatchDialogEvent('close', instance, bubbles);
   }
 
   /**

--- a/packages/components/src/components/dialog/dialog.stories.ts
+++ b/packages/components/src/components/dialog/dialog.stories.ts
@@ -11,7 +11,7 @@ import '../button';
 import '../popover';
 import '../tooltip';
 
-const createDialog = (args: Args, content: TemplateResult) => html`<mdc-dialog
+const createDialog = (args: Args, content: TemplateResult, onClose: () => void) => html`<mdc-dialog
   class="${args.class}"
   style="${args.style}"
   id="${args.id}"
@@ -31,6 +31,7 @@ const createDialog = (args: Args, content: TemplateResult) => html`<mdc-dialog
   variant="${args.variant}"
   @shown="${action('onshown')}"
   @hidden="${action('onhidden')}"
+  @close="${onClose}"
 >
   ${content}
 </mdc-dialog>`;
@@ -95,9 +96,15 @@ const render = (args: Args) => {
     const dialog = document.getElementById(args.id) as HTMLElement;
     dialog.toggleAttribute('visible');
   };
+
+  const onClose = () => {
+    const dialog = document.getElementById(args.id) as HTMLElement;
+    dialog.removeAttribute('visible');
+  };
+
   return html`
     ${createTrigger(args.triggerId, 'Click me!', toggleVisibility)}
-    ${createDialog(args, dialogBodyContent(toggleVisibility))}
+    ${createDialog(args, dialogBodyContent(toggleVisibility), onClose)}
   `;
 };
 
@@ -106,9 +113,15 @@ const renderWithCustomHeader = (args: Args) => {
     const dialog = document.getElementById(args.id) as HTMLElement;
     dialog.toggleAttribute('visible');
   };
+
+  const onClose = () => {
+    const dialog = document.getElementById(args.id) as HTMLElement;
+    dialog.removeAttribute('visible');
+  };
+
   return html`
     ${createTrigger(args.triggerId, 'Click me!', toggleVisibility)}
-    ${createDialog(args, dialogBodyContent(toggleVisibility, true))}
+    ${createDialog(args, dialogBodyContent(toggleVisibility, true), onClose)}
   `;
 };
 
@@ -117,6 +130,11 @@ const renderSaveCancelBtns = (args: Args) => {
     const dialog = document.getElementById(args.id) as HTMLElement;
     dialog.toggleAttribute('visible');
   };
+  const onClose = () => {
+    const dialog = document.getElementById(args.id) as HTMLElement;
+    dialog.removeAttribute('visible');
+  };
+
   const showConfirmAlert = () => {
     // eslint-disable-next-line no-alert
     if (window.confirm('Are you sure you want to cancel?')) {
@@ -131,7 +149,7 @@ const renderSaveCancelBtns = (args: Args) => {
       </div>
       <mdc-button slot="footer-button-secondary" @click="${showConfirmAlert}">Cancel</mdc-button>
       <mdc-button slot="footer-button-primary" @click="${toggleVisibility}">Save</mdc-button>
-    `)}
+    `, onClose)}
   `;
 };
 
@@ -140,12 +158,17 @@ const renderNoFooter = (args: Args) => {
     const dialog = document.getElementById(args.id) as HTMLElement;
     dialog.toggleAttribute('visible');
   };
+  const onClose = () => {
+    const dialog = document.getElementById(args.id) as HTMLElement;
+    dialog.removeAttribute('visible');
+  };
+
   return html`
     ${createTrigger(args.triggerId, 'Click me!', toggleVisibility)}
     ${createDialog(args, html`
       <div slot="dialog-body">
         <p>This is the body content of the dialog.</p>
-      </div>`)}
+      </div>`, onClose)}
   `;
 };
 
@@ -154,9 +177,13 @@ const renderWithPopover = (args: Args) => {
     const dialog = document.getElementById(args.id) as HTMLElement;
     dialog.toggleAttribute('visible');
   };
+  const onClose = () => {
+    const dialog = document.getElementById(args.id) as HTMLElement;
+    dialog.removeAttribute('visible');
+  };
   return html`
     ${createTrigger(args.triggerId, 'Click me!', toggleVisibility)}
-    ${createDialog(args, dialogWithPopoverContent(toggleVisibility))}
+    ${createDialog(args, dialogWithPopoverContent(toggleVisibility), onClose)}
   `;
 };
 
@@ -168,6 +195,14 @@ const renderDialogWithinDialog = (args: Args) => {
   const toggleVisibilityNested = () => {
     const nestedDialog = document.getElementById('nested-dialog') as HTMLElement;
     nestedDialog.toggleAttribute('visible');
+  };
+  const onClose = () => {
+    const dialog = document.getElementById(args.id) as HTMLElement;
+    dialog.removeAttribute('visible');
+  };
+  const onCloseNested = () => {
+    const nestedDialog = document.getElementById('nested-dialog') as HTMLElement;
+    nestedDialog.removeAttribute('visible');
   };
   return html`
     ${createTrigger(args.triggerId, 'Click me!', toggleVisibility)}
@@ -183,10 +218,11 @@ const renderDialogWithinDialog = (args: Args) => {
           close-button-aria-label="Close nested dialog"
           header-text="Nested Dialog Header"
           description-text="This is a nested dialog description."
+          @close="${onCloseNested}"
           >
         <mdc-button slot="dialog-body">Button inside a nested dialog</mdc-button></mdc-dialog>
       </div>
-    `)}
+    `, onClose)}
   `;
 };
 
@@ -377,12 +413,18 @@ export const WithoutTriggerElement: StoryObj = {
 };
 
 export const MountUnmount: StoryObj = {
-  render: (args: Args) => html`
+  render: (args: Args) => {
+    const onClose = () => {
+      const dialog = document.getElementById(args.id) as HTMLElement;
+      dialog.removeAttribute('visible');
+    };
+    return html`
       <mdc-button id="dialog-trigger-btn">
         Trigger Button which is connected, but mountDialog controls the mounting of the dialog
       </mdc-button>
-      ${args.mountDialog ? createDialog(args, dialogBodyContent()) : ''}
-    `,
+      ${args.mountDialog ? createDialog(args, dialogBodyContent(), onClose) : ''}
+    `;
+  },
   args: {
     ...commonProperties,
     ...headerDescriptionProperties,

--- a/packages/components/src/components/dialog/dialog.types.ts
+++ b/packages/components/src/components/dialog/dialog.types.ts
@@ -12,6 +12,7 @@ interface Events {
   onHiddenEvent: Event;
   onCreatedEvent: Event;
   onDestroyedEvent: Event;
+  onCloseEvent: Event;
 }
 
 export type { DialogSize, DialogRole, DialogVariant, Events };


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

BREAKING CHANGE:
- This changes the dialog to a complete controlled component. Use and update the "visible" attribute from the outside in all cases.
- Pressing Escape or pressing the close button in the dialog will fire the onClose callback (close event) and will NOT make the dialog visible - thats the responsibility of the implementing application now.

