### PR TITLE
fix: store update error on select default value

### DIFF
--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -259,7 +259,7 @@ class Select
         option.setAttribute('tabindex', '-1');
         break;
       case 'removed': {
-        if (index === -1 || option.tabIndex !== 0) {
+        if (!this.navItems || index === -1 || option.tabIndex !== 0) {
           return;
         }
 


### PR DESCRIPTION
### Description

- The select component when renders for the first time with a default selected value, then the `onStoreUpdate` would be called where all options are removed from store before they are even added.
- At that time, the `itemStore.items` will be undefined (as no options are added) and trying to get the length of items results in an error.
<img width="959" height="175" alt="image" src="https://github.com/user-attachments/assets/cf76baea-7c8a-4598-935a-2cacf687d9d2" />

- This PR fixes this issue by checking the truthiness value of `itemStore.items` before removing the state item on onStoreUpdate.

### Links

- MOMENTUM-828
