### PR TITLE
fix(menupopover): update tabindex after menu item(s) changed

### DIFF
--- a/packages/components/src/components/listitem/listitem.component.ts
+++ b/packages/components/src/components/listitem/listitem.component.ts
@@ -14,8 +14,9 @@ import { TAG_NAME as TOOLTIP_TAG_NAME } from '../tooltip/tooltip.constants';
 
 import { DEFAULTS } from './listitem.constants';
 import styles from './listitem.styles';
-import type { ListItemVariants } from './listitem.types';
+import { ListItemVariants } from './listitem.types';
 import { generateListItemId, generateTooltipId } from './listitem.utils';
+import { ListItemEventManager } from './listitem.events';
 
 /**
  * mdc-listitem component is used to display a label with different types of controls.
@@ -61,6 +62,10 @@ import { generateListItemId, generateTooltipId } from './listitem.utils';
  * @event keydown - (React: onKeyDown) This event is dispatched when a key is pressed down on the listitem.
  * @event keyup - (React: onKeyUp) This event is dispatched when a key is released on the listitem.
  * @event focus - (React: onFocus) This event is dispatched when the listitem receives focus.
+ * @event enabled - (React: onEnabled) This event is dispatched after the listitem is enabled
+ * @event disabled - (React: onDisabled) This event is dispatched after the listitem is disabled
+ * @event created - (React: onCreated) This event is dispatched after the listitem is created (added to the DOM)
+ * @event destroyed - (React: onDestroyed) This event is dispatched after the listitem is destroyed (removed from the DOM)
  */
 class ListItem extends DisabledMixin(TabIndexMixin(Component)) {
   /** @internal */
@@ -149,6 +154,13 @@ class ListItem extends DisabledMixin(TabIndexMixin(Component)) {
     this.role = this.role || ROLE.LISTITEM;
     // Add a unique id to the listitem if it does not have one.
     this.id = this.id || generateListItemId();
+
+    ListItemEventManager.onCreatedListItem(this);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    ListItemEventManager.onDestroyedListItem(this);
   }
 
   /**
@@ -194,7 +206,7 @@ class ListItem extends DisabledMixin(TabIndexMixin(Component)) {
     }
 
     // Remove any existing tooltip.
-    this.hideTooltipOnLeave()
+    this.hideTooltipOnLeave();
 
     // Create tooltip for the listitem element.
     const tooltip = document.createElement(TOOLTIP_TAG_NAME);
@@ -253,8 +265,10 @@ class ListItem extends DisabledMixin(TabIndexMixin(Component)) {
     [...this.leadingControlsSlot, ...this.trailingControlsSlot].forEach(element => {
       if (disabled) {
         element.setAttribute('disabled', '');
+        ListItemEventManager.onDisableListItem(this);
       } else {
         element.removeAttribute('disabled');
+        ListItemEventManager.onEnableListItem(this);
       }
     });
     // Set the aria-disabled attribute to indicate that the list item is disabled.

--- a/packages/components/src/components/listitem/listitem.events.ts
+++ b/packages/components/src/components/listitem/listitem.events.ts
@@ -1,0 +1,51 @@
+import type ListItem from './listitem.component';
+
+export class ListItemEventManager {
+  /**
+   * Dispatches a custom event for the ListItem.
+   *
+   * @param eventName - The name of the event.
+   * @param instance - The LitItem instance.
+   */
+  private static dispatchListItemEvent(eventName: string, instance: ListItem) {
+    instance.dispatchEvent(new Event(eventName, { composed: true, bubbles: true }));
+  }
+
+  /**
+   * Custom event that is fired when the popover is shown.
+   *
+   * @param instance - The popover instance.
+   */
+  static onDisableListItem(instance: ListItem) {
+    this.dispatchListItemEvent('disabled', instance);
+  }
+
+  /**
+   * Custom event that is fired when the popover is hidden.
+   *
+   * @param instance - The popover instance.
+   */
+  static onEnableListItem(instance: ListItem) {
+    this.dispatchListItemEvent('enabled', instance);
+  }
+
+  /**
+   * Custom event that is fired when the popover is created.
+   *
+   * @param instance - The popover instance.
+   */
+  static onCreatedListItem(instance: ListItem) {
+    // Use setTimeout to ensure the event is dispatched after the component is fully initialized
+    // Inherited Element might execute its own lifecycle methods
+    setTimeout(() => this.dispatchListItemEvent('created', instance), 0);
+  }
+
+  /**
+   * Custom event that is fired when the popover is destroyed.
+   *
+   * @param instance - The popover instance.
+   */
+  static onDestroyedListItem(instance: ListItem) {
+    this.dispatchListItemEvent('destroyed', instance);
+  }
+}

