### PR TITLE
fix(astro): extraneous path added

### DIFF
--- a/packages/documentation/src/pages/index.astro
+++ b/packages/documentation/src/pages/index.astro
@@ -1,3 +1,3 @@
 <script is:inline>
-	window.location.pathname = '/momentum-design/en';
+	window.location.pathname = '/en';
 </script>


### PR DESCRIPTION
remove /momentum-design. it is unneeded now that we are going to momentum.design/en