### PR TITLE
fix(storybook): render primary story only once in storybook

### DIFF
--- a/packages/components/config/storybook/preview.jsx
+++ b/packages/components/config/storybook/preview.jsx
@@ -1,6 +1,7 @@
+import React from 'react';
 import '@momentum-design/fonts/dist/css/fonts.css';
 import '@momentum-design/tokens/dist/css/components/complete.css';
-
+import { Stories, Title, Subtitle, Primary, Description, Controls } from '@storybook/blocks';
 import { setCustomElementsManifest } from '@storybook/web-components';
 
 import customElements from '../../dist/custom-elements.json';
@@ -69,6 +70,16 @@ const preview = {
       source: {
         excludeDecorators: true,
       },
+      page: () => (
+        <>
+          <Title />
+          <Subtitle />
+          <Description />
+          <Primary />
+          <Controls sort="requiredFirst" />
+          <Stories includePrimary={false} />
+        </>
+      ),
     },
     actions: { argTypesRegex: '^on[A-Z].*' },
     backgrounds: {


### PR DESCRIPTION
### Description

Storybook automatically renders the primary story 2 times on the docs page. 
It can cause random issues for components which depends on unique ids
