### PR TITLE
fix: support keyboard navigation when menuitems are wrapped in menusection

### DIFF
--- a/packages/components/src/components/menubar/menubar.e2e-test.ts
+++ b/packages/components/src/components/menubar/menubar.e2e-test.ts
@@ -378,5 +378,76 @@ test.describe('Menubar Feature Scenarios', () => {
       await expect(undo).toBeFocused();
       await componentsPage.visualRegression.takeScreenshot('mdc-menubar-edit-popover');
     });
+
+    // Menubar with menusection and divider
+    await test.step('menubar with menusection groups and dividers', async () => {
+      await componentsPage.mount({
+        html: `
+          <mdc-menubar style="width: 8rem; margin: 1rem 0;">
+            <mdc-menusection>
+              <mdc-menuitem id="temp-id1" label="Style1"></mdc-menuitem>
+              <mdc-menuitem id="temp-id2" label="Style2"></mdc-menuitem>
+              <mdc-menuitem id="temp-id3" label="Style3"></mdc-menuitem>
+              <mdc-menuitem id="temp-id4" label="Style4" arrow-position="trailing"></mdc-menuitem>
+              <mdc-menupopover triggerid="temp-id4">
+                <mdc-menusection>
+                  <mdc-menuitem id="submenu-small" label="Small"></mdc-menuitem>
+                  <mdc-menuitem label="Medium"></mdc-menuitem>
+                  <mdc-menuitem label="Large"></mdc-menuitem>
+                </mdc-menusection>
+              </mdc-menupopover>
+            </mdc-menusection>
+            <mdc-divider></mdc-divider>
+            <mdc-menusection>
+              <mdc-menuitem id="align-id1" label="Align1" arrow-position="trailing"></mdc-menuitem>
+              <mdc-menuitem id="align-id2" label="Align2"></mdc-menuitem>
+              <mdc-menuitem id="align-id3" label="Align3"></mdc-menuitem>
+              <mdc-menuitem id="align-id4" label="Align4"></mdc-menuitem>
+              <mdc-menupopover triggerid="align-id1">
+                <mdc-menusection>
+                  <mdc-menuitem id="submenu-left" label="Left"></mdc-menuitem>
+                  <mdc-menuitem label="Center"></mdc-menuitem>
+                  <mdc-menuitem label="Right"></mdc-menuitem>
+                </mdc-menusection>
+              </mdc-menupopover>
+            </mdc-menusection>
+          </mdc-menubar>
+        `,
+        clearDocument: true,
+      });
+      const style1 = componentsPage.page.locator('#temp-id1');
+      const style2 = componentsPage.page.locator('#temp-id2');
+      const style3 = componentsPage.page.locator('#temp-id3');
+      const style4 = componentsPage.page.locator('#temp-id4');
+      const align1 = componentsPage.page.locator('#align-id1');
+      const styleSubmenu = componentsPage.page.locator('mdc-menupopover[triggerid="temp-id4"]');
+      const alignSubmenu = componentsPage.page.locator('mdc-menupopover[triggerid="align-id1"]');
+
+      await test.step('Keyboard navigation through menubar with menusection', async () => {
+        await componentsPage.actionability.pressTab();
+        await expect(style1).toBeFocused();
+        // Down Arrow moves to next
+        await componentsPage.actionability.pressAndCheckFocus('ArrowDown', [style2, style3, style4, align1]);
+        // Up Arrow moves back
+        await componentsPage.actionability.pressAndCheckFocus('ArrowUp', [style4, style3, style2, style1]);
+      });
+
+      await test.step('Open submenu from menuitem inside menusection', async () => {
+        await style4.focus();
+        await componentsPage.page.keyboard.press('ArrowRight');
+        await expect(styleSubmenu).toBeVisible();
+        const submenuSmall = componentsPage.page.locator('#submenu-small');
+        await expect(submenuSmall).toBeFocused();
+        await componentsPage.page.keyboard.press('ArrowRight');
+        await expect(styleSubmenu).not.toBeVisible();
+        await expect(alignSubmenu).toBeVisible();
+        const submenuLeft = componentsPage.page.locator('#submenu-left');
+        await expect(submenuLeft).toBeFocused();
+        await componentsPage.page.keyboard.press('ArrowLeft');
+        await expect(alignSubmenu).not.toBeVisible();
+        await expect(styleSubmenu).toBeVisible();
+        await expect(submenuSmall).toBeFocused();
+      });
+    });
   });
 });

