### PR TITLE
feat(tab): icon slot

### DIFF
--- a/packages/components/src/components/tab/tab.component.ts
+++ b/packages/components/src/components/tab/tab.component.ts
@@ -250,9 +250,11 @@ class Tab extends IconNameMixin(Buttonsimple) {
   public override render() {
     return html`
       <div part="container">
+      <slot name="icon">
         ${this.iconName
           ? html` <mdc-icon name="${this.iconName as IconNames}" size="1" length-unit="rem" part="icon"></mdc-icon>`
           : nothing}
+      </slot>
         ${this.text
           ? html` <mdc-text
               type=${this.active ? TYPE.BODY_MIDSIZE_BOLD : TYPE.BODY_MIDSIZE_MEDIUM}

--- a/packages/components/src/components/tab/tab.e2e-test.ts
+++ b/packages/components/src/components/tab/tab.e2e-test.ts
@@ -20,6 +20,7 @@ type SetupOptions = {
 };
 
 const ICON_PLACEHOLDER = 'placeholder-bold';
+const BRAND_VISUAL_NAME = 'webex-symbol-common-color-gradient';
 
 const setup = async (args: SetupOptions) => {
   const { componentsPage, ...restArgs } = args;
@@ -106,6 +107,30 @@ test('mdc-tab', async ({ componentsPage }) => {
         await componentsPage.setAttributes(tab, { 'icon-name': ICON_PLACEHOLDER });
         await expect(tab.locator('mdc-icon')).toHaveAttribute('name', ICON_PLACEHOLDER);
         await componentsPage.removeAttribute(tab, 'icon-name');
+      });
+
+      // custom icon slot with brand-visual
+      await test.step('custom icon slot with brand-visual should work', async () => {
+        // Mount a new tab with brand-visual in icon slot
+        await componentsPage.mount({
+          html: `
+          <div id="wrapper" role="tablist">
+            <mdc-tab text="Custom Icon Tab" tab-id="custom-icon-tab">
+              <mdc-brandvisual slot="icon" name="${BRAND_VISUAL_NAME}" style="width: 1rem;"></mdc-brandvisual>
+            </mdc-tab>
+          </div>
+          `,
+          clearDocument: true,
+        });
+
+        const customIconTab = componentsPage.page.locator('mdc-tab');
+        await customIconTab.waitFor();
+
+        // Check that brand-visual is rendered in the icon slot
+        const brandVisual = customIconTab.locator('mdc-brandvisual[slot="icon"]');
+        await expect(brandVisual).toBeVisible();
+        await expect(brandVisual).toHaveAttribute('name', BRAND_VISUAL_NAME);
+        await expect(brandVisual).toHaveAttribute('slot', 'icon');
       });
 
       // tabIndex
@@ -283,6 +308,26 @@ test('mdc-tab', async ({ componentsPage }) => {
       active: '',
       'soft-disabled': '',
     });
+    await stickerSheet.createMarkupWithCombination({ variant: Object.values(TAB_VARIANTS) });
+
+    // Tabs with custom brand-visual icon slot - not active
+    stickerSheet.setChildren(`<mdc-brandvisual slot="icon" name="${BRAND_VISUAL_NAME}" style="width: 1rem;"></mdc-brandvisual>`);
+    stickerSheet.setAttributes({ text: 'Brand Visual Inactive', 'icon-name': '', 'aria-label': '' });
+    await stickerSheet.createMarkupWithCombination({ variant: Object.values(TAB_VARIANTS) });
+
+    // Tabs with custom brand-visual icon slot - active
+    stickerSheet.setChildren(`<mdc-brandvisual slot="icon" name="${BRAND_VISUAL_NAME}" style="width: 1rem;"></mdc-brandvisual>`);
+    stickerSheet.setAttributes({ text: 'Brand Visual Active', 'icon-name': '', 'aria-label': '', active: '' });
+    await stickerSheet.createMarkupWithCombination({ variant: Object.values(TAB_VARIANTS) });
+
+    // Tabs with custom brand-visual icon slot only - not active
+    stickerSheet.setChildren(`<mdc-brandvisual slot="icon" name="${BRAND_VISUAL_NAME}" style="width: 1rem;"></mdc-brandvisual>`);
+    stickerSheet.setAttributes({ text: '', 'icon-name': '', 'aria-label': 'Brand Visual Only Inactive' });
+    await stickerSheet.createMarkupWithCombination({ variant: Object.values(TAB_VARIANTS) });
+
+    // Tabs with custom brand-visual icon slot only - active
+    stickerSheet.setChildren(`<mdc-brandvisual slot="icon" name="${BRAND_VISUAL_NAME}" style="width: 1rem;"></mdc-brandvisual>`);
+    stickerSheet.setAttributes({ text: '', 'icon-name': '', 'aria-label': 'Brand Visual Only Active', active: '' });
     await stickerSheet.createMarkupWithCombination({ variant: Object.values(TAB_VARIANTS) });
 
     await stickerSheet.mountStickerSheet();

--- a/packages/components/src/components/tab/tab.stories.ts
+++ b/packages/components/src/components/tab/tab.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj, Args } from '@storybook/web-components';
 import '.';
 import '../badge';
+import '../brandvisual';
 import { html, nothing } from 'lit';
 import { action } from 'storybook/actions';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -135,5 +136,36 @@ export const IconOnlyTab: StoryObj = {
   },
   argTypes: {
     ...hideControls(['text']),
+  },
+};
+
+export const CustomIconSlot: StoryObj = {
+  render: (args: Args) =>
+    html`<div role="tablist">
+      <mdc-tab
+        @click="${action('onclick')}"
+        @keydown="${action('onkeydown')}"
+        @keyup="${action('onkeyup')}"
+        @focus="${action('onfocus')}"
+        @activechange="${action('onactivechange')}"
+        ?active="${args.active}"
+        aria-label="${ifDefined(args.text ? nothing : 'Label')}"
+        ?disabled="${args.disabled}"
+        ?soft-disabled="${args['soft-disabled']}"
+        tabIndex="${ifDefined(args.tabIndex)}"
+        text="${ifDefined(args.text)}"
+        variant="${ifDefined(args.variant)}"
+        tab-id="tab1"
+        ?auto-focus-on-mount="${args['auto-focus-on-mount']}"
+      >
+        <mdc-brandvisual style="width: 1rem;" slot="icon" name="webex-symbol-common-color-gradient"></mdc-brandvisual>
+      </mdc-tab>
+    </div>`,
+  args: {
+    ...defaultArgs,
+    'icon-name': undefined, // Remove default icon-name since we're using custom slot
+  },
+  argTypes: {
+    ...hideControls(['icon-name']),
   },
 };


### PR DESCRIPTION
We want to be able to add a BrandVisual in the tab component, instead of an icon.
