### PR TITLE
fix: prevent click event from emitting on disabled menu item

### DIFF
--- a/packages/components/LEARNINGS.md
+++ b/packages/components/LEARNINGS.md
@@ -16,3 +16,9 @@ To address this, the select component now considers all options provided through
 the default slot and wraps them inside a `listbox`. This wrapping is performed
 within the `connectedCallback` lifecycle method, ensuring that screen readers
 can properly recognize the relationship between the listbox and its options.
+
+### Form-Associated Custom Elements: Native Behavior & Event Suppression
+
+When a custom element is form-associated, it inherits native form control behavior.
+This includes automatic suppression of user interaction events when the element is disabled.
+That said, you do not need to manually prevent these events — the browser enforces this behavior automatically, just like it does for native elements like <input disabled> or <button disabled>.

--- a/packages/components/src/components/listitem/listitem.styles.ts
+++ b/packages/components/src/components/listitem/listitem.styles.ts
@@ -42,6 +42,11 @@ const styles = css`
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+  
+  :host([disabled]) {
+    pointer-events: none;
+  }
+
   :host([disabled]),
   :host([disabled]:hover),
   :host([disabled]:active),

--- a/packages/components/src/components/navmenuitem/navmenuitem.styles.ts
+++ b/packages/components/src/components/navmenuitem/navmenuitem.styles.ts
@@ -54,7 +54,6 @@ const styles = [
     :host([disabled]) {
       color: var(--mdc-navmenuitem-disabled-color);
       background-color: var(--mdc-navmenuitem-disabled-background-color);
-      pointer-events: none;
     }
 
     :host([active][disabled]) {


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description
Fixes an issue where a disabled menu item was still emitting a click event.

#### Fixes
Suppresses click event when the menu item is disabled.
