### PR TITLE
fix(site): momentum site redirect

### DIFF
--- a/packages/documentation/astro.config.mjs
+++ b/packages/documentation/astro.config.mjs
@@ -27,8 +27,7 @@ export default defineConfig({
     react(),
     mdx(),
   ],
-  site: 'https://momentum-design.github.io',
-  base: '/momentum-design',
+  site: 'https://momentum-design',
   vite: {
     build: {
       rollupOptions: {


### PR DESCRIPTION
records are in a third party vendor and managed there, added the github admin pages settings to point to momentum.design, and made this astro change. cc @tricarro 

-> https://docs.astro.build/en/guides/deploy/github/#change-your-github-url-to-a-custom-domain