### PR TITLE
fix: select add updatestate method for selected changes

### DIFF
--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -472,6 +472,22 @@ class Select extends FormInternalsMixin(DataAriaLabelMixin(FormfieldWrapper)) im
     this.visualCombobox.focus();
   }
 
+  /**
+   * Updates the state of the select component.
+   * This public method should be fired when the selected on the option components is updated from the outside.
+   * It ensures that the selected attribute is set correctly on the options
+   * and that the aria-selected attribute is updated accordingly.
+   */
+  public updateState(): void {
+    const newSelectedOption = this.getFirstSelectedOption();
+
+    if (!newSelectedOption) {
+      this.setSelectedOption(this.placeholder ? null : this.getFirstValidOption());
+    } else if (this.selectedOption?.value !== newSelectedOption.value) {
+      this.setSelectedOption(newSelectedOption);
+    }
+  }
+
   public override render() {
     return html`
       ${this.renderLabel()}

--- a/packages/components/src/components/select/select.e2e-test.ts
+++ b/packages/components/src/components/select/select.e2e-test.ts
@@ -338,6 +338,68 @@ test('mdc-select', async ({ componentsPage }) => {
       expect(validationMessage).toBe(customMessage);
     });
 
+    await test.step('selected value should be updated when changing the selected option programmatically', async () => {
+      const select = await setup({
+        componentsPage,
+        label: 'Select an option',
+        placeholder: 'Select an option',
+        children: `
+          <mdc-selectlistbox>
+            <mdc-option selected label="Option 1" secondary-label="Secondary Label 1" value="option1"></mdc-option>
+            <mdc-option label="Option 2" secondary-label="Secondary Label 2" value="option2"></mdc-option>
+            <mdc-option label="Option 3" secondary-label="Secondary Label 3" value="option3"></mdc-option>
+            <mdc-option label="Option 4" secondary-label="Secondary Label 4" value="option4"></mdc-option>
+          </mdc-selectlistbox>
+        `,
+      });
+
+      await test.step('should update selected option when selected attribute is changed from option1 to option2', async () => {
+        await componentsPage.page.evaluate(() => {
+          const select = document.querySelector('mdc-select[label="Select an option"]');
+          const selectListbox = document.querySelector('mdc-select[label="Select an option"] mdc-selectlistbox');
+          if (selectListbox) {
+            const options = selectListbox.querySelectorAll('mdc-option');
+            options.forEach((option, idx) => {
+              if (idx === 0) {
+                option.removeAttribute('selected');
+              }
+              if (idx === 1) {
+                option.setAttribute('selected', '');
+              }
+            });
+            // @ts-ignore
+            select.updateState();
+          }
+        });
+
+        await expect(select).toHaveAttribute('value', 'option2');
+        await expect(select.locator('mdc-option').nth(1)).toHaveAttribute('selected');
+      });
+
+      await test.step('should fallback to placeholder when selected attribute get removed', async () => {
+        await componentsPage.page.evaluate(() => {
+          const select = document.querySelector('mdc-select[label="Select an option"]');
+          const selectListbox = document.querySelector('mdc-select[label="Select an option"] mdc-selectlistbox');
+          if (selectListbox) {
+            const options = selectListbox.querySelectorAll('mdc-option');
+            options.forEach(option => {
+              option.removeAttribute('selected');
+            });
+            // @ts-ignore
+            select.updateState();
+          }
+        });
+
+        await expect(select).toHaveAttribute('value', '');
+        const selectedOptions = await select.locator('mdc-option[selected]').count();
+        expect(selectedOptions).toBe(0);
+
+        const mdcTextElement = select.locator('mdc-text[part="base-text "]');
+        const textContent = await mdcTextElement.textContent();
+        expect(textContent?.trim()).toBe('Select an option');
+      });
+    });
+
     await test.step('keyboard', async () => {
       await test.step('component should open dropdown when space/enter is pressed', async () => {
         const select = await setup({ componentsPage, children: defaultChildren() });

--- a/packages/components/src/components/select/select.stories.ts
+++ b/packages/components/src/components/select/select.stories.ts
@@ -12,6 +12,8 @@ import '../optgroup';
 import '../option';
 import { POPOVER_PLACEMENT } from '../popover/popover.constants';
 
+import type Select from './select.component';
+
 const helpTextTypes = Object.values(VALIDATION).filter((type: string) => type !== 'priority');
 
 const wrapWithDiv = (htmlString: TemplateResult) => html`
@@ -355,6 +357,61 @@ export const SelectWithDynamicOptions: StoryObj = {
   },
   argTypes: {
     ...disableControls(['readonly', 'name', 'data-aria-label', 'disabled', 'required', 'help-text-type', 'help-text']),
+  },
+  ...hideAllControls(),
+};
+
+export const SelectWithChangingSelectedAfterMount: StoryObj = {
+  render: () => {
+    const handleClick = () => {
+      const select = document.querySelector('mdc-select[label="Select an option"]') as Select;
+      const selectListbox = document.querySelector('mdc-select[label="Select an option"] mdc-selectlistbox');
+      if (selectListbox) {
+        const options = selectListbox.querySelectorAll('mdc-option');
+        options.forEach((option, idx) => {
+          if (idx === 0) {
+            option.removeAttribute('selected');
+          }
+          if (idx === 1) {
+            option.setAttribute('selected', '');
+          }
+        });
+        select.updateState();
+      }
+    };
+
+    const handleClickRemove = () => {
+      const select = document.querySelector('mdc-select[label="Select an option"]') as Select;
+      const selectListbox = document.querySelector('mdc-select[label="Select an option"] mdc-selectlistbox');
+      if (selectListbox) {
+        const options = selectListbox.querySelectorAll('mdc-option');
+        options.forEach(option => {
+          option.removeAttribute('selected');
+        });
+        select.updateState();
+      }
+    };
+
+    return wrapWithDiv(html`
+      <mdc-button @click=${handleClick}>Change Selected to Option 2</mdc-button>
+      <mdc-button @click=${handleClickRemove}>Remove Selected</mdc-button>
+      <mdc-select
+        label="Select an option"
+        placeholder="Select an option"
+        @change="${action('onchange')}"
+        @click="${action('onclick')}"
+        @input="${action('oninput')}"
+        @keydown="${action('onkeydown')}"
+        @focus="${action('onfocus')}"
+      >
+        <mdc-selectlistbox>
+          <mdc-option selected label="Option 1" secondary-label="Secondary Label 1" value="option1"></mdc-option>
+          <mdc-option label="Option 2" secondary-label="Secondary Label 2" value="option2"></mdc-option>
+          <mdc-option label="Option 3" secondary-label="Secondary Label 3" value="option3"></mdc-option>
+          <mdc-option label="Option 4" secondary-label="Secondary Label 4" value="option4"></mdc-option>
+        </mdc-selectlistbox>
+      </mdc-select>
+    `);
   },
   ...hideAllControls(),
 };


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- [Select] adding a public method on the component to allow for a stateUpdate. This is for cases where the selected attribute on passed Options changes programmatically on the outside. By firing this method the state of the Select internally will be updated.