--- a/packages/components/src/components/listitem/listitem.types.ts
+++ b/packages/components/src/components/listitem/listitem.types.ts
@@ -2,13 +2,20 @@ import type { ValueOf } from '../../utils/types';
 
 import { LISTITEM_VARIANTS } from './listitem.constants';
 
-type ListItemVariants = ValueOf<typeof LISTITEM_VARIANTS>;
+export type ListItemVariants = ValueOf<typeof LISTITEM_VARIANTS>;
 
-interface Events {
+export interface Events {
   onClickEvent: MouseEvent;
   onKeyDownEvent: KeyboardEvent;
   onKeyUpEvent: KeyboardEvent;
   onFocusEvent: FocusEvent;
 }
 
-export type { ListItemVariants, Events };
+declare global {
+  interface GlobalEventHandlersEventMap {
+    disabled: Event;
+    enabled: Event;
+    created: Event;
+    destroyed: Event;
+  }
+}

--- a/packages/components/src/components/menupopover/menupopover.stories.ts
+++ b/packages/components/src/components/menupopover/menupopover.stories.ts
@@ -13,6 +13,7 @@ import '../icon';
 import '../menuitem';
 import '../listitem';
 import '../list';
+import { KEYS } from '../../utils/keys';
 
 const createPopover = (args: Args, content: TemplateResult = html``) => html`
   <mdc-menupopover
@@ -444,4 +445,61 @@ export const MenuInList: StoryObj = {
         <mdc-listitem @click=${action('onclick')} label="List Item 6"></mdc-listitem>
       </mdc-list>
       ${createPopover(args, defaultMenuContent)}`,
+};
+
+export const DynamicMenu: StoryObj = {
+  args: { ...Example.args, triggerID: 'button-trigger' },
+  render: () => {
+    let counter = 1;
+
+    const stopEnterAndSpace = (event: any) =>
+      event.key === KEYS.ENTER || event.key === KEYS.SPACE ? event.stopPropagation() : undefined;
+
+    const addNewMenu = (event: any) => {
+      event.stopImmediatePropagation();
+
+      const withDelay = event.target?.getAttribute('name') === 'delay';
+      const parent = event.target?.closest('mdc-menupopover');
+
+      const menuItem = document.createElement('mdc-menuitem');
+      menuItem.setAttribute('label', `#${counter} Remove itself ${withDelay ? 'with delay' : ''}`);
+      menuItem.addEventListener('click', (e: any) => {
+        e.stopPropagation();
+        if (withDelay) {
+          setTimeout(() => e.target?.remove?.(), 500);
+        } else {
+          e.target?.remove?.();
+        }
+      });
+      menuItem.addEventListener('keydown', stopEnterAndSpace);
+
+      if (withDelay) {
+        setTimeout(() => parent?.append(menuItem), 500);
+      } else {
+        parent?.append(menuItem);
+      }
+      counter += 1;
+    };
+
+    return html`<mdc-button id="trigger-btn">Dynamic menu</mdc-button>
+      <mdc-menupopover triggerID="trigger-btn" placement="bottom-start">
+        <mdc-menuitem label="Add menu item..." name="instant" @click=${addNewMenu} @keydown=${stopEnterAndSpace}>
+          <mdc-icon name="plus-bold" size="2" slot="leading-controls" length-unit="rem"></mdc-icon>
+        </mdc-menuitem>
+        <mdc-menuitem label="Add with delay..." name="delay" @click=${addNewMenu} @keydown=${stopEnterAndSpace}>
+          <mdc-icon name="completed-by-time-bold" size="2" slot="leading-controls" length-unit="rem"></mdc-icon>
+        </mdc-menuitem>
+        <mdc-menuitem label="Nested" id="sub-trigger" arrow-position="trailing"> </mdc-menuitem>
+        <mdc-menupopover triggerID="sub-trigger" placement="right-start">
+          <mdc-menuitem label="Add menu item..." name="instant" @click=${addNewMenu} @keydown=${stopEnterAndSpace}>
+            <mdc-icon name="plus-bold" size="2" slot="leading-controls" length-unit="rem"></mdc-icon>
+          </mdc-menuitem>
+          <mdc-menuitem label="Add with delay..." name="delay" @click=${addNewMenu} @keydown=${stopEnterAndSpace}>
+            <mdc-icon name="completed-by-time-bold" size="2" slot="leading-controls" length-unit="rem"></mdc-icon>
+          </mdc-menuitem>
+          <mdc-divider></mdc-divider>
+        </mdc-menupopover>
+        <mdc-divider></mdc-divider>
+      </mdc-menupopover>`;
+  },
 };


### PR DESCRIPTION
### Description

- add created, destroyed, enabled and disabled events to mdc-listitem
- update tabindexes based on menu item lifecycle events
