### PR TITLE
chore: add screenreader announcement for textarea component

### DIFF
--- a/packages/components/src/components/textarea/index.ts
+++ b/packages/components/src/components/textarea/index.ts
@@ -2,6 +2,7 @@ import Textarea from './textarea.component';
 import { TAG_NAME } from './textarea.constants';
 import '../button';
 import '../icon';
+import '../screenreaderannouncer';
 import '../text';
 import '../toggletip';
 

--- a/packages/components/src/components/textarea/textarea.component.ts
+++ b/packages/components/src/components/textarea/textarea.component.ts
@@ -63,7 +63,8 @@ import styles from './textarea.styles';
  * @cssproperty --mdc-textarea-focused-background-color - Background color for the textarea container when focused
  * @cssproperty --mdc-textarea-focused-border-color - Border color for the textarea container when focused
  *
- * @csspart textarea-container - The textarea container
+ * @csspart textarea-container - The textarea container.
+ * @csspart textarea - The textarea input element.
  */
 
 class Textarea extends AutoFocusOnMountMixin(FormInternalsMixin(DataAriaLabelMixin(FormfieldWrapper))) {
@@ -129,12 +130,24 @@ class Textarea extends AutoFocusOnMountMixin(FormInternalsMixin(DataAriaLabelMix
   @property({ type: Number, attribute: 'max-character-limit' }) maxCharacterLimit?: number;
 
   /**
+   * announcement to be made when the max character limit is set.
+   * if the number of characters in the textarea are more than 90% of the max character limit,
+   * the announcement will be made.
+   * The number of characters and the max character will be announced in this format.
+   * `%{number-of-characters} of %{max-character-limit} characters typed.`
+   * Ex: "93 of 100 characters typed."
+   */
+  @property({ type: String, attribute: 'character-limit-announcement' }) characterLimitAnnouncement?: string;
+
+  /**
    * @internal
    * The textarea element
    */
   @query('textarea') override inputElement!: HTMLTextAreaElement;
 
   private characterLimitExceedingFired: boolean = false;
+
+  private ariaLiveAnnouncer?: string;
 
   protected get textarea(): HTMLTextAreaElement {
     return this.inputElement;
@@ -294,6 +307,26 @@ class Textarea extends AutoFocusOnMountMixin(FormInternalsMixin(DataAriaLabelMix
   private updateValue() {
     this.value = this.textarea.value;
     this.internals.setFormValue(this.textarea.value);
+    this.announceMaxLengthWarning();
+  }
+
+  /**
+   * Announces the character limit warning based on the current value length.
+   * If the value length exceeds the max character limit, the help text is announced (if help text is present).
+   * If the value length does not exceed the max character limit, then the character limit announcement is announced.
+   */
+  private announceMaxLengthWarning() {
+    this.ariaLiveAnnouncer = '';
+    if (!this.maxCharacterLimit || this.value.length === 0) {
+      return;
+    }
+    if (this.helpText && this.value.length > this.maxCharacterLimit) {
+      this.ariaLiveAnnouncer = this.helpText;
+    } else if (this.characterLimitAnnouncement && this.value.length <= this.maxCharacterLimit) {
+      this.ariaLiveAnnouncer = this.characterLimitAnnouncement
+        .replace('%{number-of-characters}', this.value.length.toString())
+        .replace('%{max-character-limit}', this.maxCharacterLimit.toString());
+    }
   }
 
   /**
@@ -357,6 +390,11 @@ class Textarea extends AutoFocusOnMountMixin(FormInternalsMixin(DataAriaLabelMix
           aria-describedby="${ifDefined(this.helpText ? FORMFIELD_DEFAULTS.HELPER_TEXT_ID : '')}"
           aria-invalid="${this.helpTextType === 'error' ? 'true' : 'false'}"
         ></textarea>
+        <mdc-screenreaderannouncer
+          identity="${this.inputId}"
+          announcement="${ifDefined(this.ariaLiveAnnouncer)}"
+          data-aria-live="polite"
+        ></mdc-screenreaderannouncer>
       </div>
       ${this.renderTextareaFooter()}
     `;

--- a/packages/components/src/components/textarea/textarea.stories.ts
+++ b/packages/components/src/components/textarea/textarea.stories.ts
@@ -49,6 +49,7 @@ const render = (args: Args) =>
     toggletip-strategy="${args['toggletip-strategy']}"
     info-icon-aria-label="${args['info-icon-aria-label']}"
     max-character-limit="${ifDefined(args['max-character-limit'])}"
+    character-limit-announcement="${ifDefined(args['character-limit-announcement'])}"
   ></mdc-textarea>`;
 
 const meta: Meta = {
@@ -142,6 +143,9 @@ const meta: Meta = {
       control: 'boolean',
     },
     'info-icon-aria-label': {
+      control: 'text',
+    },
+    'character-limit-announcement': {
       control: 'text',
     },
     ...hideControls(['characterLimitExceedingFired', 'textarea', 'validity', 'willValidate']),
@@ -288,7 +292,13 @@ export const AllVariants: StoryObj = {
 };
 
 export const TextareaWithCharacterCounter: StoryObj = {
-  render: () => {
+  args: {
+    required: true,
+    placeholder: `Write what's on your mind`,
+    'max-character-limit': 75,
+    'character-limit-announcement': '%{number-of-characters} out of %{max-character-limit} characters are typed.',
+  },
+  render: (args: Args) => {
     let helpText = '';
     let helpTextType: ValidationType = VALIDATION.DEFAULT;
 
@@ -327,9 +337,10 @@ export const TextareaWithCharacterCounter: StoryObj = {
             @limitexceeded=${handleCharacterLimitCheck}
             help-text="${helpText}"
             help-text-type="${helpTextType}"
-            required
-            max-character-limit="75"
-            placeholder="Write what's on your mind"
+            ?required="${args.required}"
+            max-character-limit="${args['max-character-limit']}"
+            placeholder="${args.placeholder}"
+            character-limit-announcement="${args['character-limit-announcement']}"
           ></mdc-textarea>
           <div style="display: flex; gap: 0.25rem; margin-top: 0.25rem">
             <mdc-button type="submit" size="24">Submit</mdc-button>


### PR DESCRIPTION
### Description

- Add debounce for screen reader announcment.
- Add screenreader component inside textarea component.
- Add new attribute `character-limit-announcement` for textarea component.
- When the user starts typing in the textarea and if the component contains a max length limit and character limit text attributes, then we will announce the text while the user is typing.
- The debounce method on the screenreader component will debounce the announce calls for 500 milliseconds.