### PR TITLE
fix(popover): handle popovers with empty triggerid attribute

### DIFF
--- a/packages/components/src/components/popover/popover.component.ts
+++ b/packages/components/src/components/popover/popover.component.ts
@@ -987,6 +987,8 @@ class Popover extends BackdropMixin(PreventScrollMixin(FocusTrapMixin(Component)
   };
 
   protected isEventFromTrigger(event: Event): boolean {
+    if (!this.triggerID) return false;
+
     if (event.composed) {
       return event.composedPath().some(el => (el as HTMLElement)?.id === this.triggerID);
     }


### PR DESCRIPTION
### Description

Handle popovers with empty triggerid attribute