### PR TITLE
fix(virtualizedlist): use native scroll event

### DIFF
--- a/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
@@ -21,20 +21,11 @@ import { SetListDataProps, VirtualizerProps } from './virtualizedlist.types';
  *
  * @tagname mdc-virtualizedlist
  *
- * @event onscroll - (React: onScroll) Event that gets called when user scrolls inside of list.
+ * @event scroll - (React: onScroll) Event that gets called when user scrolls inside of list.
  *
  * @slot - Client side List with nested list items.
  */
 class VirtualizedList extends Component {
-  /**
-   * Callback that gets called when user scrolls inside of list. This gives access to the scroll container element
-   * as well via the event. Particularly useful for
-   * handling logic related when the user scrolls to the top or bottom of a list.
-   * @default undefined
-   */
-  @property({ type: Function, attribute: 'onscroll' })
-  override onscroll: ((this: GlobalEventHandlers, ev: Event) => void) | null;
-
   /**
    * Object that sets and updates the virtualizer with any relevant props.
    * There are two required object props in order to get virtualization to work properly.
@@ -166,10 +157,18 @@ class VirtualizedList extends Component {
     </div>`;
   }
 
+  /**
+   * Refires the scroll event from the internal scroll container to the host element
+   */
+  private handleScroll(event: Event): void {
+    const EventConstructor = event.constructor as typeof Event;
+    this.dispatchEvent(new EventConstructor(event.type, event));
+  }
+
   public override render() {
-    return html`<div ${ref(this.scrollElementRef)} part="scroll" @scroll=${this.onscroll && this.onscroll}>
+    return html`<div ${ref(this.scrollElementRef)} part="scroll" @scroll=${this.handleScroll}>
       ${this.virtualizerController ? this.getVirtualizedListWrapper(this.virtualizerController) : html``}
-    </div> `;
+    </div>`;
   }
 
   public static override styles: Array<CSSResult> = [...Component.styles, ...styles];

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.e2e-test.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.e2e-test.ts
@@ -22,7 +22,7 @@ const setup = async (args: SetupOptions) => {
 
 test.describe('mdc-virtualizedlist', () => {
   test('default virtualized list behavior', async ({ componentsPage }) => {
-    await setup({
+    const virtualizedList = await setup({
       componentsPage,
     });
 
@@ -35,7 +35,10 @@ test.describe('mdc-virtualizedlist', () => {
 
     currentLastElement = componentsPage.page.getByRole('listitem').last();
     await currentLastElement.waitFor();
+
+    const waitForScrollEvent = await componentsPage.waitForEvent(virtualizedList, 'scroll');
     await currentLastElement.scrollIntoViewIfNeeded();
+    await waitForScrollEvent();
 
     await componentsPage.page.getByText('list item number 99').waitFor();
 

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.helper.test.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.helper.test.ts
@@ -64,7 +64,7 @@ class VirtualizedWrapper extends Component {
     return html`
       <div style="height: 500px; width: 500px;">
         <mdc-virtualizedlist
-          .onscroll=${this.onscroll}
+          @scroll=${this.onscroll}
           .virtualizerProps=${this.virtualizerProps}
           .setlistdata=${this.setListData}
           >${this.list}</mdc-virtualizedlist

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.stories.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj, Args } from '@storybook/web-components';
 import '.';
 import { html } from 'lit';
+import { action } from '@storybook/addon-actions';
 
 import { classArgType, styleArgType } from '../../../config/storybook/commonArgTypes';
 import './virtualizedlist.helper.test';
@@ -9,7 +10,7 @@ import { disableControls } from '../../../config/storybook/utils';
 const render = (args: Args) =>
   html` <mdc-virtualizedwrapper
     .virtualizerProps=${args.virtualizerProps}
-    .onscroll=${args.onscroll}
+    .onscroll=${action('scroll')}
   ></mdc-virtualizedwrapper>`;
 
 const meta: Meta = {
@@ -27,13 +28,6 @@ const meta: Meta = {
       [Tanstack Virtualizer API](https://tanstack.com/virtual/latest/docs/api/virtualizer) docs for more 
       about all possible props.`,
       control: 'object',
-    },
-    onscroll: {
-      description: `Function that gets called when user scrolls in list. 
-      Can be used to access the scroll container in order to 
-      handle scrolling logic such as user scrolls to top or bottom.`,
-      type: 'function',
-      table: { defaultValue: { summary: 'undefined' } },
     },
     setlistdata: {
       description: `A function that is passed in that when called, will udpate the state of the parent component.

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.types.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.types.ts
@@ -3,7 +3,7 @@ import { StyleInfo } from 'lit/directives/style-map.js';
 
 import type { TypedCustomEvent } from '../../utils/types';
 
-import type VirtualizedList  from './virtualizedlist.component';
+import type VirtualizedList from './virtualizedlist.component';
 
 interface SetListDataProps {
   virtualItems: Array<VirtualItem>;
@@ -11,10 +11,12 @@ interface SetListDataProps {
   listStyle: Readonly<StyleInfo>;
 }
 
+type VirtualizedListScrollEvent = TypedCustomEvent<VirtualizedList>;
+
 interface Events {
-  onScrollEvent: TypedCustomEvent<VirtualizedList>;
+  onScrollEvent: VirtualizedListScrollEvent;
 }
 
 type VirtualizerProps = Partial<VirtualizerOptions<Element, Element>>;
 
-export type { Events, VirtualizerProps, SetListDataProps };
+export type { Events, VirtualizedListScrollEvent, VirtualizerProps, SetListDataProps };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -98,6 +98,7 @@ import type {
   InputBlurEvent,
   InputClearEvent,
 } from './components/input/input.types';
+import type { VirtualizedListScrollEvent } from './components/virtualizedlist/virtualizedlist.types';
 
 // Constants / Utils Imports
 import {
@@ -215,6 +216,7 @@ export type {
   InputFocusEvent,
   InputBlurEvent,
   InputClearEvent,
+  VirtualizedListScrollEvent,
 };
 
 // Constants / Utils Exports


### PR DESCRIPTION
### Description
Update the virtualizedlist component to dispatch the scroll event instead of using an `onscroll` attribute for the listener.

**Breaking Change:** The `onscroll` attribute no longer works, use the `scroll` event. The target for the event has also changed from the internal `div` to the `virtualizedlist` element.

