### PR TITLE
fix(listitem): ensure trailing content doesn’t overlap when width shrinks

### DIFF
--- a/packages/components/src/components/listitem/listitem.styles.ts
+++ b/packages/components/src/components/listitem/listitem.styles.ts
@@ -79,9 +79,13 @@ const styles = css`
     align-items: center;
     column-gap: var(--mdc-listitem-column-gap);
     display: flex;
-    width: 100%;
+  }
+  :host::part(leading) {
+    flex: 1;
+    min-width: 0;
   }
   :host::part(trailing) {
+    flex: 0 0 auto;
     justify-content: flex-end;
   }
   :host::part(leading-text-secondary-label),


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description
When ListItem width was constrained, both leading and trailing parts were forced to width: 100%, causing trailing content to overlap and preventing proper shrink/ellipsis.

#### Fix:

- Updated layout so the leading section flexes with available space while the trailing section sizes to its content, preventing overlap.
