### PR TITLE
fix(popover): hide popover portal from dom

### DIFF
--- a/packages/components/src/components/popover/popover.e2e-test.ts
+++ b/packages/components/src/components/popover/popover.e2e-test.ts
@@ -1283,6 +1283,7 @@ test('mdc-popover', async ({ componentsPage }) => {
 
       await expect(popover.evaluate(node => node.parentElement?.id)).resolves.toBe('root');
       await expect(container.locator('mdc-popoverportal')).toHaveCount(1);
+      await expect(container.locator('mdc-popoverportal')).not.toBeVisible();
 
       await componentsPage.page.evaluate(async () => {
         const w = window as typeof window & Utils;
@@ -1305,6 +1306,7 @@ test('mdc-popover', async ({ componentsPage }) => {
 
       await expect(popover.evaluate(node => node.parentElement?.id)).resolves.toBe('root');
       await expect(container.locator('mdc-popoverportal')).toHaveCount(1);
+      await expect(container.locator('mdc-popoverportal')).not.toBeVisible();
 
       await componentsPage.page.evaluate(() => {
         const w = window as typeof window & Utils;

--- a/packages/components/src/components/popover/popover.portal.component.ts
+++ b/packages/components/src/components/popover/popover.portal.component.ts
@@ -28,6 +28,7 @@ export class PopoverPortal extends Component {
     super.connectedCallback();
     // We don't want the portal to be focusable or visible for screen readers
     this.ariaHidden = 'true';
+    this.style.display = 'none';
   }
 
   /**

--- a/packages/components/src/components/popover/popover.stories.ts
+++ b/packages/components/src/components/popover/popover.stories.ts
@@ -593,6 +593,12 @@ export const AppendTo: StoryObj = {
           overflow: hidden;
           position: relative;
         }
+        .hover-menu {
+          display: flex;
+        }
+        .hover-menu > * {
+          flex: 1 1 50%;
+        }
       </style>
       <template id="menu-without-append-to-tpl">
         <mdc-button id="popover-trigger-1">Open popover in the #root</mdc-button>


### PR DESCRIPTION
### Description

Containers (eg.: flex box) now skip mdc-popoverportal elements.
