### PR TITLE
fix: dialog focustrap expose

### DIFF
--- a/packages/components/src/components/dialog/dialog.component.ts
+++ b/packages/components/src/components/dialog/dialog.component.ts
@@ -187,13 +187,13 @@ class Dialog extends PreventScrollMixin(FocusTrapMixin(CardAndDialogFooterMixin(
   @property({ type: Boolean, reflect: true, attribute: 'disable-aria-haspopup' })
   disableAriaHasPopup: boolean = DEFAULTS.DISABLE_ARIA_HAS_POPUP;
 
-    /**
+  /**
    * Determines whether the focus trap is enabled.
    * If true, focus will be restricted to the content within this component.
-   * 
-   * NOTE: this should only be disabled in rare cases! By default a Modal Dialog 
+   *
+   * NOTE: this should only be disabled in rare cases! By default a Modal Dialog
    * should trap focus always.
-   * 
+   *
    * @default true
    */
   @property({ type: Boolean, reflect: true, attribute: 'focus-trap' })
@@ -407,8 +407,7 @@ class Dialog extends PreventScrollMixin(FocusTrapMixin(CardAndDialogFooterMixin(
       this.activatePreventScroll();
 
       await this.updateComplete;
-      console.log(this.focusTrap)
-      if(this.focusTrap) {
+      if (this.focusTrap) {
         this.activateFocusTrap?.();
       }
       this.setInitialFocus?.();

--- a/packages/components/src/components/dialog/dialog.component.ts
+++ b/packages/components/src/components/dialog/dialog.component.ts
@@ -187,11 +187,17 @@ class Dialog extends PreventScrollMixin(FocusTrapMixin(CardAndDialogFooterMixin(
   @property({ type: Boolean, reflect: true, attribute: 'disable-aria-haspopup' })
   disableAriaHasPopup: boolean = DEFAULTS.DISABLE_ARIA_HAS_POPUP;
 
-  /**
-   * For now FocusTrap is always true as the dialog is a modal component only.
-   * This means it will always trap focus within the dialog when it is open.
+    /**
+   * Determines whether the focus trap is enabled.
+   * If true, focus will be restricted to the content within this component.
+   * 
+   * NOTE: this should only be disabled in rare cases! By default a Modal Dialog 
+   * should trap focus always.
+   * 
+   * @default true
    */
-  public override focusTrap: boolean = true;
+  @property({ type: Boolean, reflect: true, attribute: 'focus-trap' })
+  focusTrap: boolean = DEFAULTS.FOCUS_TRAP;
 
   /**
    * For now preventScroll is always true as the dialog is a modal component only.
@@ -401,7 +407,10 @@ class Dialog extends PreventScrollMixin(FocusTrapMixin(CardAndDialogFooterMixin(
       this.activatePreventScroll();
 
       await this.updateComplete;
-      this.activateFocusTrap?.();
+      console.log(this.focusTrap)
+      if(this.focusTrap) {
+        this.activateFocusTrap?.();
+      }
       this.setInitialFocus?.();
 
       // Set aria-expanded attribute on the trigger element to true if it exists

--- a/packages/components/src/components/dialog/dialog.constants.ts
+++ b/packages/components/src/components/dialog/dialog.constants.ts
@@ -18,6 +18,7 @@ const DEFAULTS = {
   CANCEL_ICON: 'cancel-bold' as Extract<IconNames, 'cancel-bold'>,
   VARIANT: DIALOG_VARIANT.DEFAULT,
   DISABLE_ARIA_HAS_POPUP: false,
+  FOCUS_TRAP: true,
 } as const;
 
 const DIALOG_SIZE = ['small', 'medium', 'large'] as const;

--- a/packages/components/src/components/dialog/dialog.stories.ts
+++ b/packages/components/src/components/dialog/dialog.stories.ts
@@ -5,7 +5,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { action } from '@storybook/addon-actions';
 
 import { classArgType, styleArgType } from '../../../config/storybook/commonArgTypes';
-import { disableControls, hideControls } from '../../../config/storybook/utils';
+import { disableControls } from '../../../config/storybook/utils';
 
 import { DIALOG_ROLE, DIALOG_SIZE, DEFAULTS, DIALOG_VARIANT } from './dialog.constants';
 import '../link';
@@ -32,6 +32,7 @@ const createDialog = (args: Args, content: TemplateResult, onClose: () => void) 
     size="${args.size}"
     ?visible="${args.visible}"
     variant="${args.variant}"
+    ?focus-trap="${args['focus-trap']}"
     @shown="${action('onshown')}"
     @hidden="${action('onhidden')}"
     @close="${onClose}"
@@ -305,6 +306,9 @@ const meta: Meta = {
     'should-focus-trap-wrap': {
       control: 'boolean',
     },
+    'focus-trap': {
+      control: 'boolean',
+    },
     role: {
       control: 'select',
       options: Object.values(DIALOG_ROLE),
@@ -324,7 +328,6 @@ const meta: Meta = {
       '--mdc-dialog-elevation-3',
       '--mdc-dialog-width',
     ]),
-    ...hideControls(['focusTrap']),
   },
 };
 

--- a/packages/components/src/utils/mixins/FocusTrapMixin.ts
+++ b/packages/components/src/utils/mixins/FocusTrapMixin.ts
@@ -64,6 +64,10 @@ class FocusTrapStack {
    * @param trap - The focus trap to deactivate.
    */
   static deactivate(trap: any) {
+    if(!this.stack.has(trap)) {
+      return;
+    }
+    
     this.stack.delete(trap);
     this.removeKeydownListener();
 


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- Allow focus trap to be set for Dialog. It should be avoided though at all costs, given that the Dialog component is a Modal Dialog. Only set this to false in case u handle the focustrap manually on the implementation side.
