### PR TITLE
fix(virtualizedlist): improve virtualizedlist

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -114,7 +114,7 @@
     "@momentum-design/fonts": "workspace:*",
     "@momentum-design/icons": "workspace:*",
     "@momentum-design/tokens": "workspace:*",
-    "@tanstack/lit-virtual": "^3.11.3",
+    "@tanstack/lit-virtual": "^3.13.2",
     "lit": "^3.2.0",
     "lottie-web": "^5.12.2",
     "uuid": "^11.0.5"

--- a/packages/components/src/components/list/list.component.ts
+++ b/packages/components/src/components/list/list.component.ts
@@ -55,6 +55,7 @@ class List extends ListNavigationMixin(CaptureDestroyEventForChildElement(Compon
 
   public override role: string | null = ROLE.LIST;
 
+  /** @internal */
   protected focusWithin = false;
 
   constructor() {
@@ -118,6 +119,7 @@ class List extends ListNavigationMixin(CaptureDestroyEventForChildElement(Compon
     this.resetTabIndexes(newIndex, this.focusWithin);
   }
 
+  /** @internal */
   private handleFocusEvent = (event: FocusEvent) => {
     // If previously focused element is being removed from the DOM, ignore the focusout event
     if (event.relatedTarget === null) {

--- a/packages/components/src/components/list/list.component.ts
+++ b/packages/components/src/components/list/list.component.ts
@@ -39,36 +39,37 @@ class List extends ListNavigationMixin(CaptureDestroyEventForChildElement(Compon
    * and pressing the up arrow on the first item will focus the last item.
    * If 'false', navigation will stop at the first or last item.
    *
-   * @default ''
+   * @default 'true'
    */
   @property({ type: String, reflect: true })
   public override loop: 'true' | 'false' = DEFAULTS.LOOP;
 
   /**
    * The index of the item that should receive focus when the list is first rendered.
-   * If the index is out of bounds, the first item (index 0) will receive focus.
+   * If the index is out of bounds, the focused element will be clamped to the nearest valid index.
    *
    * @default 0
    */
   @property({ type: Number, reflect: true, attribute: 'initial-focus' })
   public override initialFocus: number = DEFAULTS.INITIAL_FOCUS;
 
+  public override role: string | null = ROLE.LIST;
+
+  protected focusWithin = false;
+
   constructor() {
     super();
 
-    this.addEventListener(LIFE_CYCLE_EVENTS.CREATED, this.handleCreatedEvent);
-    this.addEventListener(LIFE_CYCLE_EVENTS.DESTROYED, this.handleDestroyEvent);
+    this.addEventListener(LIFE_CYCLE_EVENTS.CREATED, this.handleCreatedEvent.bind(this));
+    this.addEventListener(LIFE_CYCLE_EVENTS.DESTROYED, this.handleDestroyEvent.bind(this));
+    this.addEventListener('focusin', this.handleFocusEvent);
+    this.addEventListener('focusout', this.handleFocusEvent);
+
     // This must be initialized after the destroyed event listener
     // to keep the element in the itemStore in order to move the focus correctly
     this.itemsStore = new ElementStore<ListItem>(this, {
       isValidItem: this.isValidItem,
     });
-  }
-
-  override connectedCallback(): void {
-    super.connectedCallback();
-    // Set the role attribute for accessibility.
-    this.setAttribute('role', ROLE.LIST);
   }
 
   /**
@@ -83,14 +84,14 @@ class List extends ListNavigationMixin(CaptureDestroyEventForChildElement(Compon
    *
    * @internal
    */
-  private handleCreatedEvent = (event: Event) => {
+  protected handleCreatedEvent(event: Event) {
     const createdElement = event.target as HTMLElement;
     if (!this.isValidItem(createdElement)) {
       return;
     }
 
     createdElement.tabIndex = -1;
-  };
+  }
 
   /**
    * Update the focus when an item is removed.
@@ -98,7 +99,7 @@ class List extends ListNavigationMixin(CaptureDestroyEventForChildElement(Compon
    *
    * @internal
    */
-  private handleDestroyEvent = (event: Event) => {
+  protected handleDestroyEvent(event: Event) {
     const destroyedElement = event.target as HTMLElement;
     if (!this.isValidItem(destroyedElement) || destroyedElement.tabIndex !== 0) {
       return;
@@ -114,11 +115,20 @@ class List extends ListNavigationMixin(CaptureDestroyEventForChildElement(Compon
       newIndex = destroyedItemIndex - 1;
     }
 
-    this.resetTabIndexes(newIndex);
+    this.resetTabIndexes(newIndex, this.focusWithin);
+  }
+
+  private handleFocusEvent = (event: FocusEvent) => {
+    // If previously focused element is being removed from the DOM, ignore the focusout event
+    if (event.relatedTarget === null) {
+      return;
+    }
+
+    this.focusWithin = event.type === 'focusin';
   };
 
   /** @internal */
-  private isValidItem(item: Element): boolean {
+  protected isValidItem(item: Element): boolean {
     return item.matches(`${LISTITEM_TAGNAME}:not([disabled])`);
   }
 

--- a/packages/components/src/components/list/list.stories.ts
+++ b/packages/components/src/components/list/list.stories.ts
@@ -175,9 +175,8 @@ export const ListWithRemovalElements: StoryObj = {
       }
     };
 
-    const removeLast = (event: Event) => {
-      const button = event.target as HTMLElement;
-      const items = [...button.closest('mdc-list')!.querySelectorAll('mdc-listitem')];
+    const removeLast = () => {
+      const items = [...document.querySelector('mdc-list')!.querySelectorAll('mdc-listitem')];
 
       items[items.length - 1]?.remove();
     };
@@ -200,6 +199,7 @@ export const ListWithRemovalElements: StoryObj = {
             </mdc-listitem> `,
         )}
       </mdc-list>
+      <mdc-button @click=${removeLast}>Remove Last</mdc-button>
     `;
   },
 };

--- a/packages/components/src/components/listitem/listitem.component.ts
+++ b/packages/components/src/components/listitem/listitem.component.ts
@@ -125,6 +125,9 @@ class ListItem extends DisabledMixin(TabIndexMixin(LifeCycleMixin(Component))) {
   @property({ type: Boolean, reflect: true, attribute: 'soft-disabled' })
   softDisabled?: boolean;
 
+  @property({ type: Number, reflect: true, attribute: 'data-index' })
+  dataIndex?: number;
+
   constructor() {
     super();
 
@@ -224,6 +227,10 @@ class ListItem extends DisabledMixin(TabIndexMixin(LifeCycleMixin(Component))) {
 
     if (changedProperties.has('softDisabled')) {
       this.disableSlottedChildren(this.softDisabled);
+    }
+
+    if (changedProperties.has('dataIndex')) {
+      this.ariaPosInSet = `${this.dataIndex !== undefined ? this.dataIndex + 1 : ''}`;
     }
   }
 

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
@@ -74,6 +74,8 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
 
   private hiddenIndexes: number[] = [];
 
+  private isAtBottom: boolean = false;
+
   /**
    * Create the virtualizer controller and the virtualizer instance when the component is first connected to the DOM.
    */
@@ -140,6 +142,12 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
       this.selectedIndex = Math.max(0, Math.min(this.virtualizer.options.count - 1, newSelectedIndex));
       this.requestUpdate();
       await this.updateComplete;
+
+      if (this.isAtBottom) {
+        this.scrollElementRef.value.scrollTop = this.scrollElementRef.value.scrollHeight;
+
+        return;
+      }
 
       const scrollDifference = this.scrollElementRef.value!.scrollHeight - previousScrollHeight;
       const shouldAdjustScroll =
@@ -329,6 +337,18 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
    * Refires the scroll event from the internal scroll container to the host element
    */
   private handleScroll(event: Event): void {
+    const scrollElement = this.scrollElementRef.value;
+    if (!scrollElement) {
+      // We really shouldn't get here
+      return;
+    }
+
+    if (this.virtualizer) {
+      const lastItemSize = this.virtualizer.options.estimateSize(this.virtualizer.options.count - 1);
+      this.isAtBottom =
+        scrollElement.scrollHeight - scrollElement.scrollTop <= scrollElement.clientHeight + lastItemSize;
+    }
+
     const EventConstructor = event.constructor as typeof Event;
     this.dispatchEvent(new EventConstructor(event.type, event));
   }

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
@@ -40,13 +40,17 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
 
   /**
    * Object that sets and updates the virtualizer with any relevant props.
-   * There are two required object props in order to get virtualization to work properly.
-   * count - The length of your list that you are virtualizing.
+   * There are three required object props in order to get virtualization to work properly.
+   *
+   * **count** - The length of your list that you are virtualizing.
    * As your list grows/shrinks, this component must be updated with the appropriate value
    * (Same with any other updated prop).
-   * estimateSize - A function that returns the estimated size of your items.
+   *
+   * **estimateSize** - A function that returns the estimated size of your items.
    * If your list is fixed, this will just be the size of your items.
    * If your list is dynamic, try to return approximate the size of each item.
+   *
+   * **getItemKey** - A function that returns a unique key for each item in your list based on its index.
    *
    * A full list of possible props can be in
    * [Tanstack Virtualizer API Docs](https://tanstack.com/virtual/latest/docs/api/virtualizer)
@@ -55,6 +59,14 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
   @property({ type: Object })
   virtualizerProps: VirtualizerProps = DEFAULTS.VIRTUALIZER_PROPS;
 
+  /**
+   * Disable automatic scroll anchoring when the list size changes.
+   * By default, the list will attempt to keep the same items in view when the list size changes.
+   * However, if you don't expect the list size to change often, or if you want to handle scroll anchoring yourself,
+   * you can set this prop to true to disable the automatic behavior.
+   *
+   * @default false
+   */
   @property({ type: Boolean })
   disableScrollAnchoring: boolean = false;
 
@@ -64,16 +76,43 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
 
   public scrollElementRef: Ref<HTMLDivElement> = createRef();
 
+  /**
+   * The currently selected index in the list.
+   * If keyboard navigation is being used, this will be the focused item.
+   * If the list is clicked, this will be the last clicked item.
+   * @internal
+   */
   private selectedIndex: number = this.initialFocus;
 
+  /**
+   * The key of the currently selected item.
+   * This is used to keep track where the selected item goes when the list changes size.
+   * @internal
+   */
   private selectedKey: VirtualItem['key'] | null = null;
 
+  /**
+   * The index of the first item in the current virtual items.
+   * @internal
+   */
   private firstIndex: number = 0;
 
+  /**
+   * The key of the first item in the current virtual items.
+   * @internal
+   */
   private firstKey: VirtualItem['key'] | null = null;
 
+  /**
+   * The indexes of items that are not in the current virtual items, but need to be rendered for focus purposes.
+   * @internal
+   */
   private hiddenIndexes: number[] = [];
 
+  /**
+   * Is the scroll position at the bottom of the list?
+   * @internal
+   */
   private isAtBottom: boolean = false;
 
   /**
@@ -109,6 +148,7 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
       return;
     }
 
+    // If we don't have a scroll element yet, just update the options
     if (!this.scrollElementRef.value) {
       this.virtualizer.setOptions({
         ...this.virtualizer.options,
@@ -131,6 +171,7 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
 
       const countDifference = Math.abs(this.virtualizerProps.count - oldProps.count);
 
+      // Find the new selected index based on the selected key
       const prevSelectedIndex = this.selectedIndex;
       let newSelectedIndex = this.selectedIndex;
       for (let i = prevSelectedIndex - countDifference; i <= prevSelectedIndex + countDifference; i += 1) {
@@ -140,27 +181,36 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
         }
       }
       this.selectedIndex = Math.max(0, Math.min(this.virtualizer.options.count - 1, newSelectedIndex));
+
+      // Wait for the virtualizer to finish updating before we read the new scrollHeight
       this.requestUpdate();
       await this.updateComplete;
 
       if (this.isAtBottom) {
+        // Use this method instead of using scrollToIndex to ensure that refactor in the scroll padding
         this.scrollElementRef.value.scrollTop = this.scrollElementRef.value.scrollHeight;
 
         return;
       }
 
       const scrollDifference = this.scrollElementRef.value!.scrollHeight - previousScrollHeight;
+      // If the user has focus within the list, use the selected index as the anchor point for scroll adjustment.
+      // If the user does not have focus within the list, use the first visible item as the anchor point for scroll adjustment.
       const shouldAdjustScroll =
         (this.focusWithin && prevSelectedIndex < this.selectedIndex) ||
         (!this.focusWithin && this.firstKey !== prevFirstKey);
 
       if (scrollDifference > 0 && shouldAdjustScroll) {
+        // Temporarily disable automatic scroll adjustment on item size change
         this.virtualizer.shouldAdjustScrollPositionOnItemSizeChange = () => false;
+
+        // Update the scroll position to keep the same items in view (and in roughly the same position)
         const scrollTop = previousScrollTop + scrollDifference;
         this.scrollElementRef.value!.scrollTop = scrollTop;
 
         setTimeout(() => {
-          this.virtualizer!.scrollToOffset(scrollTop, { align: 'start' });
+          // Set the scroll position again in case it was changed while the virtualizer was updating
+          this.scrollElementRef.value!.scrollTop = scrollTop;
           this.virtualizer!.shouldAdjustScrollPositionOnItemSizeChange = undefined;
         }, 0);
       }
@@ -169,6 +219,7 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
 
   /**
    * @returns The virtualizer props merged with necessary internal props.
+   * @internal
    */
   private getVirtualizerProps(): VirtualizerProps & Pick<VirtualizerOptions, 'getScrollElement'> {
     return {
@@ -180,24 +231,27 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
   }
 
   /**
-   * Sets the initial focus of the list based on the `initialFocus` prop and scrolls the item into view.
+   * Sets the initial focus of the list based on the `initial-focus` prop and scrolls the item into view.
    */
   protected override setInitialFocus(): void {
-    const instance = this.virtualizer!;
-
-    this.selectedIndex = Math.max(0, Math.min(instance.options.count - 1, this.initialFocus));
-    this.selectedKey = instance.options.getItemKey(this.selectedIndex);
-
-    instance.scrollToIndex(this.selectedIndex, { align: 'center' });
-
-    // Wait for the virtualizer to render the items before trying to scroll to the index
-    setTimeout(() => {
-      const selectedElement = this.navItems.find(
-        item => this.virtualizer?.indexFromElement(item) === this.selectedIndex,
-      );
-      if (selectedElement) {
-        selectedElement.tabIndex = 0;
+    setTimeout(async () => {
+      if (!this.virtualizer) {
+        return;
       }
+
+      this.selectedIndex = Math.max(0, Math.min(this.virtualizer.options.count - 1, this.initialFocus));
+      this.selectedKey = this.virtualizer.options.getItemKey(this.selectedIndex);
+
+      this.virtualizer.scrollToIndex(this.selectedIndex, { align: 'center' });
+
+      setTimeout(() => {
+        const selectedElement = this.navItems.find(
+          item => this.virtualizer?.indexFromElement(item) === this.selectedIndex,
+        );
+        if (selectedElement) {
+          selectedElement.tabIndex = 0;
+        }
+      }, 1);
     }, 0);
   }
 
@@ -207,6 +261,13 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
     this.fireVirtualItemsChangeEvent();
   }
 
+  /**
+   * Fires the `virtualItemsChange` event with the current virtual items and a measureElement function.
+   * This is used to inform the parent component of the current virtual items
+   *
+   * @param instance - The virtualizer instance to get the virtual items from. Defaults to the internal virtualizer.
+   * @internal
+   */
   private fireVirtualItemsChangeEvent(instance: Virtualizer = this.virtualizer!): void {
     const virtualItems = instance.getVirtualItems();
 
@@ -220,6 +281,15 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
     );
   }
 
+  /**
+   * Provides the element to the virtualizer to measure its size.
+   * In addition if the element is one of the hidden indexes, it moves the element to the correct position for focus purposes.
+   * This means that we can use the browser's own 'scroll on focus' behaviour to refocus the list item when focus is updated.
+   *
+   * @param instance - The virtualizer instance
+   * @param el - The element to measure
+   * @internal
+   */
   private handleMeasureElement = (instance: Virtualizer, el: Element | undefined) => {
     const element = el as HTMLElement | undefined;
     instance.measureElement(element);
@@ -235,6 +305,8 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
       const virtualItems = instance.getVirtualItems();
       const actualItems = virtualItems.filter(({ index }) => !this.hiddenIndexes.includes(index));
 
+      // The scroll element is positioned based on the first item's offset therefore we need to set the location of the
+      // hidden item based on the first actual item.
       const { start } = virtualItems.find(({ index }) => index === elementIndex) ?? {};
       const offset = (start ?? 0) - (actualItems[0]?.start ?? 0);
 
@@ -251,6 +323,7 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
    *
    * @param instance - The virtualizer instance
    * @param sync - Whether the virtualizer is scrolling
+   * @internal
    */
   protected handleOnChange = (instance: Virtualizer, sync: boolean) => {
     // Request an update, this is in Tanstack's VirtualizerController but gets overridden when updating the
@@ -261,11 +334,12 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
   };
 
   /**
-   * Calculates the array of indexes to render. We add the selected index if it's
-   * outside the current range so it can be focused.
+   * Calculates the array of indexes to render. We add the selected index (and +1/-1) if it's
+   * outside the current range so the focus can be kept correctly.
    *
    * @param range - The current range of items being rendered
    * @returns An array of indexes to render, including the selected index if it's outside the current range.
+   * @internal
    */
   protected virtualizerRangeExtractor = (range: Range): number[] => {
     const defaultIndexes = this.virtualizerProps.rangeExtractor?.(range) ?? defaultRangeExtractor(range);
@@ -316,6 +390,7 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
     this.setSelectedIndex(newIndex);
   }
 
+  /** @internal */
   private setSelectedIndex(navItemIndex: number): void {
     if (!this.virtualizer) {
       return;
@@ -329,12 +404,17 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
     }
   }
 
+  /** @internal */
   private setAriaSetSize(element: HTMLElement): void {
     element.setAttribute('aria-setsize', `${this.virtualizer?.options.count ?? -1}`);
   }
 
   /**
-   * Refires the scroll event from the internal scroll container to the host element
+   * Refires the scroll event from the internal scroll container to the host element.
+   * Also updates whether the scroll is at the bottom of the list for scroll anchoring purposes.
+   *
+   * @param event - The scroll event from the internal scroll container.
+   * @internal
    */
   private handleScroll(event: Event): void {
     if (this.scrollElementRef.value && this.virtualizer) {

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
@@ -424,10 +424,8 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
   private handleScroll(event: Event): void {
     if (this.scrollElementRef.value && this.virtualizer) {
       const scrollElement = this.scrollElementRef.value;
-      const lastItemSize = this.virtualizer.options.estimateSize(this.virtualizer.options.count - 1);
 
-      this.isAtBottom =
-        scrollElement.scrollHeight - scrollElement.scrollTop <= scrollElement.clientHeight + lastItemSize / 2;
+      this.isAtBottom = scrollElement.scrollHeight - scrollElement.scrollTop <= scrollElement.clientHeight + 50;
     }
 
     const EventConstructor = event.constructor as typeof Event;

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
@@ -337,14 +337,10 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
    * Refires the scroll event from the internal scroll container to the host element
    */
   private handleScroll(event: Event): void {
-    const scrollElement = this.scrollElementRef.value;
-    if (!scrollElement) {
-      // We really shouldn't get here
-      return;
-    }
-
-    if (this.virtualizer) {
+    if (this.scrollElementRef.value && this.virtualizer) {
+      const scrollElement = this.scrollElementRef.value;
       const lastItemSize = this.virtualizer.options.estimateSize(this.virtualizer.options.count - 1);
+
       this.isAtBottom =
         scrollElement.scrollHeight - scrollElement.scrollTop <= scrollElement.clientHeight + lastItemSize;
     }

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
@@ -326,6 +326,11 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
    * @internal
    */
   protected handleOnChange = (instance: Virtualizer, sync: boolean) => {
+    // If we are at the bottom of the list and not scrolling, keep us at the bottom of the list.
+    if (!sync && this.isAtBottom && this.scrollElementRef.value) {
+      this.scrollElementRef.value.scrollTop = this.scrollElementRef.value.scrollHeight;
+    }
+
     // Request an update, this is in Tanstack's VirtualizerController but gets overridden when updating the
     // virtualizer's options therefore we need to call it here ourselves.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -422,7 +427,7 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
       const lastItemSize = this.virtualizer.options.estimateSize(this.virtualizer.options.count - 1);
 
       this.isAtBottom =
-        scrollElement.scrollHeight - scrollElement.scrollTop <= scrollElement.clientHeight + lastItemSize;
+        scrollElement.scrollHeight - scrollElement.scrollTop <= scrollElement.clientHeight + lastItemSize / 2;
     }
 
     const EventConstructor = event.constructor as typeof Event;

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
@@ -1,31 +1,43 @@
-import { CSSResult, PropertyValues, TemplateResult, html } from 'lit';
+import { type CSSResult, type PropertyValues, type TemplateResult, html } from 'lit';
 import { VirtualizerController } from '@tanstack/lit-virtual';
 import { property } from 'lit/decorators.js';
-import { Virtualizer, VirtualItem } from '@tanstack/virtual-core';
-import { StyleInfo } from 'lit/directives/style-map.js';
-import { Ref, createRef, ref } from 'lit/directives/ref.js';
+import { defaultRangeExtractor, type Range, type VirtualItem } from '@tanstack/virtual-core';
+import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
+import { type Ref, createRef, ref } from 'lit/directives/ref.js';
 
-import { Component } from '../../models';
+import List from '../list/list.component';
+import { DataAriaLabelMixin } from '../../utils/mixins/DataAriaLabelMixin';
 
 import styles from './virtualizedlist.styles';
 import { DEFAULTS } from './virtualizedlist.constants';
-import { SetListDataProps, VirtualizerProps } from './virtualizedlist.types';
+import type { VirtualizerProps, VirtualizerOptions, Virtualizer } from './virtualizedlist.types';
 
 /**
- * `mdc-virtualizedlist` component for creating custom virtualized lists.
- * IMPORTANT: This component does not create it's own list/list items.
- * Use the setlistdata callback prop to update client state in order to
- * Pass list/listitems as a child of this component, which this will virtuailze
- * This implementation handles dynamic lists as well as fixed sized lists.
+ * `mdc-virtualizedlist` is an extension of the `mdc-list` component that adds virtualization capabilities using the Tanstack Virtual library.
+ *
+ * `virtualizerProps` is a required prop that requires at least two properties to be set: `count` and `estimateSize`.
+ * `count` is the total number of items in the list, and `estimateSize` is a function that returns the estimated size (in pixels) of each item in the list.
+ *
+ * The `virtualItemsChange` event provides the current virtual items and a measureElement function to help with dynamic sizing.
+ * This should be listened to in order to render the correct virtualized items.
+ *
  * Please refer to [Tanstack Virtual Docs](https://tanstack.com/virtual/latest) for more in depth documentation.
+ *
+ * To add a header to the list, use the `mdc-listheader` component and place it in the `list-header` slot.
  *
  * @tagname mdc-virtualizedlist
  *
  * @event scroll - (React: onScroll) Event that gets called when user scrolls inside of list.
+ * @event virtualItemsChange - (React: onVirtualItemsChange) Event that gets called when the virtual items change.
  *
- * @slot - Client side List with nested list items.
+ * @slot default - This is a default/unnamed slot, where listitems can be placed.
+ * @slot list-header - This slot is used to pass a header for the list, which can be a `mdc-listheader` component.
  */
-class VirtualizedList extends Component {
+class VirtualizedList extends DataAriaLabelMixin(List) {
+  public override loop: 'true' | 'false' = 'false';
+
+  public override role: string | null = null;
+
   /**
    * Object that sets and updates the virtualizer with any relevant props.
    * There are two required object props in order to get virtualization to work properly.
@@ -40,39 +52,36 @@ class VirtualizedList extends Component {
    * [Tanstack Virtualizer API Docs](https://tanstack.com/virtual/latest/docs/api/virtualizer)
    *
    */
-  @property({ type: Object, attribute: 'virtualizerprops' })
+  @property({ type: Object })
   virtualizerProps: VirtualizerProps = DEFAULTS.VIRTUALIZER_PROPS;
 
-  /**
-   * Callback that gets envoked when updates to the virtualizer interally occur.
-   * This must be implemented in such a way that this function will trigger update to parent.
-   *
-   * virtualItems - Array that will be what the client displays on screen. Use this to render
-   * a List of your choosing with these items nested inside as your ListItems.
-   * measureElement - Ref to pass to each ListItem rendered client side.
-   * Each ListItem should also be be passed key and a data-index (which can be found on the virtualItem).
-   * listStyle - This should be passed as the style attribute to your List.
-   */
-  @property({ type: Function, attribute: 'setlistdata' })
-  setlistdata: (({ virtualItems, measureElement, listStyle }: SetListDataProps) => void) | null;
+  @property({ type: Boolean })
+  disableScrollAnchoring: boolean = false;
 
-  /**
-   * @internal
-   */
-  private virtualizerController: VirtualizerController<Element, Element> | null;
+  private virtualizerController: VirtualizerController<Element, Element> | null = null;
+
+  public virtualizer: Virtualizer | null = null;
 
   public scrollElementRef: Ref<HTMLDivElement> = createRef();
 
-  public virtualizer: Virtualizer<Element, Element> | null;
+  private selectedIndex: number = this.initialFocus;
 
-  public virtualItems: Array<VirtualItem> = [];
+  private selectedKey: VirtualItem['key'] | null = null;
 
-  constructor() {
-    super();
-    this.virtualizerController = null;
-    this.virtualizer = null;
-    this.setlistdata = null;
-    this.onscroll = null;
+  private firstIndex: number = 0;
+
+  private firstKey: VirtualItem['key'] | null = null;
+
+  private hiddenIndexes: number[] = [];
+
+  /**
+   * Create the virtualizer controller and the virtualizer instance when the component is first connected to the DOM.
+   */
+  public override connectedCallback(): void {
+    this.virtualizerController = new VirtualizerController(this, this.getVirtualizerProps());
+    this.virtualizer = this.virtualizerController.getVirtualizer();
+
+    super.connectedCallback();
   }
 
   /**
@@ -80,81 +89,240 @@ class VirtualizedList extends Component {
    * if the client updates any props (most commonly, count). Updating the options
    * this way ensures we don't initialize a new virtualizer upon very prop change.
    */
-  public override update(changedProperties: PropertyValues): void {
+  public override update(changedProperties: PropertyValues<this>): void {
     super.update(changedProperties);
 
-    if (changedProperties.get('virtualizerProps')) {
-      this.setVirtualizerOptions();
+    if (changedProperties.has('virtualizerProps')) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.setVirtualizerOptions(changedProperties.get('virtualizerProps'));
     }
   }
 
   /**
-   * This is needed in order to ensure the initial render happens
-   */
-  public override firstUpdated(changedProperties: PropertyValues): void {
-    super.firstUpdated(changedProperties);
-    this.setVirtualizerOptions();
-  }
-
-  /**
+   * Update virtualizer with the union of the two virtualizer options (current, passed in).
    * @internal
-   * Update virtuailzer with the union of the two virtualizer options (current, passed in).
    */
-  private setVirtualizerOptions(): void {
-    this.virtualizer?.setOptions({ ...this.virtualizer.options, ...this.virtualizerProps });
-    this.requestUpdate();
-  }
+  private async setVirtualizerOptions(oldProps: VirtualizerProps | undefined): Promise<void> {
+    if (!this.virtualizer) {
+      return;
+    }
 
-  public override connectedCallback(): void {
-    this.virtualizerController = new VirtualizerController(this, {
-      count: this.virtualizerProps.count!,
-      estimateSize: this.virtualizerProps?.estimateSize!,
-      getScrollElement: () => this.scrollElementRef.value || null,
-      ...this.virtualizerProps,
+    if (!this.scrollElementRef.value) {
+      this.virtualizer.setOptions({
+        ...this.virtualizer.options,
+        ...this.getVirtualizerProps(),
+      });
+
+      return;
+    }
+
+    const prevFirstKey = this.firstKey;
+    const previousScrollTop = this.scrollElementRef.value.scrollTop;
+    const previousScrollHeight = this.scrollElementRef.value.scrollHeight;
+    this.virtualizer.setOptions({
+      ...this.virtualizer.options,
+      ...this.getVirtualizerProps(),
     });
 
-    super.connectedCallback();
+    if (!this.disableScrollAnchoring && oldProps && this.virtualizerProps.count !== oldProps.count) {
+      this.navItems.forEach(this.setAriaSetSize.bind(this));
+
+      const countDifference = Math.abs(this.virtualizerProps.count - oldProps.count);
+
+      const prevSelectedIndex = this.selectedIndex;
+      let newSelectedIndex = this.selectedIndex;
+      for (let i = prevSelectedIndex - countDifference; i <= prevSelectedIndex + countDifference; i += 1) {
+        if (this.virtualizer.options.getItemKey(i) === this.selectedKey) {
+          newSelectedIndex = i;
+          break;
+        }
+      }
+      this.selectedIndex = Math.max(0, Math.min(this.virtualizer.options.count - 1, newSelectedIndex));
+      this.requestUpdate();
+      await this.updateComplete;
+
+      const scrollDifference = this.scrollElementRef.value!.scrollHeight - previousScrollHeight;
+      const shouldAdjustScroll =
+        (this.focusWithin && prevSelectedIndex < this.selectedIndex) ||
+        (!this.focusWithin && this.firstKey !== prevFirstKey);
+
+      if (scrollDifference > 0 && shouldAdjustScroll) {
+        this.virtualizer.shouldAdjustScrollPositionOnItemSizeChange = () => false;
+        const scrollTop = previousScrollTop + scrollDifference;
+        this.scrollElementRef.value!.scrollTop = scrollTop;
+
+        setTimeout(() => {
+          this.virtualizer!.scrollToOffset(scrollTop, { align: 'start' });
+          this.virtualizer!.shouldAdjustScrollPositionOnItemSizeChange = undefined;
+        }, 0);
+      }
+    }
   }
 
   /**
-   * @internal
-   * Renders the list wrapper and invokes the callback which eventually will render in the slot.
-   * Uses getTotalSize to update the height of the wrapper. This value is equal to the total size
-   * OR the total estimated size (if you haven't physically scrolled the entire list)
-   * Passes the virtualItems, measureElement, and listStyle to callback for client to pass in as child
-   *
-   * @returns The template result containing the list wrapper.
+   * @returns The virtualizer props merged with necessary internal props.
    */
-  private getVirtualizedListWrapper(virtualizerController: VirtualizerController<Element, Element>): TemplateResult {
-    this.virtualizer = virtualizerController.getVirtualizer();
+  private getVirtualizerProps(): VirtualizerProps & Pick<VirtualizerOptions, 'getScrollElement'> {
+    return {
+      ...this.virtualizerProps,
+      getScrollElement: () => this.scrollElementRef.value || null,
+      onChange: this.handleOnChange,
+      rangeExtractor: this.virtualizerRangeExtractor,
+    };
+  }
 
-    const { getTotalSize, getVirtualItems, measureElement } = this.virtualizer;
+  /**
+   * Sets the initial focus of the list based on the `initialFocus` prop and scrolls the item into view.
+   */
+  protected override setInitialFocus(): void {
+    const instance = this.virtualizer!;
 
-    const newVirtualItems = getVirtualItems();
+    this.selectedIndex = Math.max(0, Math.min(instance.options.count - 1, this.initialFocus));
+    this.selectedKey = instance.options.getItemKey(this.selectedIndex);
 
-    // Only update client if there's a difference in virtual items
-    if (newVirtualItems !== this.virtualItems) {
-      this.virtualItems = newVirtualItems;
+    instance.scrollToIndex(this.selectedIndex, { align: 'center' });
 
-      const virtualItems = getVirtualItems();
-      // this style is required to be rendered by the client side list in order to handle scrolling properly
-      const listStyle: Readonly<StyleInfo> = {
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        width: '100%',
-        transform: `translateY(${virtualItems[0]?.start ?? 0}px)`,
-      };
-
-      // pass back data to client for rendering
-      if (this.setlistdata) {
-        this.setlistdata({ virtualItems, measureElement, listStyle });
+    // Wait for the virtualizer to render the items before trying to scroll to the index
+    setTimeout(() => {
+      const selectedElement = this.navItems.find(
+        item => this.virtualizer?.indexFromElement(item) === this.selectedIndex,
+      );
+      if (selectedElement) {
+        selectedElement.tabIndex = 0;
       }
+    }, 0);
+  }
+
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    super.willUpdate(changedProperties);
+
+    this.fireVirtualItemsChangeEvent();
+  }
+
+  private fireVirtualItemsChangeEvent(instance: Virtualizer = this.virtualizer!): void {
+    const virtualItems = instance.getVirtualItems();
+
+    const eventDetails = {
+      virtualItems,
+      measureElement: (el: Element | undefined) => this.handleMeasureElement(instance, el),
+    };
+
+    this.dispatchEvent(
+      new CustomEvent('virtualItemsChange', { detail: eventDetails, bubbles: false, cancelable: false }),
+    );
+  }
+
+  private handleMeasureElement = (instance: Virtualizer, el: Element | undefined) => {
+    const element = el as HTMLElement | undefined;
+    instance.measureElement(element);
+
+    if (!element) {
+      return;
     }
 
-    return html`<div part="container" style="height: ${getTotalSize()}px;">
-      <slot></slot>
-    </div>`;
+    const elementIndex = instance.indexFromElement(element);
+    if (this.hiddenIndexes.includes(elementIndex)) {
+      element.setAttribute('data-virtualized-hidden', 'true');
+
+      const virtualItems = instance.getVirtualItems();
+      const actualItems = virtualItems.filter(({ index }) => !this.hiddenIndexes.includes(index));
+
+      const { start } = virtualItems.find(({ index }) => index === elementIndex) ?? {};
+      const offset = (start ?? 0) - (actualItems[0]?.start ?? 0);
+
+      element.style.setProperty('--mdc-virtualizedlist-hidden-top', `${offset}px`);
+    } else {
+      element.removeAttribute('data-virtualized-hidden');
+      element.style.removeProperty('--mdc-virtualizedlist-hidden-top');
+    }
+  };
+
+  /**
+   * Handle the virtualizer's onChange event to emit the virtualItemsChange event
+   * This is called when the internal state of the virtualizer changes.
+   *
+   * @param instance - The virtualizer instance
+   * @param sync - Whether the virtualizer is scrolling
+   */
+  protected handleOnChange = (instance: Virtualizer, sync: boolean) => {
+    // Request an update, this is in Tanstack's VirtualizerController but gets overridden when updating the
+    // virtualizer's options therefore we need to call it here ourselves.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.updateComplete.then(() => this.requestUpdate());
+    this.virtualizerProps.onChange?.(instance, sync);
+  };
+
+  /**
+   * Calculates the array of indexes to render. We add the selected index if it's
+   * outside the current range so it can be focused.
+   *
+   * @param range - The current range of items being rendered
+   * @returns An array of indexes to render, including the selected index if it's outside the current range.
+   */
+  protected virtualizerRangeExtractor = (range: Range): number[] => {
+    const defaultIndexes = this.virtualizerProps.rangeExtractor?.(range) ?? defaultRangeExtractor(range);
+
+    this.firstIndex = range.startIndex;
+    this.firstKey = this.virtualizer?.options.getItemKey(this.firstIndex) ?? null;
+    this.hiddenIndexes = [];
+
+    const stickyIndexes = [this.selectedIndex - 1, this.selectedIndex, this.selectedIndex + 1];
+
+    stickyIndexes.forEach(index => {
+      if (!defaultIndexes.includes(index)) {
+        if (index < range.startIndex && index >= 0) {
+          defaultIndexes.unshift(index);
+        }
+
+        if (index > range.endIndex && index < (this.virtualizer?.options.count ?? 0)) {
+          defaultIndexes.push(index);
+        }
+
+        this.hiddenIndexes.push(index);
+      }
+    });
+
+    defaultIndexes.sort((a, b) => a - b);
+
+    return defaultIndexes;
+  };
+
+  protected override handleCreatedEvent(event: Event): void {
+    super.handleCreatedEvent(event);
+
+    const element = event.target as HTMLElement;
+    if (!this.isValidItem(element)) {
+      return;
+    }
+
+    this.setAriaSetSize(element);
+  }
+
+  protected override resetTabIndexes(index: number, focusElement = true): void {
+    super.resetTabIndexes(index, focusElement);
+    this.setSelectedIndex(index);
+  }
+
+  protected override resetTabIndexAndSetFocus(newIndex: number, oldIndex?: number, focusNewItem?: boolean): void {
+    super.resetTabIndexAndSetFocus(newIndex, oldIndex, focusNewItem);
+    this.setSelectedIndex(newIndex);
+  }
+
+  private setSelectedIndex(navItemIndex: number): void {
+    if (!this.virtualizer) {
+      return;
+    }
+
+    const node = this.navItems[navItemIndex];
+    if (node) {
+      const virtualizedIndex = this.virtualizer.indexFromElement(node) ?? -1;
+      this.selectedIndex = virtualizedIndex;
+      this.selectedKey = this.virtualizer.options.getItemKey(virtualizedIndex);
+    }
+  }
+
+  private setAriaSetSize(element: HTMLElement): void {
+    element.setAttribute('aria-setsize', `${this.virtualizer?.options.count ?? -1}`);
   }
 
   /**
@@ -165,13 +333,48 @@ class VirtualizedList extends Component {
     this.dispatchEvent(new EventConstructor(event.type, event));
   }
 
-  public override render() {
-    return html`<div ${ref(this.scrollElementRef)} part="scroll" @scroll=${this.handleScroll}>
-      ${this.virtualizerController ? this.getVirtualizedListWrapper(this.virtualizerController) : html``}
+  /**
+   * Renders the virtualized list wrapper that contains the necessary divs
+   *
+   * @returns The template result containing the list wrapper.
+   * @internal
+   */
+  private getVirtualizedListWrapper(): TemplateResult {
+    if (!this.virtualizer) {
+      return html``;
+    }
+
+    const { getVirtualItems, getTotalSize } = this.virtualizer;
+
+    const items = getVirtualItems();
+
+    const containerStyles: Readonly<StyleInfo> = {
+      height: `${getTotalSize()}px`,
+    };
+
+    const transformAnchorIndex = items.findIndex(({ index }) => !this.hiddenIndexes.includes(index));
+
+    const listStyle: Readonly<StyleInfo> = {
+      transform: `translateY(${items[transformAnchorIndex]?.start ?? 0}px)`,
+    };
+
+    return html`<div part="wrapper" style="${styleMap(containerStyles)}">
+      <div part="container" style="${styleMap(listStyle)}" role="list" aria-label="${this.dataAriaLabel ?? ''}">
+        <slot role="presentation"></slot>
+      </div>
     </div>`;
   }
 
-  public static override styles: Array<CSSResult> = [...Component.styles, ...styles];
+  public override render() {
+    return html`
+      <slot name="list-header"></slot>
+      <div ${ref(this.scrollElementRef)} part="scroll" @scroll=${this.handleScroll} tabindex="-1">
+        ${this.getVirtualizedListWrapper()}
+      </div>
+    `;
+  }
+
+  public static override styles: Array<CSSResult> = [...List.styles, ...styles];
 }
 
 export default VirtualizedList;

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
@@ -327,7 +327,7 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
    */
   protected handleOnChange = (instance: Virtualizer, sync: boolean) => {
     // If we are at the bottom of the list and not scrolling, keep us at the bottom of the list.
-    if (!sync && this.isAtBottom && this.scrollElementRef.value) {
+    if (!sync && this.isAtBottom && this.scrollElementRef.value && !this.disableScrollAnchoring) {
       this.scrollElementRef.value.scrollTop = this.scrollElementRef.value.scrollHeight;
     }
 

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.constants.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.constants.ts
@@ -7,6 +7,7 @@ const DEFAULTS = {
   VIRTUALIZER_PROPS: {
     count: 0,
     estimateSize: () => 0,
+    getItemKey: (index: number) => index,
   },
 } as const;
 

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.e2e-test.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.e2e-test.ts
@@ -163,7 +163,7 @@ test('mdc-virtualizedlist', async ({ componentsPage }) => {
     };
 
     const BUTTONS = [
-      'Add 5 to Top',
+      'Add 5 At Top',
       'Add Above',
       'Add Below',
       'Add Last',
@@ -327,28 +327,6 @@ test('mdc-virtualizedlist', async ({ componentsPage }) => {
         await expect(outsideListRemoveLastButton).toBeFocused();
         await componentsPage.actionability.pressShiftTab();
         await expect(buttonLocator(virtualizedList, 6, 'Remove Below')).toBeFocused();
-      });
-
-      await test.step('remove above', async () => {
-        const { virtualizedList, listItemCounter } = await setupAndFocusInList();
-
-        await componentsPage.page.keyboard.press('ArrowDown');
-        await componentsPage.page.keyboard.press('ArrowDown');
-        const removeAboveButton = await tabToListItemButton(virtualizedList, 2, 'Remove Above');
-        await removeAboveButton.press('Enter');
-        await expect(listItemCounter).toHaveText('9');
-        // Focus should remain on the button - the item above has been removed so index - 1
-        await expect(buttonLocator(virtualizedList, 1, 'Remove Above')).toBeFocused();
-      });
-
-      await test.step('remove below', async () => {
-        const { virtualizedList, listItemCounter } = await setupAndFocusInList();
-
-        await componentsPage.page.keyboard.press('ArrowDown');
-        const removeBelowButton = await tabToListItemButton(virtualizedList, 1, 'Remove Below');
-        await removeBelowButton.press('Enter');
-        await expect(listItemCounter).toHaveText('9');
-        await expect(removeBelowButton).toBeFocused();
       });
     });
   });

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.helper.test.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.helper.test.ts
@@ -166,8 +166,6 @@ class VirtualizedDynamicList extends Component {
 
   counter = 9;
 
-  private virtualizerRef: Ref<VirtualizedList> = createRef();
-
   protected override update(changedProperties: PropertyValues): void {
     super.update(changedProperties);
 
@@ -237,7 +235,6 @@ class VirtualizedDynamicList extends Component {
     return html`
       <div id="VirtualizedDynamicList--wrapper">
         <mdc-virtualizedlist
-          ${ref(this.virtualizerRef)}
           .virtualizerProps=${this.virtualizerProps}
           @virtualItemsChange=${this.handleVirtualItemsChange}
         >

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.helper.test.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.helper.test.ts
@@ -1,22 +1,40 @@
-import { CSSResult, PropertyValues, TemplateResult, html } from 'lit';
+// eslint-disable-next-line max-classes-per-file
+import { CSSResult, PropertyValues, TemplateResult, css, html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { VirtualItem } from '@tanstack/virtual-core';
-import { ref } from 'lit/directives/ref.js';
+import { createRef, ref, type Ref } from 'lit/directives/ref.js';
+import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { Component } from '../../models';
 
-import { SetListDataProps, VirtualizerProps } from './virtualizedlist.types';
+import '../list';
+import '../listitem';
+import '../button';
+import '../buttongroup';
+import '../avatar';
+import '../textarea';
+import type VirtualizedList from './virtualizedlist.component';
+import { VirtualizerProps, type VirtualizedListVirtualItemsChangeEvent } from './virtualizedlist.types';
 
 class VirtualizedWrapper extends Component {
   @property({ type: Function, attribute: 'onscroll' })
   override onscroll: ((this: GlobalEventHandlers, ev: Event) => void) | null;
 
   @property({ type: Object, attribute: 'virtualizerprops' })
-  virtualizerProps: VirtualizerProps = { count: 100, estimateSize: () => 100, overscan: 60 };
+  virtualizerProps: VirtualizerProps = { count: 100, estimateSize: () => 100, getItemKey: index => index };
+
+  @property({ type: String })
+  story: 'text' | 'interactive' | 'dynamic' = 'text';
+
+  @property({ type: String, reflect: true })
+  loop: 'true' | 'false' = 'false';
+
+  @property({ type: Number, reflect: true, attribute: 'initial-focus' })
+  initialFocus: number = 0;
 
   @state()
-  list: TemplateResult<1> = html``;
+  virtualData: VirtualizedListVirtualItemsChangeEvent['detail'] = { virtualItems: [], measureElement: () => null };
 
   @state()
   listItemTexts = new Array(this.virtualizerProps.count).fill(true).map((_, index) => `list item number ${index}`);
@@ -24,12 +42,12 @@ class VirtualizedWrapper extends Component {
   constructor() {
     super();
     this.onscroll = null;
-    this.setListData = this.setListData.bind(this);
   }
 
   public override update(changedProperties: PropertyValues) {
     super.update(changedProperties);
-    if (changedProperties.get('virtualizerProps')) {
+
+    if (changedProperties.has('virtualizerProps')) {
       this.updateListItemTextArray();
     }
   }
@@ -47,39 +65,589 @@ class VirtualizedWrapper extends Component {
       .map((_, index) => `list item number ${index}`);
   }
 
-  private setListData({ virtualItems, measureElement, listStyle }: SetListDataProps) {
-    if (virtualItems) {
-      this.list = html`<ul style="margin: 0;${styleMap(listStyle)}">
-        ${virtualItems.map(
-          (virtualItem: VirtualItem) =>
-            html`<li role="listitem" key=${virtualItem.key} data-index=${virtualItem.index} ref=${ref(measureElement)}>
-              ${this.listItemTexts[virtualItem.index]}
-            </li>`,
-        )}
-      </ul>`;
+  private renderItem(index: number) {
+    if (this.story === 'text') {
+      return html`<mdc-listitem
+        data-index=${index}
+        ref=${ref(this.virtualData.measureElement)}
+        label="${this.listItemTexts[index]}"
+      ></mdc-listitem> `;
     }
+    if (this.story === 'interactive') {
+      return html`
+        <mdc-listitem data-index=${index} ${ref(this.virtualData.measureElement)}>
+          <span slot="leading-text-primary-label">${this.listItemTexts[index]}</span>
+          <mdc-button
+            slot="trailing-controls"
+            color="positive"
+            prefix-icon="data-range-selection-bold"
+            aria-label="mock label"
+          ></mdc-button>
+          <mdc-button slot="trailing-controls" variant="tertiary">Learn More</mdc-button>
+        </mdc-listitem>
+      `;
+    }
+    if (this.story === 'dynamic') {
+      return html`
+        <mdc-listitem
+          data-index=${index}
+          style="--mdc-listitem-height: ${50 + (index % 5) * 10}px"
+          ${ref(this.virtualData.measureElement)}
+        >
+          <span slot="leading-text-primary-label">${this.listItemTexts[index]}</span>
+          <mdc-button
+            slot="trailing-controls"
+            color="positive"
+            prefix-icon="data-range-selection-bold"
+            aria-label="mock label"
+          ></mdc-button>
+          <mdc-button slot="trailing-controls" variant="tertiary">Learn More</mdc-button>
+        </mdc-listitem>
+      `;
+    }
+
+    return html``;
   }
+
+  private handleVirtualItemsChange = (event: VirtualizedListVirtualItemsChangeEvent) => {
+    this.virtualData = event.detail;
+  };
 
   override render() {
     return html`
-      <div style="height: 500px; width: 500px;">
+      <div part="wrapper">
         <mdc-virtualizedlist
           @scroll=${this.onscroll}
+          @virtualItemsChange=${this.handleVirtualItemsChange}
           .virtualizerProps=${this.virtualizerProps}
-          .setlistdata=${this.setListData}
-          >${this.list}</mdc-virtualizedlist
+          initial-focus=${this.initialFocus}
+          loop=${this.loop}
         >
+          ${repeat(
+            this.virtualData.virtualItems,
+            ({ key }) => key,
+            ({ index }) => this.renderItem(index),
+          )}
+        </mdc-virtualizedlist>
       </div>
     `;
   }
 
-  public static override styles: Array<CSSResult> = Component.styles;
+  public static override styles: Array<CSSResult> = [
+    ...Component.styles,
+    css`
+      :host([story='text'])::part(wrapper) {
+        width: 500px;
+        height: 500px;
+      }
+      :host([story='interactive'])::part(wrapper) {
+        width: 100%;
+        height: 500px;
+      }
+      :host([story='dynamic'])::part(wrapper) {
+        width: 100%;
+        height: 500px;
+      }
+    `,
+  ];
 }
 
 VirtualizedWrapper.register('mdc-virtualizedwrapper');
 
+class VirtualizedDynamicList extends Component {
+  @state()
+  listItems: string[] = new Array(10).fill(true).map((_, index) => `list item number ${index}`);
+
+  @state()
+  virtualData: VirtualizedListVirtualItemsChangeEvent['detail'] = { virtualItems: [], measureElement: () => null };
+
+  @state()
+  virtualizerProps: VirtualizerProps = { count: 0, estimateSize: () => 0, getItemKey: index => index };
+
+  counter = 9;
+
+  private virtualizerRef: Ref<VirtualizedList> = createRef();
+
+  protected override update(changedProperties: PropertyValues): void {
+    super.update(changedProperties);
+
+    if (changedProperties.has('listItems')) {
+      this.virtualizerProps = {
+        count: this.listItems.length,
+        estimateSize: () => 50,
+        getItemKey: (index: number) => this.listItems[index],
+      };
+    }
+  }
+
+  private generateListItem(index: number, label: string): TemplateResult {
+    return html`
+      <mdc-listitem data-index=${index} label=${label} ${ref(this.virtualData.measureElement)}>
+        <mdc-buttongroup slot="trailing-controls">
+          <mdc-button variant="primary" color="positive" @click=${() => this.addItem(0, 5)}>Add 5 At Top</mdc-button>
+          <mdc-button variant="primary" color="positive" @click=${() => this.addItem(index)}>Add Above</mdc-button>
+          <mdc-button variant="primary" color="positive" @click=${() => this.addItem(index + 1)}>Add Below</mdc-button>
+          <mdc-button variant="primary" color="positive" @click=${() => this.addItem()}>Add Last</mdc-button>
+        </mdc-buttongroup>
+        <mdc-buttongroup slot="trailing-controls">
+          <mdc-button variant="primary" color="negative" @click=${() => this.removeItem(index)}>Remove This</mdc-button>
+          <mdc-button variant="primary" color="negative" @click=${() => this.removeItem(index - 1)}
+            >Remove Above</mdc-button
+          >
+          <mdc-button variant="primary" color="negative" @click=${() => this.removeItem(index + 1)}
+            >Remove Below</mdc-button
+          >
+        </mdc-buttongroup>
+      </mdc-listitem>
+    `;
+  }
+
+  protected addItem(index?: number, count = 1): void {
+    // eslint-disable-next-line no-return-assign
+    const newItems = new Array(count).fill(true).map(() => `list item number ${(this.counter += 1)}`);
+
+    if (index === undefined) {
+      this.listItems = [...this.listItems, ...newItems];
+    } else {
+      this.listItems = [
+        ...this.listItems.slice(0, index),
+        ...newItems,
+        ...this.listItems.slice(index, this.listItems.length),
+      ];
+    }
+  }
+
+  protected removeItem(index?: number): void {
+    if (index === undefined) {
+      this.listItems = this.listItems.slice(0, -1);
+    } else {
+      this.listItems = [...this.listItems.slice(0, index), ...this.listItems.slice(index + 1, this.listItems.length)];
+    }
+  }
+
+  private handleVirtualItemsChange = (event: VirtualizedListVirtualItemsChangeEvent) => {
+    this.virtualData = event.detail;
+  };
+
+  protected override createRenderRoot(): HTMLElement | DocumentFragment {
+    return this;
+  }
+
+  protected override render(): TemplateResult {
+    return html`
+      <div id="VirtualizedDynamicList--wrapper">
+        <mdc-virtualizedlist
+          ${ref(this.virtualizerRef)}
+          .virtualizerProps=${this.virtualizerProps}
+          @virtualItemsChange=${this.handleVirtualItemsChange}
+        >
+          ${repeat(
+            this.virtualData.virtualItems,
+            ({ key }) => key,
+            ({ index }) => this.generateListItem(index, this.listItems[index]),
+          )}
+        </mdc-virtualizedlist>
+      </div>
+      <div style="margin-top: 1rem;">
+        <div>Current List Size: <span data-test="counter">${this.listItems.length}</span></div>
+        <div style="display: flex; gap: 0.25rem;">
+          <mdc-button @click=${() => this.removeItem()}>Remove Last</mdc-button>
+        </div>
+      </div>
+      <style>
+        #VirtualizedDynamicList--wrapper {
+          width: 100%;
+          height: 400px;
+        }
+      </style>
+    `;
+  }
+}
+
+VirtualizedDynamicList.register('mdc-virtualizeddynamiclist');
+
+class ChatExample extends Component {
+  @state()
+  chatMessages: Record<string, { name: string; message: string; parent?: string }> = {
+    msg_001: { name: 'Alice Johnson', message: 'Hey team! Just finished the quarterly report. Ready for review.' },
+    msg_002: { name: 'Bob Smith', message: "Great work Alice! I'll take a look this afternoon." },
+    msg_003: { name: 'Carol Davis', message: "Perfect timing. We can discuss it in tomorrow's standup." },
+    msg_004: {
+      name: 'Alice Johnson',
+      message: 'Sounds good! Also, anyone know if the client meeting is still at 3pm?',
+      parent: 'msg_001',
+    },
+    msg_005: { name: 'Bob Smith', message: "Yes, still at 3pm. I'll send the calendar invite.", parent: 'msg_001' },
+    msg_006: { name: 'David Wilson', message: 'Morning everyone! Can someone help me with the API documentation?' },
+    msg_007: { name: 'Emma Brown', message: 'Good morning! What specific part are you struggling with?' },
+    msg_008: {
+      name: 'David Wilson',
+      message: 'I need to understand the authentication flow for the new endpoints.',
+      parent: 'msg_006',
+    },
+    msg_009: {
+      name: 'Frank Miller',
+      message: 'I can help with that! Let me share the updated docs.',
+      parent: 'msg_006',
+    },
+    msg_010: {
+      name: 'Emma Brown',
+      message: 'Frank has the latest version, mine might be outdated.',
+      parent: 'msg_006',
+    },
+    msg_011: { name: 'Carol Davis', message: 'Quick question - has anyone tested the new deployment pipeline?' },
+    msg_012: { name: 'Bob Smith', message: 'I ran it yesterday, worked perfectly! No issues on my end.' },
+    msg_013: { name: 'Alice Johnson', message: 'Same here. The performance improvements are noticeable.' },
+    msg_014: { name: 'Carol Davis', message: 'Excellent! Should we roll it out to staging then?', parent: 'msg_011' },
+    msg_015: { name: 'Alice Johnson', message: "I think we're ready. Bob, what do you think?", parent: 'msg_011' },
+    msg_016: {
+      name: 'Bob Smith',
+      message: "Let's do it! I can handle the deployment this evening.",
+      parent: 'msg_011',
+    },
+    msg_017: { name: 'Frank Miller', message: 'Just pushed the hotfix for the login issue. Please test when you can.' },
+    msg_018: { name: 'Emma Brown', message: "Thanks Frank! I'll test it right now." },
+    msg_019: { name: 'David Wilson', message: 'Login is working perfectly on my end now. Great job!' },
+    msg_020: { name: 'Frank Miller', message: 'Awesome! The fix was simpler than I thought.', parent: 'msg_017' },
+    msg_021: { name: 'Bob Smith', message: 'Should we backport this to the release branch?', parent: 'msg_017' },
+    msg_022: {
+      name: 'Alice Johnson',
+      message: 'Yes, definitely. This was blocking our demo tomorrow.',
+      parent: 'msg_017',
+    },
+    msg_023: { name: 'Emma Brown', message: 'Hey team, reminder that code freeze is at 5pm today for the sprint.' },
+    msg_024: { name: 'Carol Davis', message: 'Perfect timing! I just submitted my last PR.' },
+    msg_025: { name: 'David Wilson', message: 'Mine is still in review. Carol, could you take a look?' },
+    msg_026: { name: 'Carol Davis', message: "Sure! Send me the link and I'll review it now.", parent: 'msg_025' },
+    msg_027: { name: 'Bob Smith', message: 'I can also help with reviews if needed.', parent: 'msg_025' },
+    msg_028: { name: 'Frank Miller', message: 'Does anyone know if the database migration is scheduled for tonight?' },
+    msg_029: { name: 'Emma Brown', message: "Yes, it's scheduled for 11pm. I'll be monitoring it." },
+    msg_030: { name: 'Alice Johnson', message: 'I can stay online too in case we need to rollback.' },
+    msg_031: {
+      name: 'Frank Miller',
+      message: "Great! I'll prepare the rollback scripts just in case.",
+      parent: 'msg_028',
+    },
+    msg_032: { name: 'Bob Smith', message: 'Should we create a war room channel for tonight?', parent: 'msg_028' },
+    msg_033: { name: 'Emma Brown', message: "Good idea! I'll set it up and invite everyone.", parent: 'msg_028' },
+    msg_034: { name: 'Grace Lee', message: 'Just joined the team! Excited to work with everyone. 👋' },
+    msg_035: { name: 'Alice Johnson', message: 'Welcome Grace! Great to have you on board!' },
+    msg_036: { name: 'Bob Smith', message: 'Welcome! Let me know if you need help getting set up.' },
+    msg_037: {
+      name: 'Grace Lee',
+      message: 'Thanks everyone! Alice, could you help me with the development environment setup?',
+      parent: 'msg_034',
+    },
+    msg_038: {
+      name: 'Alice Johnson',
+      message: "Absolutely! I'll send you the setup guide and we can pair tomorrow.",
+      parent: 'msg_034',
+    },
+    msg_039: {
+      name: 'Carol Davis',
+      message: "Grace, I've added you to all the relevant Slack channels too.",
+      parent: 'msg_034',
+    },
+    msg_040: { name: 'David Wilson', message: 'Quick update: the API rate limiting is now live in production.' },
+    msg_041: { name: 'Frank Miller', message: 'Nice! Are we seeing any impact on performance?' },
+    msg_042: { name: 'Emma Brown', message: 'Monitoring shows everything looks good so far.' },
+    msg_043: {
+      name: 'David Wilson',
+      message: 'Perfect! The new limits should prevent the timeout issues we had last week.',
+      parent: 'msg_040',
+    },
+    msg_044: { name: 'Bob Smith', message: 'Great work David! This was a critical fix.', parent: 'msg_040' },
+    msg_045: { name: 'Carol Davis', message: 'Thanks everyone! This has been a productive week.' },
+    msg_046: { name: 'Grace Lee', message: 'Looking forward to contributing next week!' },
+    msg_047: { name: 'Alice Johnson', message: 'Have a great weekend everyone!' },
+    msg_048: { name: 'Frank Miller', message: 'See you all on Monday! 🎉' },
+    msg_049: { name: 'Emma Brown', message: "One last thing - don't forget the retrospective is moved to Tuesday." },
+    msg_050: { name: 'Bob Smith', message: "Thanks for the reminder! I'll update my calendar." },
+    msg_051: { name: 'Carol Davis', message: 'Same here. What time was it again?', parent: 'msg_049' },
+    msg_052: { name: 'Emma Brown', message: '2pm, right after the sprint planning meeting.', parent: 'msg_049' },
+    msg_053: {
+      name: 'Grace Lee',
+      message: 'Should I join the retrospective even though I just started?',
+      parent: 'msg_049',
+    },
+    msg_054: {
+      name: 'Alice Johnson',
+      message: "Absolutely! It's a great way to learn about our process.",
+      parent: 'msg_049',
+    },
+  };
+
+  listItems: string[] = this.getOrderedMessageKeys();
+
+  @state()
+  virtualData: VirtualizedListVirtualItemsChangeEvent['detail'] = { virtualItems: [], measureElement: () => null };
+
+  @state()
+  virtualizerProps: VirtualizerProps = {
+    count: this.listItems.length,
+    estimateSize: () => 55,
+    getItemKey: index => this.listItems[index],
+  };
+
+  // Start AI-Assisted
+  @state()
+  textareaValue: string = '';
+
+  private messageCounter = 54; // Start after existing messages
+
+  private randomMessageTimer?: number;
+
+  private textareaRef: Ref<HTMLElement> = createRef();
+
+  private readonly randomMessages = [
+    'Just finished reviewing the latest pull request.',
+    'The build is now passing on all environments.',
+    "Quick reminder about tomorrow's team meeting.",
+    "I've updated the documentation with the latest changes.",
+    'The performance metrics look great this week!',
+    'Does anyone have time to pair on this feature?',
+    'Just deployed the hotfix to production.',
+    'The client feedback has been very positive.',
+    "I'll be working from home tomorrow.",
+    'Great work on the sprint demo today!',
+    'The new feature is ready for QA testing.',
+    'Coffee break anyone? ☕',
+    'The integration tests are now automated.',
+    'Thanks for the code review feedback!',
+    'The database migration completed successfully.',
+  ];
+
+  private readonly teamMembers = [
+    'Alice Johnson',
+    'Bob Smith',
+    'Carol Davis',
+    'David Wilson',
+    'Emma Brown',
+    'Frank Miller',
+    'Grace Lee',
+  ];
+  // End AI-Assisted
+
+  private virtualizerRef: Ref<VirtualizedList> = createRef();
+
+  private getOrderedMessageKeys(): string[] {
+    const allKeys = Object.keys(this.chatMessages);
+    const topLevelKeys = allKeys.filter(key => !this.chatMessages[key].parent);
+    const orderedKeys: string[] = [];
+
+    // Process each top-level message and its threads
+    topLevelKeys.forEach(topLevelKey => {
+      orderedKeys.push(topLevelKey);
+
+      // Find all threaded messages for this top-level message
+      const threadedMessages = allKeys.filter(key => this.chatMessages[key].parent === topLevelKey);
+
+      // Add threaded messages immediately after their parent
+      orderedKeys.push(...threadedMessages);
+    });
+
+    return orderedKeys;
+  }
+
+  // Start AI-Assisted
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.startRandomMessageTimer();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.stopRandomMessageTimer();
+  }
+
+  private startRandomMessageTimer(): void {
+    this.randomMessageTimer = window.setInterval(() => {
+      this.addRandomMessage();
+    }, 5000);
+  }
+
+  private stopRandomMessageTimer(): void {
+    if (this.randomMessageTimer) {
+      clearInterval(this.randomMessageTimer);
+      this.randomMessageTimer = undefined;
+    }
+  }
+
+  private addRandomMessage(): void {
+    const randomMessage = this.randomMessages[Math.floor(Math.random() * this.randomMessages.length)];
+    const randomAuthor = this.teamMembers[Math.floor(Math.random() * this.teamMembers.length)];
+    const messageId = `msg_${String(this.messageCounter + 1).padStart(3, '0')}`;
+
+    // Randomly decide if this should be a threaded message (30% chance)
+    let parentId: string | undefined;
+
+    // Find a recent top-level message to thread under
+    const topLevelMessages = Object.keys(this.chatMessages)
+      .filter(key => !this.chatMessages[key].parent)
+      .slice(-10); // Get last 5 top-level messages
+
+    if (topLevelMessages.length > 0) {
+      parentId = topLevelMessages[Math.floor(Math.random() * topLevelMessages.length)];
+    }
+
+    this.messageCounter += 1;
+    this.chatMessages = {
+      ...this.chatMessages,
+      [messageId]: {
+        name: randomAuthor,
+        message: randomMessage,
+        ...(parentId && { parent: parentId }),
+      },
+    };
+  }
+
+  private handleTextareaKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      this.sendMessage();
+    }
+  };
+
+  private handleTextareaInput = (event: Event): void => {
+    const target = event.target as HTMLTextAreaElement;
+    this.textareaValue = target.value;
+  };
+
+  private sendMessage(): void {
+    if (this.textareaValue.trim()) {
+      const messageId = `msg_${String(this.messageCounter + 1).padStart(3, '0')}`;
+      this.messageCounter += 1;
+
+      this.chatMessages = {
+        ...this.chatMessages,
+        [messageId]: {
+          name: 'You',
+          message: this.textareaValue.trim(),
+        },
+      };
+
+      this.textareaValue = '';
+
+      // Focus back to textarea after sending
+      if (this.textareaRef.value) {
+        const textarea = this.textareaRef.value.querySelector('textarea');
+        if (textarea) {
+          textarea.value = '';
+          textarea.focus();
+        }
+      }
+    }
+  }
+  // End AI-Assisted
+
+  protected override update(changedProperties: PropertyValues): void {
+    super.update(changedProperties);
+
+    if (changedProperties.has('chatMessages')) {
+      this.listItems = this.getOrderedMessageKeys();
+      this.virtualizerProps = {
+        count: this.listItems.length,
+        estimateSize: () => 50,
+        getItemKey: (index: number) => this.listItems[index],
+      };
+    }
+  }
+
+  private generateListItem({ index }: VirtualItem): TemplateResult {
+    const message = this.chatMessages[this.listItems[index]];
+
+    return html`
+      <mdc-listitem data-index=${index} ${ref(this.virtualData.measureElement)}>
+        <div
+          slot="content"
+          style=${styleMap({
+            display: 'flex',
+            gap: '0.5rem',
+            'align-items': 'center',
+            ...(message.parent ? { 'margin-left': '1rem' } : {}),
+          })}
+        >
+          <mdc-avatar
+            initials=${message.name
+              .split(' ')
+              .map(str => str[0])
+              .join('')}
+          ></mdc-avatar>
+          <mdc-text tagname="span">${message.message}</mdc-text>
+        </div>
+      </mdc-listitem>
+    `;
+  }
+
+  private handleVirtualItemsChange = (event: VirtualizedListVirtualItemsChangeEvent) => {
+    this.virtualData = event.detail;
+  };
+
+  protected override createRenderRoot(): HTMLElement | DocumentFragment {
+    return this;
+  }
+
+  protected override render(): TemplateResult {
+    return html`
+      <div id="VirtualizedDynamicList--wrapper">
+        <mdc-virtualizedlist
+          ${ref(this.virtualizerRef)}
+          .virtualizerProps=${this.virtualizerProps}
+          @virtualItemsChange=${this.handleVirtualItemsChange}
+          initial-focus=${this.listItems.length - 1}
+          stick-to-bottom
+        >
+          ${repeat(this.virtualData.virtualItems, ({ key }) => key, this.generateListItem.bind(this))}
+        </mdc-virtualizedlist>
+        <!-- Start AI-Assisted -->
+        <div class="chat-input-container">
+          <mdc-textarea
+            ${ref(this.textareaRef)}
+            placeholder="Type a message... (Press Enter to send, Shift+Enter for new line)"
+            .value=${this.textareaValue}
+            @input=${this.handleTextareaInput}
+            @keydown=${this.handleTextareaKeyDown}
+            resize="none"
+            rows="2"
+          ></mdc-textarea>
+          <mdc-button @click=${this.sendMessage} variant="primary" ?disabled=${!this.textareaValue.trim()}>
+            Send
+          </mdc-button>
+        </div>
+        <!-- End AI-Assisted -->
+      </div>
+      <style>
+        #VirtualizedDynamicList--wrapper {
+          width: 100%;
+          height: min(100%, 600px);
+          display: flex;
+          flex-direction: column;
+        }
+
+        /* Start AI-Assisted */
+        .chat-input-container {
+          display: flex;
+          gap: 0.5rem;
+          padding: 0.5rem;
+          border-top: 1px solid var(--mds-color-theme-outline-secondary-normal);
+          align-items: flex-end;
+        }
+
+        .chat-input-container mdc-textarea {
+          flex: 1;
+        }
+        /* End AI-Assisted */
+      </style>
+    `;
+  }
+}
+
+ChatExample.register('mdc-virtualizedlist-chat-example');
+
 declare global {
   interface HTMLElementTagNameMap {
     ['mdc-virtualizedwrapper']: VirtualizedWrapper;
+    ['mdc-virtualizeddynamiclist']: VirtualizedDynamicList;
+    ['mdc-virtualizedlist-chat-example']: ChatExample;
   }
 }

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.stories.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.stories.ts
@@ -5,12 +5,14 @@ import { action } from '@storybook/addon-actions';
 
 import { classArgType, styleArgType } from '../../../config/storybook/commonArgTypes';
 import './virtualizedlist.helper.test';
-import { disableControls } from '../../../config/storybook/utils';
+import { hideControls } from '../../../config/storybook/utils';
 
 const render = (args: Args) =>
   html` <mdc-virtualizedwrapper
     .virtualizerProps=${args.virtualizerProps}
+    story=${args.story}
     .onscroll=${action('scroll')}
+    initial-focus=${args['initial-focus']}
   ></mdc-virtualizedwrapper>`;
 
 const meta: Meta = {
@@ -22,19 +24,16 @@ const meta: Meta = {
     badges: ['stable'],
   },
   argTypes: {
-    ...disableControls(['scrollElementRef', 'virtualizer', 'virtualizerController']),
-    virtualizerProps: {
-      description: `Props to send to Tanstack virtual. Please reference 
-      [Tanstack Virtualizer API](https://tanstack.com/virtual/latest/docs/api/virtualizer) docs for more 
-      about all possible props.`,
-      control: 'object',
-    },
-    setlistdata: {
-      description: `A function that is passed in that when called, will udpate the state of the parent component.
-      This is necessary so that updates inside of virtualizedlist also 
-      rerender the parent with any appropriate updates.`,
-      type: 'function',
-    },
+    ...hideControls([
+      'virtualizerController',
+      'virtualizer',
+      'scrollElementRef',
+      'focusTrapRef',
+      'loop',
+      'role',
+      'itemsStore',
+    ]),
+    ...hideControls(['story']), // This is only used in the test helper to switch between list types
     ...classArgType,
     ...styleArgType,
   },
@@ -44,6 +43,30 @@ export default meta;
 
 export const Example: StoryObj = {
   args: {
-    virtualizerProps: { count: 200, estimateSize: () => 100, overscan: 30 },
+    virtualizerProps: { count: 200, estimateSize: () => 24, overscan: 30 },
+    story: 'text',
   },
+};
+
+export const Interactive: StoryObj = {
+  args: {
+    virtualizerProps: { count: 200, estimateSize: () => 75 },
+    story: 'interactive',
+  },
+};
+
+export const InteractiveStartAtBottom: StoryObj = {
+  args: {
+    virtualizerProps: { count: 200, estimateSize: () => 75 },
+    story: 'interactive',
+    'initial-focus': 199,
+  },
+};
+
+export const Dynamic: StoryObj = {
+  render: () => html` <mdc-virtualizeddynamiclist></mdc-virtualizeddynamiclist>`,
+};
+
+export const Chat: StoryObj = {
+  render: () => html` <mdc-virtualizedlist-chat-example></mdc-virtualizedlist-chat-example>`,
 };

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.styles.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.styles.ts
@@ -2,14 +2,37 @@ import { css } from 'lit';
 
 const styles = [
   css`
+    :host {
+      height: 100%;
+    }
+
     :host::part(scroll) {
       height: 100%;
       width: 100%;
       overflow-y: auto;
+      padding: 0.25rem 0;
+      scroll-padding: 0.25rem 0;
+      contain: strict;
+      overflow-anchor: none;
     }
-    :host::part(container) {
+
+    :host::part(wrapper) {
       position: relative;
       width: 100%;
+    }
+
+    :host::part(container) {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      padding: 0 0.25rem;
+    }
+
+    ::slotted([data-virtualized-hidden]) {
+      position: absolute !important;
+      top: var(--mdc-virtualizedlist-hidden-top) !important;
+      left: 0 !important;
     }
   `,
 ];

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.types.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.types.ts
@@ -1,22 +1,37 @@
-import { VirtualItem, VirtualizerOptions } from '@tanstack/virtual-core';
-import { StyleInfo } from 'lit/directives/style-map.js';
+import type {
+  VirtualItem,
+  Virtualizer as TanstackVirtualizer,
+  VirtualizerOptions as TanstackVirtualizerOptions,
+} from '@tanstack/virtual-core';
 
 import type { TypedCustomEvent } from '../../utils/types';
 
 import type VirtualizedList from './virtualizedlist.component';
 
-interface SetListDataProps {
-  virtualItems: Array<VirtualItem>;
-  measureElement: (node: Element | null | undefined) => void;
-  listStyle: Readonly<StyleInfo>;
-}
-
 type VirtualizedListScrollEvent = TypedCustomEvent<VirtualizedList>;
+type VirtualizedListVirtualItemsChangeEvent = TypedCustomEvent<
+  VirtualizedList,
+  {
+    virtualItems: Array<VirtualItem>;
+    measureElement: (node: Element | null | undefined) => void;
+  }
+>;
 
 interface Events {
   onScrollEvent: VirtualizedListScrollEvent;
+  onVirtualItemsChangeEvent: VirtualizedListVirtualItemsChangeEvent;
 }
 
-type VirtualizerProps = Partial<VirtualizerOptions<Element, Element>>;
+type Virtualizer = TanstackVirtualizer<Element, Element>;
+type VirtualizerOptions = TanstackVirtualizerOptions<Element, Element>;
+type VirtualizerProps = Omit<Partial<VirtualizerOptions>, 'getScrollElement'> &
+  Required<Pick<VirtualizerOptions, 'count' | 'estimateSize' | 'getItemKey'>>;
 
-export type { Events, VirtualizedListScrollEvent, VirtualizerProps, SetListDataProps };
+export type {
+  Events,
+  VirtualizedListScrollEvent,
+  VirtualizedListVirtualItemsChangeEvent,
+  Virtualizer,
+  VirtualizerProps,
+  VirtualizerOptions,
+};

--- a/packages/components/src/utils/mixins/ListNavigationMixin.ts
+++ b/packages/components/src/utils/mixins/ListNavigationMixin.ts
@@ -15,9 +15,11 @@ export declare abstract class ListNavigationMixinInterface {
 
   protected abstract get navItems(): HTMLElement[];
 
-  protected resetTabIndexes(index: number): void;
+  protected resetTabIndexes(index: number, focusElement?: boolean): void;
 
   protected resetTabIndexAndSetFocus(newIndex: number, oldIndex?: number, focusNewItem?: boolean): void;
+
+  protected setInitialFocus(): void;
 }
 
 /**
@@ -90,6 +92,10 @@ export const ListNavigationMixin = <T extends Constructor<Component>>(superClass
     protected override async firstUpdated(changedProperties: PropertyValues) {
       super.firstUpdated(changedProperties);
 
+      this.setInitialFocus();
+    }
+
+    protected setInitialFocus() {
       const indexToFocus = Math.max(Math.min(this.initialFocus, this.navItems.length - 1), 0);
       this.resetTabIndexAndSetFocus(indexToFocus, undefined, false);
     }
@@ -188,13 +194,15 @@ export const ListNavigationMixin = <T extends Constructor<Component>>(superClass
      *
      * @param index - The index of the currently focused item.
      */
-    protected resetTabIndexes(index: number) {
+    protected resetTabIndexes(index: number, focusElement = true) {
       if (this.navItems.length > 0) {
         this.navItems.forEach(item => item.setAttribute('tabindex', '-1'));
         const currentIndex = this.navItems[index] ? index : 0;
 
         this.navItems[currentIndex].setAttribute('tabindex', '0');
-        this.navItems[currentIndex].focus();
+        if (focusElement) {
+          this.navItems[currentIndex].focus();
+        }
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,7 +2662,7 @@ __metadata:
     "@storybook/theming": ^8.2.5
     "@storybook/web-components": ^8.2.5
     "@storybook/web-components-vite": ^8.2.5
-    "@tanstack/lit-virtual": ^3.11.3
+    "@tanstack/lit-virtual": ^3.13.2
     axe-html-reporter: ^2.2.11
     chalk: ^4.1.2
     concurrently: ^8.2.2
@@ -3695,21 +3695,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/lit-virtual@npm:^3.11.3":
-  version: 3.11.3
-  resolution: "@tanstack/lit-virtual@npm:3.11.3"
+"@tanstack/lit-virtual@npm:^3.13.2":
+  version: 3.13.12
+  resolution: "@tanstack/lit-virtual@npm:3.13.12"
   dependencies:
-    "@tanstack/virtual-core": 3.11.3
+    "@tanstack/virtual-core": 3.13.12
   peerDependencies:
     lit: ^3.1.0
-  checksum: aff5f994220c067047091c7d11cbe12c84eaeeee4a90a9b91926f58024b9ff0c72cc2be3d4e3236acce9ce68d04b8c1ce2e099b437afca029e1a7b35c66fe8df
+  checksum: bc3cddf28e275411deeda106a355322ccaf6493fc3da89258bf7a4e94ced69f4b2955bcd4be4f36d29eaafbfce8f631157edbe925cfc984286bf8aeb2551bd11
   languageName: node
   linkType: hard
 
-"@tanstack/virtual-core@npm:3.11.3":
-  version: 3.11.3
-  resolution: "@tanstack/virtual-core@npm:3.11.3"
-  checksum: 43dacdd27802de45c0ccdb34a4cba5f47c7b5aab1cc920a9851e382074fc9099419cc4b014afab74791672e4837afe0ef6ecf47e344267b457858dd982ffac57
+"@tanstack/virtual-core@npm:3.13.12":
+  version: 3.13.12
+  resolution: "@tanstack/virtual-core@npm:3.13.12"
+  checksum: bef2c3138543a2088fff7d4fa46624d07403b18d92ec5a7271e187457851535031a79bc78ac655355a221d5549ef3b5674a3b249d2531f4c17c93107498c8438
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
(Still WIP)

### Description

Rewrite the virtualizedlist to:
- add keyboard navigation
- keep active (focused/selected) element available in the DOM
- add scroll anchoring when items are added/removed from the list
- add the correct aria properties to the list items so screen reader reads the list correctly

This PR also fixes a bug where if the last element in a list is the active element and is removed from the DOM, the focus is always moved to the new last element.

**Breaking Changes**
The API for the virtualizedlist component has been completely updated. You still need to pass the virtualizerProps but the virtual items are now provided by an event instead of a callback. 
(Following the standard DOM modal: https://lit.dev/docs/composition/component-composition/#passing-data-up-and-down-the-tree)
