### PR TITLE
fix: radio element does not change event when navigating via keyboard

### DIFF
--- a/packages/components/src/components/radio/radio.component.ts
+++ b/packages/components/src/components/radio/radio.component.ts
@@ -86,8 +86,7 @@ class Radio extends FormInternalsMixin(DataAriaLabelMixin(FormfieldWrapper)) imp
    * Read more: https://developer.mozilla.org/en-US/docs/Web/API/Event/composed
    */
   private dispatchChangeEvent(event: Event): void {
-    const EventConstructor = event.constructor as typeof Event;
-    this.dispatchEvent(new EventConstructor(event.type, event));
+    this.dispatchEvent(new Event('change', event));
   }
 
   /** @internal */


### PR DESCRIPTION
### Description

Fix radio element not firing the change event when updating the selected radio using the keyboard.

### Links

Storybook Link: https://momentum-design.github.io/momentum-design/storybook-static/index.html?path=/story/components-radiogroup--example
