### PR TITLE
fix: stop event bubbling of keydown in select popover

### DIFF
--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -399,53 +399,52 @@ class Select extends FormInternalsMixin(DataAriaLabelMixin(FormfieldWrapper)) im
    * @param event - The keyboard event.
    */
   private handlePopoverKeydown(event: KeyboardEvent): void {
+    let optionToFocus: Option | null = null;
     switch (event.key) {
       case KEYS.HOME: {
-        const firstOption = this.getFirstValidOption();
-        this.focusAndUpdateTabIndexes(firstOption);
-        event.preventDefault();
+        optionToFocus = this.getFirstValidOption();
         break;
       }
       case KEYS.END: {
-        const lastOption = this.getLastValidOption();
-        this.focusAndUpdateTabIndexes(lastOption);
-        event.preventDefault();
+        optionToFocus = this.getLastValidOption();
         break;
       }
       case KEYS.ARROW_DOWN: {
         const options = this.getAllValidOptions();
         const currentIndex = options.findIndex(option => option === event.target);
         const newIndex = Math.min(currentIndex + 1, options.length - 1);
-        this.focusAndUpdateTabIndexes(options[newIndex]);
-        event.preventDefault();
+        optionToFocus = options[newIndex];
         break;
       }
       case KEYS.ARROW_UP: {
         const options = this.getAllValidOptions();
         const currentIndex = options.findIndex(option => option === event.target);
         const newIndex = Math.max(currentIndex - 1, 0);
-        this.focusAndUpdateTabIndexes(options[newIndex]);
-        event.preventDefault();
+        optionToFocus = options[newIndex];
         break;
       }
       case KEYS.PAGE_DOWN: {
         const options = this.getAllValidOptions();
         const currentIndex = options.findIndex(option => option === event.target);
         const newIndex = Math.min(currentIndex + 10, options.length - 1);
-        this.focusAndUpdateTabIndexes(options[newIndex]);
-        event.preventDefault();
+        optionToFocus = options[newIndex];
         break;
       }
       case KEYS.PAGE_UP: {
         const options = this.getAllValidOptions();
         const currentIndex = options.findIndex(option => option === event.target);
         const newIndex = Math.max(currentIndex - 10, 0);
-        this.focusAndUpdateTabIndexes(options[newIndex]);
-        event.preventDefault();
+        optionToFocus = options[newIndex];
         break;
       }
       default:
         break;
+    }
+
+    if (optionToFocus) {
+      this.focusAndUpdateTabIndexes(optionToFocus);
+      event.preventDefault();
+      event.stopPropagation();
     }
   }
 


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- [Select] Fix an issue where keydown events in Select nested popover are bubbling
