### PR TITLE
fix(dialog): Add conditional footer spacing to prevent empty footer gaps

### DIFF
--- a/packages/components/src/components/dialog/dialog.styles.ts
+++ b/packages/components/src/components/dialog/dialog.styles.ts
@@ -20,7 +20,6 @@ const styles = css`
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    gap: 1rem;
     position: absolute;
     right: 50%;
     bottom: 50%;
@@ -103,11 +102,19 @@ const styles = css`
     width: 100%;
   }
 
+  :host::part(has-header-content) {
+    margin-top: 1rem;
+  }
+
   :host::part(footer) {
     display: flex;
     gap: 0.5rem;
     align-items: center;
     justify-content: flex-end;
+  }
+
+  :host::part(has-footer-content) {
+    margin-top: 1rem;
   }
 
   :host::part(dialog-close-btn) {


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

#### 🎯 Problem
Dialog components displayed unwanted spacing gaps when footer slots were empty, creating poor visual layout.

#### 🔧 Solution
Implemented a JavaScript + CSS hybrid approach to conditionally apply spacing only when footer content is present.

#### 🤔 Why Not Pure CSS?
Pure CSS cannot solve this problem completely because:
- Slot elements always exist in DOM even when empty
- CSS cannot detect Web Components slot assignment state
- `:empty` and `:has()` selectors don't work with slot content detection

#### 🧪 Testing
- Manual testing confirms no gaps when footer is empty
- Proper spacing when footer content is present
- Dynamic updates when content is added/removed