--- a/packages/components/src/components/menubar/menubar.feature
+++ b/packages/components/src/components/menubar/menubar.feature
@@ -150,6 +150,24 @@ Feature: Vertical Menubar Accessibility and User Interaction
       And its submenu opens
       And focus moves to the first focusable menuitem inside the submenu
 
+  Rule: ✅ Menubar with MenuSections
+
+    Scenario: Keyboard navigation with menusection groups
+      Given the Menubar contains menusection groups, each with multiple menuitems
+      When I press `Down Arrow` or `Up Arrow`
+      Then focus moves between menuitems across menusections in the correct order
+
+    Scenario: Open submenu from menuitem inside menusection
+      Given a menuitem inside a menusection has a submenu
+      When I focus the menuitem and press `ArrowRight`
+      Then its submenu opens
+      And focus moves to the first menuitem in the submenu
+
+    Scenario: All menubar keyboard and mouse interactions work with menusection structure
+      Given the Menubar is structured with menusection elements
+      When I interact with the menubar using keyboard or mouse
+      Then all navigation, submenu opening, and accessibility behaviors match those of a flat menubar
+
   Rule: ✅ ScreenReader Accessibility (VoiceOver on macOS)
 
     Scenario: VoiceOver moves focus to Menubar

--- a/packages/components/src/components/menubar/menubar.stories.ts
+++ b/packages/components/src/components/menubar/menubar.stories.ts
@@ -263,3 +263,36 @@ export const EditorMenubar: StoryObj = {
     </script>
   `,
 };
+
+export const WithMenuSections: StoryObj = {
+  render: () =>
+    html` <mdc-menubar style="width: 8rem; margin: 1rem 0;">
+      <mdc-menusection>
+        <mdc-menuitem id="temp-id1" label="Style1"></mdc-menuitem>
+        <mdc-menuitem id="temp-id2" label="Style2"></mdc-menuitem>
+        <mdc-menuitem id="temp-id3" label="Style3"></mdc-menuitem>
+        <mdc-menuitem id="temp-id4" label="Style4" arrow-position="trailing"></mdc-menuitem>
+        <mdc-menupopover triggerid="temp-id4">
+          <mdc-menusection>
+            <mdc-menuitem label="Small"></mdc-menuitem>
+            <mdc-menuitem label="Medium"></mdc-menuitem>
+            <mdc-menuitem label="Large"></mdc-menuitem>
+          </mdc-menusection>
+        </mdc-menupopover>
+      </mdc-menusection>
+      <mdc-divider></mdc-divider>
+      <mdc-menusection>
+        <mdc-menuitem id="align-id1" label="Align1" arrow-position="trailing"></mdc-menuitem>
+        <mdc-menuitem id="align-id2" label="Align2"></mdc-menuitem>
+        <mdc-menuitem id="align-id3" label="Align3"></mdc-menuitem>
+        <mdc-menuitem id="align-id4" label="Align4"></mdc-menuitem>
+        <mdc-menupopover triggerid="align-id1">
+          <mdc-menusection>
+            <mdc-menuitem label="Left"></mdc-menuitem>
+            <mdc-menuitem label="Center"></mdc-menuitem>
+            <mdc-menuitem label="Right"></mdc-menuitem>
+          </mdc-menusection>
+        </mdc-menupopover>
+      </mdc-menusection>
+    </mdc-menubar>`,
+};


### PR DESCRIPTION


<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

* support  to add keyboard navigation when menuitems are wrapped in menusection