### PR TITLE
fix: link href default fix and refactoring

### DIFF
--- a/packages/components/src/components/buttonlink/buttonlink.component.ts
+++ b/packages/components/src/components/buttonlink/buttonlink.component.ts
@@ -1,6 +1,5 @@
 import { CSSResult, html, PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 
 import Button from '../button/button.component';
 import { ButtonComponentMixin } from '../../utils/mixins/ButtonComponentMixin';
@@ -30,7 +29,7 @@ import styles from './buttonlink.styles';
  * @event keydown - (React: onKeyDown) Fired when the user presses a key while the buttonLink has focus.
  * @event focus - (React: onFocus) Fired when the buttonLink receives keyboard or mouse focus.
  * @event blur - (React: onBlur) Fired when the buttonLink loses keyboard or mouse focus.
- * 
+ *
  * @csspart anchor - The anchor element that wraps the buttonlink content.
  * @csspart prefix-icon - The prefix icon element.
  * @csspart button-text - The slot containing the buttonlink text.
@@ -100,38 +99,15 @@ class ButtonLink extends ButtonComponentMixin(Linksimple) {
     }
   }
 
-  public override render() {
+  protected override renderAnchorContent() {
     return html`
-      <a
-        class="mdc-focus-ring"
-        part="anchor"
-        href="${this.href}"
-        target="${this.target}"
-        rel="${ifDefined(this.rel)}"
-        download="${ifDefined(this.download)}"
-        ping="${ifDefined(this.ping)}"
-        hreflang="${ifDefined(this.hreflang)}"
-        type="${ifDefined(this.type)}"
-        referrerpolicy="${ifDefined(this.referrerpolicy)}"
-        aria-label="${this.dataAriaLabel ?? ''}"
-        tabindex="${this.disabled ? -1 : 0}"
-      >
-        ${this.prefixIcon
-          ? html`<mdc-icon
-              name="${this.prefixIcon as IconNames}"
-              part="prefix-icon"
-              length-unit="rem"
-            ></mdc-icon>`
-          : ''}
-        <slot @slotchange="${this.inferButtonType}" part="button-text"></slot>
-        ${this.postfixIcon
-          ? html`<mdc-icon
-              name="${this.postfixIcon as IconNames}"
-              part="postfix-icon"
-              length-unit="rem"
-            ></mdc-icon>`
-          : ''}
-      </a>
+      ${this.prefixIcon
+        ? html`<mdc-icon name="${this.prefixIcon as IconNames}" part="prefix-icon" length-unit="rem"></mdc-icon>`
+        : ''}
+      <slot @slotchange="${this.inferButtonType}" part="button-text"></slot>
+      ${this.postfixIcon
+        ? html`<mdc-icon name="${this.postfixIcon as IconNames}" part="postfix-icon" length-unit="rem"></mdc-icon>`
+        : ''}
     `;
   }
 

--- a/packages/components/src/components/link/link.component.ts
+++ b/packages/components/src/components/link/link.component.ts
@@ -1,6 +1,5 @@
 import { CSSResult, html, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { IconNameMixin } from '../../utils/mixins/IconNameMixin';
 import Linksimple from '../linksimple/linksimple.component';
@@ -26,7 +25,7 @@ import type { LinkSize } from './link.types';
  * @event keydown - (React: onKeyDown) Fired when the user presses a key while the Link has focus.
  * @event focus - (React: onFocus) Fired when the Link receives keyboard or mouse focus.
  * @event blur - (React: onBlur) Fired when the Link loses keyboard or mouse focus.
- * 
+ *
  * @csspart anchor - The anchor element that wraps the link content.
  * @csspart icon - The icon element.
  */
@@ -59,33 +58,11 @@ class Link extends IconNameMixin(Linksimple) {
     }
   }
 
-  public override render() {
-    return html`
-      <a
-        class="mdc-focus-ring"
-        part="anchor"
-        href="${this.href}"
-        target="${this.target}"
-        rel="${ifDefined(this.rel)}"
-        download="${ifDefined(this.download)}"
-        ping="${ifDefined(this.ping)}"
-        hreflang="${ifDefined(this.hreflang)}"
-        type="${ifDefined(this.type)}"
-        referrerpolicy="${ifDefined(this.referrerpolicy)}"
-        aria-label="${this.dataAriaLabel ?? ''}"
-        tabindex="${this.disabled ? -1 : 0}"
-      >
-        <slot></slot>
-        ${this.iconName
-          ? html`<mdc-icon
-              part="icon"
-              name="${this.iconName}"
-              size="${this.getIconSize()}"
-              length-unit="rem"
-            ></mdc-icon>`
-          : nothing}
-      </a>
-    `;
+  protected override renderAnchorContent() {
+    return html` <slot></slot>
+      ${this.iconName
+        ? html`<mdc-icon part="icon" name="${this.iconName}" size="${this.getIconSize()}" length-unit="rem"></mdc-icon>`
+        : nothing}`;
   }
 
   public static override styles: Array<CSSResult> = [...Linksimple.styles, ...styles];

--- a/packages/components/src/components/linksimple/linksimple.component.ts
+++ b/packages/components/src/components/linksimple/linksimple.component.ts
@@ -1,4 +1,4 @@
-import { PropertyValues, CSSResult, html} from 'lit';
+import { PropertyValues, CSSResult, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
@@ -33,7 +33,7 @@ import styles from './linksimple.styles';
  * @cssproperty --mdc-link-inverted-color-disabled - Color of the inverted link’s child content in the disabled state.
  * @cssproperty --mdc-link-inverted-color-hover - Color of the inverted link’s child content in the hover state.
  * @cssproperty --mdc-link-inverted-color-normal - Color of the inverted link’s child content in the normal state.
- * 
+ *
  * @csspart anchor - The anchor element that wraps the linksimple content.
  */
 class Linksimple extends DataAriaLabelMixin(DisabledMixin(Component)) {
@@ -53,10 +53,9 @@ class Linksimple extends DataAriaLabelMixin(DisabledMixin(Component)) {
 
   /**
    * Href for navigation. The URL that the hyperlink points to
-   * @default #
    */
   @property({ type: String, reflect: true })
-  href = '#';
+  href?: string;
 
   /**
    * Optional target: _blank, _self, _parent, _top and _unfencedTop
@@ -135,7 +134,6 @@ class Linksimple extends DataAriaLabelMixin(DisabledMixin(Component)) {
     }
   }
 
-
   public override update(changedProperties: PropertyValues): void {
     super.update(changedProperties);
     if (changedProperties.has('disabled')) {
@@ -143,10 +141,19 @@ class Linksimple extends DataAriaLabelMixin(DisabledMixin(Component)) {
     }
   }
 
+  /**
+   * Protected method to render the anchor content.
+   * Override this method to customize the content inside the anchor tag.
+   * @internal
+   */
+  protected renderAnchorContent() {
+    return html`<slot></slot>`;
+  }
+
   public override render() {
     return html`
       <a
-        class='mdc-focus-ring'
+        class="mdc-focus-ring"
         part="anchor"
         href="${this.href}"
         target="${this.target}"
@@ -159,7 +166,7 @@ class Linksimple extends DataAriaLabelMixin(DisabledMixin(Component)) {
         aria-label="${this.dataAriaLabel ?? ''}"
         tabindex="${this.disabled ? -1 : 0}"
       >
-        <slot></slot>
+        ${this.renderAnchorContent()}
       </a>
     `;
   }


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- [Link] remove the default value of `#` for href attribute, since its not valid
- [Link] internal refactoring to share code better between link simple and other components
