### PR TITLE
fix: remove nested css selector in popover.styles.css

### DIFF
--- a/packages/components/src/components/menupopover/menupopover.stories.ts
+++ b/packages/components/src/components/menupopover/menupopover.stories.ts
@@ -49,7 +49,7 @@ const meta: Meta = {
   tags: ['autodocs'],
   component: 'mdc-menupopover',
   parameters: {
-    badges: ['wip'],
+    badges: ['stable'],
   },
   argTypes: {
     id: {

--- a/packages/components/src/components/popover/popover.styles.ts
+++ b/packages/components/src/components/popover/popover.styles.ts
@@ -37,15 +37,13 @@ const styles = css`
     color: var(--mdc-popover-inverted-text-color);
   }
 
-  :host([color='contrast']) {
-    .popover-arrow {
-      background-color: var(--mdc-popover-inverted-background-color);
-      border-color: var(--mdc-popover-inverted-border-color);
-    }
+  :host([color='contrast']) .popover-arrow {
+    background-color: var(--mdc-popover-inverted-background-color);
+    border-color: var(--mdc-popover-inverted-border-color);
+  }
 
-    .popover-close {
-      color: var(--mdc-popover-inverted-text-color);
-    }
+  :host([color='contrast']) .popover-close {
+    color: var(--mdc-popover-inverted-text-color);
   }
 
   :host::part(popover-content) {


### PR DESCRIPTION
### Description

Remove the nested selector in popover.styles.css and replace with the equivalent expanded version. This appears to be causing a crash in Safari 17

(Also, update the badge for menupopover from wip to stable since it is in the stable area of the storybook) 

### Links

WebKit Bug: https://bugs.webkit.org/show_bug.cgi?id=276942
