### PR TITLE
fix(searchfield): hide webkit search cancel button on hover

### DIFF
--- a/packages/components/src/components/searchfield/searchfield.styles.ts
+++ b/packages/components/src/components/searchfield/searchfield.styles.ts
@@ -7,12 +7,17 @@ const styles = css`
     margin: 0.25rem 0;
   }
 
-  .input {
+  :host::part(input-text) {
     white-space: nowrap;
     min-width: 90%;
   }
 
-  .input::-webkit-search-cancel-button {
+  input[type="search"]::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    pointer-events: none;
+  }
+
+  input[type="search"]:hover::-webkit-search-cancel-button {
     -webkit-appearance: none;
     pointer-events: none;
   }


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description
The searchfield component displays an unwanted native webkit search cancel button (X) when users hover over the input field in webkit-based browsers (Chrome, Safari, Edge).

### Fix
- Added CSS rules to completely hide the webkit search cancel button using `-webkit-appearance: none` and `pointer-events: none`
