### PR TITLE
chore: add test case to handle multiple submenu mouse navigation

### DIFF
--- a/packages/components/src/components/menupopover/menupopover.component.ts
+++ b/packages/components/src/components/menupopover/menupopover.component.ts
@@ -131,12 +131,16 @@ class MenuPopover extends Popover {
    * This method is used to ensure that when a menu item is clicked,
    * all other open popovers are closed, maintaining a clean user interface.
    * It iterates through the `popoverStack` and hides each popover until the stack is empty.
+   *
+   * @param until - The popover to close until.
    */
-  private closeAllMenuPopovers() {
-    while (popoverStack.peek()) {
+  private closeAllMenuPopovers(until?: Element) {
+    while (popoverStack.peek() !== until) {
       const popover = popoverStack.pop();
       if (popover) {
         popover.hidePopover();
+      } else {
+        break;
       }
     }
   }
@@ -150,6 +154,14 @@ class MenuPopover extends Popover {
    */
   override onOutsidePopoverClick = (event: MouseEvent): void => {
     if (popoverStack.peek() !== this) return;
+    const popoverOfTarget = (event.target as Element).closest(MENU_POPOVER);
+
+    // If the click occurred on a submenu, close all popovers until the submenu
+    if (popoverOfTarget && popoverStack.has(popoverOfTarget)) {
+      this.closeAllMenuPopovers(popoverOfTarget);
+      return;
+    }
+
     let insidePopoverClick = false;
     const path = event.composedPath();
     insidePopoverClick = this.contains(event.target as Node) || path.includes(this.triggerElement!);

--- a/packages/components/src/components/menupopover/menupopover.e2e-test.ts
+++ b/packages/components/src/components/menupopover/menupopover.e2e-test.ts
@@ -448,6 +448,50 @@ test('mdc-menupopover', async ({ componentsPage }) => {
         await expect(submenu).not.toBeVisible();
         await expect(menupopover).not.toBeVisible();
       });
+
+      await test.step('Close all children submenu and open the parent submenu using mouse', async () => {
+        const { wrapper, triggerElement } = await setup({
+          componentsPage,
+          html: `
+          <div id="menupopover-test-wrapper">
+            <mdc-button id="trigger-btn">File</mdc-button>
+            <mdc-menupopover triggerid="trigger-btn" backdrop>
+              <mdc-menuitem label="New" id="new-menu-trigger" arrow-position="trailing"></mdc-menuitem>
+              <mdc-menupopover triggerid="new-menu-trigger" placement="right-start">
+                <mdc-menuitem label="New Document"></mdc-menuitem>
+              <mdc-menuitem label="New Folder"></mdc-menuitem>
+              <mdc-menuitem label="New Window"></mdc-menuitem>
+            </mdc-menupopover>
+            <mdc-menuitem label="Open"></mdc-menuitem>
+            <mdc-menuitem label="Save"></mdc-menuitem>
+            <mdc-menuitem label="Save As" id="save-as-menu-trigger" arrow-position="trailing"></mdc-menuitem>
+            <mdc-menupopover triggerid="save-as-menu-trigger" placement="right-start">
+              <mdc-menuitem label="Multiple Folders"></mdc-menuitem>
+              <mdc-menuitem label="Location"></mdc-menuitem>
+              <mdc-menuitem label="Auto Save"></mdc-menuitem>
+            </mdc-menupopover>
+            <mdc-menuitem id="save-all" label="Save All"></mdc-menuitem>
+          </mdc-menupopover>
+          </div>
+        `,
+        });
+
+        const newMenuPopover = wrapper.locator('mdc-menupopover[triggerid="new-menu-trigger"]');
+        const saveAsMenuPopover = wrapper.locator('mdc-menupopover[triggerid="save-as-menu-trigger"]');
+
+        await triggerElement.click();
+        await expect(wrapper.locator('mdc-menupopover[triggerid="trigger-btn"]')).toBeVisible();
+        await wrapper.locator('#new-menu-trigger').click();
+        await expect(newMenuPopover).toBeVisible();
+        await wrapper.locator('#save-as-menu-trigger').click();
+        await expect(saveAsMenuPopover).toBeVisible();
+        await expect(newMenuPopover).not.toBeVisible();
+        await wrapper.locator('#save-all').click();
+        await expect(saveAsMenuPopover).not.toBeVisible();
+        await expect(newMenuPopover).not.toBeVisible();
+        await expect(wrapper.locator('mdc-menupopover[triggerid="trigger-btn"]')).not.toBeVisible();
+        await expect(wrapper.locator('#trigger-btn')).toBeFocused();
+      });
     });
 
     // Group: Menuitem types: checkbox and radio (with grouped navigation)

--- a/packages/components/src/components/menupopover/menupopover.feature
+++ b/packages/components/src/components/menupopover/menupopover.feature
@@ -213,6 +213,12 @@ Feature: MenuPopover Accessibility and User Interaction
       When I click anywhere outside the MenuPopover
       Then all the MenuPopover should close at once
 
+    Scenario: Close all children submenu and open the parent submenu using mouse
+      Given I have navigated into multiple nested submenus
+      When I click on one of the root parent menuitems which has a nested submenu
+      Then all of the opened nested submenus (upto that level) should close
+      And the parent submenu should open
+
   Rule: ✅ Menuitem Types
 
     Scenario: Toggle menuitemcheckbox using mouse

--- a/packages/components/src/components/menupopover/menupopover.stories.ts
+++ b/packages/components/src/components/menupopover/menupopover.stories.ts
@@ -253,3 +253,48 @@ export const WithNestedSubmenus: StoryObj = {
     </div>
   `,
 };
+
+export const MixedUsage: StoryObj = {
+  render: () => html`
+    <div style="display: flex; justify-content: space-between; width: 10rem;">
+      <mdc-button id="file-menu-trigger">File</mdc-button>
+      <mdc-menupopover triggerid="file-menu-trigger" backdrop>
+        <mdc-menuitem label="New" id="new-menu-trigger" arrow-position="trailing"></mdc-menuitem>
+        <mdc-menupopover triggerid="new-menu-trigger" placement="right-start">
+          <mdc-menuitem label="New Document"></mdc-menuitem>
+          <mdc-menuitem label="New Folder"></mdc-menuitem>
+          <mdc-menuitem label="New Window"></mdc-menuitem>
+        </mdc-menupopover>
+        <mdc-menuitem label="Open"></mdc-menuitem>
+        <mdc-menuitem label="Save"></mdc-menuitem>
+        <mdc-divider></mdc-divider>
+        <mdc-menuitem label="Save At" id="save-as-menu-trigger" arrow-position="trailing"></mdc-menuitem>
+        <mdc-menupopover triggerid="save-as-menu-trigger" placement="right-start">
+          <mdc-menuitem label="Multiple Folders" id="folder-menu-trigger" arrow-position="trailing"></mdc-menuitem>
+          <mdc-menupopover triggerid="folder-menu-trigger" placement="right-start">
+            <mdc-menuitemcheckbox label="Desktop"></mdc-menuitemcheckbox>
+            <mdc-menuitemcheckbox label="Documents"></mdc-menuitemcheckbox>
+            <mdc-menuitemcheckbox label="Downloads"></mdc-menuitemcheckbox>
+            <mdc-divider></mdc-divider>
+            <mdc-menuitem label="Save somewhere else"></mdc-menuitem>
+          </mdc-menupopover>
+          <mdc-menuitem id="location-menu-trigger" label="Location" arrow-position="trailing"></mdc-menuitem>
+          <mdc-menupopover triggerid="location-menu-trigger" placement="right-start">
+            <mdc-menuitemradio label="Apple Maps Location"></mdc-menuitemradio>
+            <mdc-menuitemradio label="Google Maps Location"></mdc-menuitemradio>
+            <mdc-divider></mdc-divider>
+            <mdc-menuitem label="Save somewhere else"></mdc-menuitem>
+          </mdc-menupopover>
+          <mdc-menuitem label="Auto Save"></mdc-menuitem>
+        </mdc-menupopover>
+        <mdc-menuitem label="Save All"></mdc-menuitem>
+      </mdc-menupopover>
+      <mdc-button id="view-menu-trigger">View</mdc-button>
+      <mdc-menupopover triggerid="view-menu-trigger">
+        <mdc-menuitem label="Zoom In"></mdc-menuitem>
+        <mdc-menuitem label="Zoom Out"></mdc-menuitem>
+        <mdc-menuitem label="Reset Zoom"></mdc-menuitem>
+      </mdc-menupopover>
+    </div>
+  `,
+};

--- a/packages/components/src/components/popover/popover.stack.ts
+++ b/packages/components/src/components/popover/popover.stack.ts
@@ -51,6 +51,16 @@ class PopoverStack {
   }
 
   /**
+   * Checks if the stack has a specific popover
+   *
+   * @param popover - Popover instance
+   * @returns True if the stack has the popover, false otherwise
+   */
+  has(popover: Popover): boolean {
+    return this.stack.includes(popover);
+  }
+
+  /**
    * Clears the stack
    */
   clear() {


### PR DESCRIPTION
### Description

- The current popover implementation doesn't allow user to click a submenu if another submenu is already open.
- Issues arise when multiple submenus are open; clicking one can inadvertently close others.
- Debugging reveals that outside clicks trigger closure of all popovers, not just the targeted ones.
- This PR fixes this issue.
- Checkout this vidcast for more info on this issue: https://app.vidcast.io/share/0df6d7f8-2a78-4eda-a75f-4c2eb8c76cf3