### PR TITLE
fix(controlled): add controlled option for menuitemcheckbox

### DIFF
--- a/packages/components/src/components/menuitemcheckbox/menuitemcheckbox.component.ts
+++ b/packages/components/src/components/menuitemcheckbox/menuitemcheckbox.component.ts
@@ -7,6 +7,7 @@ import { ROLE } from '../../utils/roles';
 import MenuItem from '../menuitem/menuitem.component';
 import { TYPE } from '../text/text.constants';
 import { TOGGLE_SIZE } from '../toggle/toggle.constants';
+import { ControlledMixin } from '../../utils/mixins/ControlledMixin';
 
 import { DEFAULTS, INDICATOR } from './menuitemcheckbox.constants';
 import type { Indicator } from './menuitemcheckbox.types';
@@ -55,7 +56,7 @@ import styles from './menuitemcheckbox.styles';
  * @event click - (React: onClick) This event is dispatched when the menuitemcheckbox is clicked.
  * @event focus - (React: onFocus) This event is dispatched when the menuitemcheckbox receives focus.
  */
-class MenuItemCheckbox extends MenuItem {
+class MenuItemCheckbox extends ControlledMixin(MenuItem) {
   /**
    * The checked attribute is used to indicate that the menuitemcheckbox is checked or not.
    * @default false
@@ -82,11 +83,14 @@ class MenuItemCheckbox extends MenuItem {
   /**
    * Handles click events to toggle checked state
    * If the menuitemcheckbox is disabled, it does nothing.
-   * If the menuitemcheckbox is not disabled, it dispatches the 'change' event.
+   * If the menuitemcheckbox is not disabled, it toggles checked if uncontrolled, and dispatches the 'change' event.
    */
   private handleMouseClick() {
     if (this.disabled) return;
 
+    if (!this.controlled) {
+      this.checked = !this.checked;
+    }
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
   }
 

--- a/packages/components/src/components/menuitemcheckbox/menuitemcheckbox.component.ts
+++ b/packages/components/src/components/menuitemcheckbox/menuitemcheckbox.component.ts
@@ -82,11 +82,10 @@ class MenuItemCheckbox extends MenuItem {
   /**
    * Handles click events to toggle checked state
    * If the menuitemcheckbox is disabled, it does nothing.
-   * If the menuitemcheckbox is not disabled, it toggles the `checked` state between `true` and `false`.
+   * If the menuitemcheckbox is not disabled, it dispatches the 'change' event.
    */
   private handleMouseClick() {
     if (this.disabled) return;
-    this.checked = !this.checked;
 
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
   }

--- a/packages/components/src/components/menuitemcheckbox/menuitemcheckbox.e2e-test.ts
+++ b/packages/components/src/components/menuitemcheckbox/menuitemcheckbox.e2e-test.ts
@@ -17,6 +17,7 @@ type SetupOptions = {
   indicator?: Indicator;
   label?: string;
   secondaryLabel?: string;
+  controlled?: boolean;
 };
 
 const setup = async (args: SetupOptions) => {
@@ -33,6 +34,7 @@ const setup = async (args: SetupOptions) => {
           ${restArgs.indicator ? `indicator="${restArgs.indicator}"` : ''}
           ${restArgs.label ? `label="${restArgs.label}"` : 'Checkbox Label'}
           ${restArgs.secondaryLabel ? `secondary-label="${restArgs.secondaryLabel}"` : ''}
+          ${restArgs.controlled ? 'controlled' : ''}
         >
         </mdc-menuitemcheckbox>
       </div>
@@ -45,214 +47,294 @@ const setup = async (args: SetupOptions) => {
   return menuitemcheckbox;
 };
 
-const expectChecked = async (checkbox: Locator) => {
-  await expect(checkbox).toHaveAttribute('aria-checked', 'true');
-  await expect(checkbox).toHaveAttribute('checked', '');
-};
-
-const expectUnchecked = async (checkbox: Locator) => {
-  await expect(checkbox).toHaveAttribute('aria-checked', 'false');
-  await expect(checkbox).not.toHaveAttribute('checked', '');
-};
-
-const expectDisabled = async (checkbox: Locator) => {
-  await expect(checkbox).toHaveAttribute('aria-disabled', 'true');
-  await expect(checkbox).toHaveAttribute('disabled', '');
-};
-
-const expectSoftDisabled = async (checkbox: Locator) => {
-  await expect(checkbox).toHaveAttribute('aria-disabled', 'true');
-  await expect(checkbox).toHaveAttribute('soft-disabled');
-};
-
-const getChangeEventFiredPromiseFunction = async (componentsPage: ComponentsPage, checkbox: Locator) =>
-  componentsPage.waitForEvent(checkbox, 'change', { timeout: 100 });
-
-const expectChangeEventNotFired = async (changeEventFiredPromiseFunction: () => Promise<JSHandle<boolean>>) => {
-  await expect(changeEventFiredPromiseFunction).rejects.toBeDefined();
-};
-
-const expectChangeEventFired = async (changeEventFiredPromiseFunction: () => Promise<JSHandle<boolean>>) =>
-  changeEventFiredPromiseFunction();
-
 test('mdc-menuitemcheckbox', async ({ componentsPage }) => {
   /**
    * FUNCTIONALITY
    */
-  await test.step('functionality', async () => {
-    // Default (unchecked) state
-    await test.step('default state (unchecked) mouse nav', async () => {
-      const checkbox = await setup({ componentsPage });
-      await expect(checkbox).toHaveAttribute('role', ROLE.MENUITEMCHECKBOX);
-      await expectUnchecked(checkbox);
+  const testFunctionality = async (controlled: boolean) => {
+    const expectChecked = async (checkbox: Locator) => {
+      await expect(checkbox).toHaveAttribute('aria-checked', 'true');
+      await expect(checkbox).toHaveAttribute('checked', '');
+      await expect(checkbox.locator('mdc-staticcheckbox')).toHaveAttribute('checked', '');
+    };
 
-      const changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
-      await checkbox.click();
-      await expectChangeEventFired(changeEventFiredPromiseFunction);
-      await expectUnchecked(checkbox);
+    const expectUnchecked = async (checkbox: Locator) => {
+      await expect(checkbox).toHaveAttribute('aria-checked', 'false');
+      await expect(checkbox).not.toHaveAttribute('checked', '');
+      await expect(checkbox.locator('mdc-staticcheckbox')).toBeVisible();
+      await expect(checkbox.locator('mdc-staticcheckbox')).not.toHaveAttribute('checked');
+    };
+
+    const expectDisabled = async (checkbox: Locator) => {
+      await expect(checkbox).toHaveAttribute('aria-disabled', 'true');
+      await expect(checkbox).toHaveAttribute('disabled', '');
+      await expect(checkbox.locator('mdc-staticcheckbox')).toHaveAttribute('disabled', '');
+    };
+
+    const expectSoftDisabled = async (checkbox: Locator) => {
+      await expect(checkbox).toHaveAttribute('aria-disabled', 'true');
+      await expect(checkbox).toHaveAttribute('soft-disabled');
+      await expect(checkbox.locator('mdc-staticcheckbox')).not.toHaveAttribute('disabled');
+    };
+
+    const getChangeEventFiredPromiseFunction = async (componentsPage: ComponentsPage, checkbox: Locator) =>
+      componentsPage.waitForEvent(checkbox, 'change', { timeout: 100 });
+
+    const expectChangeEventNotFired = async (changeEventFiredPromiseFunction: () => Promise<JSHandle<boolean>>) => {
+      await expect(changeEventFiredPromiseFunction).rejects.toBeDefined();
+    };
+
+    const expectChangeEventFired = async (changeEventFiredPromiseFunction: () => Promise<JSHandle<boolean>>) =>
+      changeEventFiredPromiseFunction();
+
+    await test.step(`functionality, controlled=${controlled}`, async () => {
+      // Default (unchecked) state
+      await test.step('default state (unchecked) mouse nav', async () => {
+        const checkbox = await setup({ componentsPage, controlled });
+        await expect(checkbox).toHaveAttribute('role', ROLE.MENUITEMCHECKBOX);
+        await expectUnchecked(checkbox);
+
+        const changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await checkbox.click();
+        await expectChangeEventFired(changeEventFiredPromiseFunction);
+        if (controlled) {
+          await expectUnchecked(checkbox);
+        } else {
+          await expectChecked(checkbox);
+        }
+      });
+
+      await test.step('default state (unchecked) keyboard nav', async () => {
+        const checkbox = await setup({ componentsPage, controlled });
+        await expect(checkbox).toHaveAttribute('role', ROLE.MENUITEMCHECKBOX);
+        await expectUnchecked(checkbox);
+        let changeEventFiredPromiseFunction: () => Promise<JSHandle<boolean>>;
+
+        await componentsPage.actionability.pressTab();
+        await expect(checkbox).toBeFocused();
+
+        changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await componentsPage.page.keyboard.press(KEYS.SPACE);
+        await expectChangeEventFired(changeEventFiredPromiseFunction);
+        if (controlled) {
+          await expectUnchecked(checkbox);
+        } else {
+          await expectChecked(checkbox);
+        }
+
+        changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await componentsPage.page.keyboard.press(KEYS.ENTER);
+        await expectChangeEventFired(changeEventFiredPromiseFunction);
+        await expectUnchecked(checkbox);
+      });
+
+      await test.step('default state (unchecked) external control', async () => {
+        const checkbox = await setup({ componentsPage, controlled });
+        await expect(checkbox).toHaveAttribute('role', ROLE.MENUITEMCHECKBOX);
+        await expectUnchecked(checkbox);
+
+        const changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await checkbox.evaluate(element => element.setAttribute('checked', ''));
+        await expectChangeEventNotFired(changeEventFiredPromiseFunction);
+        await expectChecked(checkbox);
+      });
+
+      // Checked state
+      await test.step('checked state mouse nav', async () => {
+        const checkbox = await setup({ componentsPage, controlled, checked: true });
+        await expectChecked(checkbox);
+
+        const changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await checkbox.click();
+        await expectChangeEventFired(changeEventFiredPromiseFunction);
+        if (controlled) {
+          await expectChecked(checkbox);
+        } else {
+          await expectUnchecked(checkbox);
+        }
+      });
+
+      await test.step('checked state keyboard nav', async () => {
+        const checkbox = await setup({ componentsPage, controlled, checked: true });
+        await expectChecked(checkbox);
+        let changeEventFiredPromiseFunction: () => Promise<JSHandle<boolean>>;
+
+        await componentsPage.actionability.pressTab();
+        await expect(checkbox).toBeFocused();
+
+        changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await componentsPage.page.keyboard.press(KEYS.SPACE);
+        await expectChangeEventFired(changeEventFiredPromiseFunction);
+        if (controlled) {
+          await expectChecked(checkbox);
+        } else {
+          await expectUnchecked(checkbox);
+        }
+
+        changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await componentsPage.page.keyboard.press(KEYS.ENTER);
+        await expectChangeEventFired(changeEventFiredPromiseFunction);
+        await expectChecked(checkbox);
+      });
+
+      await test.step('checked state external control', async () => {
+        const checkbox = await setup({ componentsPage, controlled, checked: true });
+        await expectChecked(checkbox);
+
+        const changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await checkbox.evaluate(element => element.removeAttribute('checked'));
+        await expectChangeEventNotFired(changeEventFiredPromiseFunction);
+        await expectUnchecked(checkbox);
+      });
+
+      // Disabled state
+      await test.step('disabled state mouse nav', async () => {
+        const checkbox = await setup({ componentsPage, controlled, disabled: true });
+        await expectDisabled(checkbox);
+        await expectUnchecked(checkbox);
+
+        // Click should not emit change event when disabled
+        const changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await checkbox.click({ force: true });
+        await expectChangeEventNotFired(changeEventFiredPromiseFunction);
+        await expectUnchecked(checkbox);
+      });
+
+      await test.step('disabled state keyboard nav', async () => {
+        const checkbox = await setup({ componentsPage, controlled, disabled: true });
+        await expectDisabled(checkbox);
+        await expectUnchecked(checkbox);
+        let changeEventFiredPromiseFunction: () => Promise<JSHandle<boolean>>;
+
+        // Disabled checkbox cannot be focussed by keyboard, but can be focussed programatically
+        await componentsPage.actionability.pressTab();
+        await expect(checkbox).not.toBeFocused();
+
+        await checkbox.focus();
+        await expect(checkbox).toBeFocused();
+
+        changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await componentsPage.page.keyboard.press(KEYS.SPACE);
+        await expectChangeEventNotFired(changeEventFiredPromiseFunction);
+        await expectUnchecked(checkbox);
+
+        changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await componentsPage.page.keyboard.press(KEYS.ENTER);
+        await expectChangeEventNotFired(changeEventFiredPromiseFunction);
+        await expectUnchecked(checkbox);
+      });
+
+      await test.step('disabled state external control', async () => {
+        const checkbox = await setup({ componentsPage, controlled, disabled: true });
+        await expectDisabled(checkbox);
+        await expectUnchecked(checkbox);
+
+        const changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await checkbox.evaluate(element => element.setAttribute('checked', ''));
+        await expectChangeEventNotFired(changeEventFiredPromiseFunction);
+        await expectChecked(checkbox);
+      });
+
+      // Soft Disabled state
+      await test.step('soft disabled state mouse nav', async () => {
+        const checkbox = await setup({ componentsPage, controlled, softDisabled: true });
+        await expectSoftDisabled(checkbox);
+        await expectUnchecked(checkbox);
+
+        // Click still emits change event and visually toggles when soft disabled
+        const changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await checkbox.click({ force: true });
+        await expectChangeEventFired(changeEventFiredPromiseFunction);
+        if (controlled) {
+          await expectUnchecked(checkbox);
+        } else {
+          await expectChecked(checkbox);
+        }
+      });
+
+      await test.step('soft disabled state keyboard nav', async () => {
+        const checkbox = await setup({ componentsPage, controlled, softDisabled: true });
+        await expectSoftDisabled(checkbox);
+        await expectUnchecked(checkbox);
+        let changeEventFiredPromiseFunction;
+
+        // Soft disabled checkbox can be focussed by keyboard
+        await componentsPage.actionability.pressTab();
+        await expect(checkbox).toBeFocused();
+
+        changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await componentsPage.page.keyboard.press(KEYS.SPACE);
+        await expectChangeEventFired(changeEventFiredPromiseFunction);
+        if (controlled) {
+          await expectUnchecked(checkbox);
+        } else {
+          await expectChecked(checkbox);
+        }
+
+        changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await componentsPage.page.keyboard.press(KEYS.ENTER);
+        await expectChangeEventFired(changeEventFiredPromiseFunction);
+        await expectUnchecked(checkbox);
+      });
+
+      await test.step('soft disabled state external control', async () => {
+        const checkbox = await setup({ componentsPage, controlled, softDisabled: true });
+        await expectSoftDisabled(checkbox);
+        await expectUnchecked(checkbox);
+
+        const changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
+        await checkbox.evaluate(element => element.setAttribute('checked', ''));
+        await expectChangeEventNotFired(changeEventFiredPromiseFunction);
+        await expectChecked(checkbox);
+      });
     });
-
-    await test.step('default state (unchecked) keyboard nav', async () => {
-      const checkbox = await setup({ componentsPage });
-      await expect(checkbox).toHaveAttribute('role', ROLE.MENUITEMCHECKBOX);
-      await expectUnchecked(checkbox);
-      let changeEventFiredPromiseFunction: () => Promise<JSHandle<boolean>>;
-
-      await componentsPage.actionability.pressTab();
-      await expect(checkbox).toBeFocused();
-
-      changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
-      await componentsPage.page.keyboard.press(KEYS.SPACE);
-      await expectChangeEventFired(changeEventFiredPromiseFunction);
-      await expectUnchecked(checkbox);
-
-      changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
-      await componentsPage.page.keyboard.press(KEYS.ENTER);
-      await expectChangeEventFired(changeEventFiredPromiseFunction);
-      await expectUnchecked(checkbox);
-    });
-
-    // Checked state
-    await test.step('checked state mouse nav', async () => {
-      const checkbox = await setup({ componentsPage, checked: true });
-      await expectChecked(checkbox);
-
-      const changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
-      await checkbox.click();
-      await expectChangeEventFired(changeEventFiredPromiseFunction);
-      await expectChecked(checkbox);
-    });
-
-    await test.step('checked state keyboard nav', async () => {
-      const checkbox = await setup({ componentsPage, checked: true });
-      await expectChecked(checkbox);
-      let changeEventFiredPromiseFunction: () => Promise<JSHandle<boolean>>;
-
-      await componentsPage.actionability.pressTab();
-      await expect(checkbox).toBeFocused();
-
-      changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
-      await componentsPage.page.keyboard.press(KEYS.SPACE);
-      await expectChangeEventFired(changeEventFiredPromiseFunction);
-      await expectChecked(checkbox);
-
-      changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
-      await componentsPage.page.keyboard.press(KEYS.ENTER);
-      await expectChangeEventFired(changeEventFiredPromiseFunction);
-      await expectChecked(checkbox);
-    });
-
-    // Disabled state
-    await test.step('disabled state mouse nav', async () => {
-      const checkbox = await setup({ componentsPage, disabled: true });
-      await expectDisabled(checkbox);
-      await expectUnchecked(checkbox);
-
-      // Click should not emit change event when disabled
-      const changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
-      await checkbox.click({ force: true });
-      await expectChangeEventNotFired(changeEventFiredPromiseFunction);
-      await expectUnchecked(checkbox);
-    });
-
-    await test.step('disabled state keyboard nav', async () => {
-      const checkbox = await setup({ componentsPage, disabled: true });
-      await expectDisabled(checkbox);
-      await expectUnchecked(checkbox);
-      let changeEventFiredPromiseFunction: () => Promise<JSHandle<boolean>>;
-
-      // Disabled checkbox cannot be focussed by keyboard, but can be focussed programatically
-      await componentsPage.actionability.pressTab();
-      await expect(checkbox).not.toBeFocused();
-
-      await checkbox.focus();
-      await expect(checkbox).toBeFocused();
-
-      changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
-      await componentsPage.page.keyboard.press(KEYS.SPACE);
-      await expectChangeEventNotFired(changeEventFiredPromiseFunction);
-      await expectUnchecked(checkbox);
-
-      changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
-      await componentsPage.page.keyboard.press(KEYS.ENTER);
-      await expectChangeEventNotFired(changeEventFiredPromiseFunction);
-      await expectUnchecked(checkbox);
-    });
-
-    // Soft Disabled state
-    await test.step('soft disabled state mouse nav', async () => {
-      const checkbox = await setup({ componentsPage, softDisabled: true });
-      await expectSoftDisabled(checkbox);
-      await expectUnchecked(checkbox);
-
-      // Click still emits change event when soft disabled
-      const changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
-      await checkbox.click({ force: true });
-      await expectChangeEventFired(changeEventFiredPromiseFunction);
-      await expectUnchecked(checkbox);
-    });
-
-    await test.step('soft disabled state keyboard nav', async () => {
-      const checkbox = await setup({ componentsPage, softDisabled: true });
-      await expectSoftDisabled(checkbox);
-      await expectUnchecked(checkbox);
-      let changeEventFiredPromiseFunction;
-
-      // Soft disabled checkbox can be focussed by keyboard
-      await componentsPage.actionability.pressTab();
-      await expect(checkbox).toBeFocused();
-
-      changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
-      await componentsPage.page.keyboard.press(KEYS.SPACE);
-      await expectChangeEventFired(changeEventFiredPromiseFunction);
-      await expectUnchecked(checkbox);
-
-      changeEventFiredPromiseFunction = await getChangeEventFiredPromiseFunction(componentsPage, checkbox);
-      await componentsPage.page.keyboard.press(KEYS.ENTER);
-      await expectChangeEventFired(changeEventFiredPromiseFunction);
-      await expectUnchecked(checkbox);
-    });
-  });
+  };
+  await testFunctionality(true);
+  await testFunctionality(false);
 
   /**
    * INDICATOR TYPES
    */
-  await test.step('indicator types', async () => {
-    // Checkbox indicator
-    await test.step('checkbox indicator, unchecked', async () => {
-      const checkbox = await setup({ componentsPage, indicator: INDICATOR.CHECKBOX });
-      await expect(checkbox.locator('mdc-staticcheckbox')).toBeVisible();
-      await expect(checkbox.locator('mdc-staticcheckbox')).not.toHaveAttribute('checked', '');
-    });
+  const testIndicatorTypes = async (controlled: boolean) => {
+    await test.step(`indicator types, controlled=${controlled}`, async () => {
+      // Checkbox indicator
+      await test.step('checkbox indicator, unchecked', async () => {
+        const checkbox = await setup({ componentsPage, controlled, indicator: INDICATOR.CHECKBOX });
+        await expect(checkbox.locator('mdc-staticcheckbox')).toBeVisible();
+        await expect(checkbox.locator('mdc-staticcheckbox')).not.toHaveAttribute('checked', '');
+      });
 
-    await test.step('checkbox indicator, checked', async () => {
-      const checkbox = await setup({ componentsPage, indicator: INDICATOR.CHECKBOX, checked: true });
-      await expect(checkbox.locator('mdc-staticcheckbox')).toHaveAttribute('checked', '');
-    });
+      await test.step('checkbox indicator, checked', async () => {
+        const checkbox = await setup({ componentsPage, controlled, indicator: INDICATOR.CHECKBOX, checked: true });
+        await expect(checkbox.locator('mdc-staticcheckbox')).toHaveAttribute('checked', '');
+      });
 
-    // Checkmark indicator
-    await test.step('checkmark indicator, unchecked', async () => {
-      const checkbox = await setup({ componentsPage, indicator: INDICATOR.CHECKMARK });
-      await expect(checkbox.locator('mdc-icon[name="check-bold"]')).not.toBeVisible();
-    });
+      // Checkmark indicator
+      await test.step('checkmark indicator, unchecked', async () => {
+        const checkbox = await setup({ componentsPage, controlled, indicator: INDICATOR.CHECKMARK });
+        await expect(checkbox.locator('mdc-icon[name="check-bold"]')).not.toBeVisible();
+      });
 
-    await test.step('checkmark indicator, checked', async () => {
-      const checkbox = await setup({ componentsPage, indicator: INDICATOR.CHECKMARK, checked: true });
-      await expect(checkbox.locator('mdc-icon[name="check-bold"]')).toBeVisible();
-    });
+      await test.step('checkmark indicator, checked', async () => {
+        const checkbox = await setup({ componentsPage, controlled, indicator: INDICATOR.CHECKMARK, checked: true });
+        await expect(checkbox.locator('mdc-icon[name="check-bold"]')).toBeVisible();
+      });
 
-    // Toggle indicator
-    await test.step('toggle indicator, unchecked', async () => {
-      const checkbox = await setup({ componentsPage, indicator: INDICATOR.TOGGLE });
-      await expect(checkbox.locator('mdc-statictoggle')).toBeVisible();
-      await expect(checkbox.locator('mdc-statictoggle')).not.toHaveAttribute('checked', '');
-    });
+      // Toggle indicator
+      await test.step('toggle indicator, unchecked', async () => {
+        const checkbox = await setup({ componentsPage, controlled, indicator: INDICATOR.TOGGLE });
+        await expect(checkbox.locator('mdc-statictoggle')).toBeVisible();
+        await expect(checkbox.locator('mdc-statictoggle')).not.toHaveAttribute('checked', '');
+      });
 
-    await test.step('toggle indicator, checked', async () => {
-      const checkbox = await setup({ componentsPage, indicator: INDICATOR.TOGGLE, checked: true });
-      await expect(checkbox.locator('mdc-statictoggle')).toHaveAttribute('checked', '');
+      await test.step('toggle indicator, checked', async () => {
+        const checkbox = await setup({ componentsPage, controlled, indicator: INDICATOR.TOGGLE, checked: true });
+        await expect(checkbox.locator('mdc-statictoggle')).toHaveAttribute('checked', '');
+      });
     });
-  });
+  };
+  await testIndicatorTypes(true);
+  await testIndicatorTypes(false);
 
   /**
    * VISUAL REGRESSION

--- a/packages/components/src/components/menuitemcheckbox/menuitemcheckbox.stories.ts
+++ b/packages/components/src/components/menuitemcheckbox/menuitemcheckbox.stories.ts
@@ -23,6 +23,8 @@ const render = (args: Args) =>
       label="${args.label}"
       indicator="${args.indicator}"
       secondary-label="${args['secondary-label']}"
+      ?controlled="${args.controlled}"
+      ?soft-disabled="${args['soft-disabled']}"
     >
       ${args.children}
     </mdc-menuitemcheckbox>`,
@@ -52,6 +54,12 @@ const meta: Meta = {
     },
     'secondary-label': {
       control: 'text',
+    },
+    controlled: {
+      control: 'boolean',
+    },
+    'soft-disabled': {
+      control: 'boolean',
     },
     ...hideControls([
       'data-aria-label',

--- a/packages/components/src/utils/mixins/ControlledMixin.ts
+++ b/packages/components/src/utils/mixins/ControlledMixin.ts
@@ -1,0 +1,21 @@
+import { LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
+
+import type { Constructor } from './index.types';
+
+export interface ControlledMixinInterface {
+  controlled: boolean;
+}
+
+export const ControlledMixin = <T extends Constructor<LitElement>>(superClass: T) => {
+  class InnerMixinClass extends superClass {
+    /**
+     * Indicates whether the component is controlled.
+     * When the component is controlled, it will not handle any interaction itself, e.g. toggling a checkbox.
+     * @default undefined
+     */
+    @property({ reflect: true, type: Boolean }) controlled?: boolean;
+  }
+  // Cast return type to your mixin's interface intersected with the superClass type
+  return InnerMixinClass as Constructor<ControlledMixinInterface> & T;
+};


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- Add 'ControlledMixin' which adds a boolean attribute 'controlled' to provide a consistent interface for controlled components.
- Add 'ControlledMixin' to MenuItemCheckbox and use controlled attribute to determine whether to toggle the checkbox on click/keyboard control
- Add tests and improve existing tests, add controlled (and soft-disabled) to story