### PR TITLE
fix: add dataAriaDescribedby to input

### DIFF
--- a/packages/components/src/components/input/input.component.ts
+++ b/packages/components/src/components/input/input.component.ts
@@ -159,6 +159,14 @@ class Input
    */
   @property({ type: String, attribute: 'clear-aria-label' }) clearAriaLabel = '';
 
+  /**
+   * Defines a id pointing to the element which describes the input element.
+   * The AriaDescribedby attribute to be set for accessibility.
+   * @default null
+   */
+  @property({ type: String, reflect: true, attribute: 'data-aria-describedby' })
+  dataAriaDescribedby: string | null = null;
+
   override connectedCallback(): void {
     super.connectedCallback();
     this.updateComplete
@@ -372,7 +380,9 @@ class Input
       ?readonly="${this.readonly}"
       ?required="${this.required}"
       type="${type}"
-      aria-describedby="${ifDefined(this.helpText ? FORMFIELD_DEFAULTS.HELPER_TEXT_ID : '')}"
+      aria-describedby="${ifDefined(
+        this.helpText ? FORMFIELD_DEFAULTS.HELPER_TEXT_ID : (this.dataAriaDescribedby ?? ''),
+      )}"
       aria-invalid="${this.helpTextType === 'error' ? 'true' : 'false'}"
       placeholder=${ifDefined(placeholderText)}
       minlength=${ifDefined(this.minlength)}

--- a/packages/components/src/components/input/input.e2e-test.ts
+++ b/packages/components/src/components/input/input.e2e-test.ts
@@ -32,6 +32,7 @@ type SetupOptions = {
   list?: string;
   size?: number;
   dataAriaLabel?: string;
+  dataAriaDescribedby?: string;
   clearAriaLabel?: string;
   secondButtonForFocus?: boolean;
 };
@@ -66,6 +67,7 @@ const setup = async (args: SetupOptions, isForm = false) => {
       ${restArgs.list ? `list="${restArgs.list}"` : ''}
       ${restArgs.size ? `size="${restArgs.size}"` : ''}
       ${restArgs.dataAriaLabel ? `data-aria-label="${restArgs.dataAriaLabel}"` : ''}
+      ${restArgs.dataAriaDescribedby ? `data-aria-describedby="${restArgs.dataAriaDescribedby}"` : ''}
       ${restArgs.clearAriaLabel ? `data-aria-label="${restArgs.clearAriaLabel}"` : ''}
       ></mdc-input>
       ${restArgs.secondButtonForFocus ? '<mdc-button>Second Button</mdc-button></div>' : ''}
@@ -97,6 +99,7 @@ test('mdc-input', async ({ componentsPage, browserName }) => {
     label: 'Label',
     helpText: 'Help Text',
     secondButtonForFocus: true,
+    dataAriaDescribedby: 'custom-helper-text-id', // custom aria-describedby
   });
 
   /**
@@ -114,8 +117,10 @@ test('mdc-input', async ({ componentsPage, browserName }) => {
       await expect(helpText).toHaveText('Help Text');
       await expect(input).toHaveAttribute('prefix-text', 'Prefix');
       await expect(input).toHaveAttribute('data-aria-label', 'prefix');
+      await expect(input).toHaveAttribute('data-aria-describedby', 'custom-helper-text-id');
       const inputEl = input.locator('input');
       await expect(inputEl).toHaveAttribute('aria-label', 'prefix');
+      await expect(inputEl).toHaveAttribute('aria-describedby', 'helper-text-id');
       await expect(input).toHaveAttribute('leading-icon', 'placeholder-bold');
       const icon = input.locator('mdc-icon');
       await expect(icon).toHaveAttribute('name', 'placeholder-bold');
@@ -194,16 +199,16 @@ test('mdc-input', async ({ componentsPage, browserName }) => {
       await componentsPage.removeAttribute(input, 'autocomplete');
     });
 
-    await test.step('attribute direname should be present on component', async () => {
-      await componentsPage.setAttributes(input, { direname: 'ltr' });
-      await expect(input).toHaveAttribute('direname', 'ltr');
-      await componentsPage.removeAttribute(input, 'direname');
+    await test.step('attribute dirname should be present on component', async () => {
+      await componentsPage.setAttributes(input, { dirname: 'ltr' });
+      await expect(input).toHaveAttribute('dirname', 'ltr');
+      await componentsPage.removeAttribute(input, 'dirname');
     });
 
-    await test.step('attribute direname should be present on component', async () => {
-      await componentsPage.setAttributes(input, { direname: 'ltr' });
-      await expect(input).toHaveAttribute('direname', 'ltr');
-      await componentsPage.removeAttribute(input, 'direname');
+    await test.step('attribute dirname should be present on component', async () => {
+      await componentsPage.setAttributes(input, { dirname: 'ltr' });
+      await expect(input).toHaveAttribute('dirname', 'ltr');
+      await componentsPage.removeAttribute(input, 'dirname');
     });
 
     await test.step('attribute pattern should be present on component', async () => {
@@ -216,6 +221,16 @@ test('mdc-input', async ({ componentsPage, browserName }) => {
       await componentsPage.setAttributes(input, { list: 'browsers' });
       await expect(input).toHaveAttribute('list', 'browsers');
       await componentsPage.removeAttribute(input, 'list');
+    });
+
+    await test.step('attribute data-aria-describedby should be present on component if help-text is not set', async () => {
+      await componentsPage.setAttributes(input, { 'data-aria-describedby': 'this-is-a-test-id' });
+      await componentsPage.removeAttribute(input, 'help-text');
+      await expect(input).toHaveAttribute('data-aria-describedby', 'this-is-a-test-id');
+      const inputEl = input.locator('input');
+      await expect(inputEl).toHaveAttribute('aria-describedby', 'this-is-a-test-id');
+      await componentsPage.removeAttribute(input, 'data-aria-describedby');
+      await componentsPage.setAttributes(input, { helpText: 'Help Text' });
     });
   });
 

--- a/packages/components/src/components/input/input.stories.ts
+++ b/packages/components/src/components/input/input.stories.ts
@@ -51,6 +51,7 @@ const render = (args: Args) => {
     list="${ifDefined(args.list)}"
     size="${ifDefined(args.size)}"
     clear-aria-label="${ifDefined(args['clear-aria-label'])}"
+    data-aria-describedby="${ifDefined(args['data-aria-describedby'])}"
   ></mdc-input>`;
 };
 
@@ -137,6 +138,9 @@ const meta: Meta = {
     'data-aria-label': {
       control: 'text',
     },
+    'data-aria-describedby': {
+      control: 'text',
+    },
     'toggletip-text': {
       control: 'text',
     },
@@ -176,6 +180,7 @@ export const Example: StoryObj = {
     autocapitalize: 'off',
     'clear-aria-label': 'clear input',
     'data-aria-label': '',
+    'data-aria-describedby': '',
   },
 };
 


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- [Input, Password, Searchfield] - adding `dataAriaDescribedby` as attribute/property to pass through to aria-describedby on internal Input. This is useful when help-text can't be used, but the Input has to be described to the screenreader by other elements.
- [Input] - Added E2E test for change to confirm behavior and avoid regression
