### PR TITLE
fix: split showhidebuttonarialabel of password

### DIFF
--- a/packages/components/src/components/password/password.component.ts
+++ b/packages/components/src/components/password/password.component.ts
@@ -18,7 +18,8 @@ import { PASSWORD_VISIBILITY_ICONS } from './password.constants';
  * - `password` field - contains the value
  * - `help-text` or `validation-message` - displayed below the password field.
  * - `help-text-type` - type of the help text, can be 'default', 'error', 'warning', 'success', 'priority'.
- * - `show-hide-button-aria-label` - aria label for the trailing show/hide button.
+ * - `show-button-aria-label` - aria label for the trailing show button.
+ * - `hide-button-aria-label` - aria label for the trailing hide button.
  * - all the attributes of the native password field.
  *
  * @tagname mdc-password
@@ -70,10 +71,16 @@ import { PASSWORD_VISIBILITY_ICONS } from './password.constants';
  */
 class Password extends Input {
   /**
-   * Aria label for the show or hide password icon button.
+   * Aria label for the show password icon button.
    */
-  @property({ type: String, attribute: 'show-hide-button-aria-label' })
-  showHideButtonAriaLabel = '';
+  @property({ type: String, attribute: 'show-button-aria-label' })
+  showButtonAriaLabel = '';
+
+  /**
+   * Aria label for the hide password icon button.
+   */
+  @property({ type: String, attribute: 'hide-button-aria-label' })
+  hideButtonAriaLabel = '';
 
   /**
    * The type of help text. It can be 'default', 'error', 'warning', 'success', 'priority'.
@@ -117,7 +124,7 @@ class Password extends Input {
         ?disabled=${this.disabled || this.readonly || !showBtn}
         size="${DEFAULTS.ICON_SIZE}"
         @click=${this.toggleShowPassword}
-        aria-label=${this.showHideButtonAriaLabel}
+        aria-label=${this.showPassword ? this.hideButtonAriaLabel : this.showButtonAriaLabel}
         prefix-icon=${this.showPassword ? PASSWORD_VISIBILITY_ICONS.HIDE_BOLD : PASSWORD_VISIBILITY_ICONS.SHOW_BOLD}
       ></mdc-button>
     `;

--- a/packages/components/src/components/password/password.e2e-test.ts
+++ b/packages/components/src/components/password/password.e2e-test.ts
@@ -27,7 +27,8 @@ type SetupOptions = {
   pattern?: string;
   list?: string;
   size?: number;
-  showHideButtonAriaLabel?: string;
+  showButtonAriaLabel?: string;
+  hideButtonAriaLabel?: string;
   secondButtonForFocus?: boolean;
 };
 
@@ -56,7 +57,8 @@ const setup = async (args: SetupOptions, isForm = false) => {
       ${restArgs.pattern ? `pattern="${restArgs.pattern}"` : ''}
       ${restArgs.list ? `list="${restArgs.list}"` : ''}
       ${restArgs.size ? `size="${restArgs.size}"` : ''}
-      ${restArgs.showHideButtonAriaLabel ? `show-hide-button-aria-label="${restArgs.showHideButtonAriaLabel}"` : ''}
+      ${restArgs.showButtonAriaLabel ? `show-button-aria-label="${restArgs.showButtonAriaLabel}"` : ''}
+      ${restArgs.hideButtonAriaLabel ? `hide-button-aria-label="${restArgs.hideButtonAriaLabel}"` : ''}
       ></mdc-password>
       ${restArgs.secondButtonForFocus ? '<mdc-button>Second Button</mdc-button></div>' : ''}
     ${isForm ? '<mdc-button type="submit" size="24">Submit</mdc-button></form>' : ''}
@@ -81,7 +83,8 @@ test('mdc-password', async ({ componentsPage, browserName }) => {
     placeholder: 'Placeholder',
     maxlength: 10,
     minlength: 5,
-    showHideButtonAriaLabel: 'show-hide button aria-label',
+    showButtonAriaLabel: 'show button aria-label',
+    hideButtonAriaLabel: 'hide button aria-label',
     label: 'Label',
     helpText: 'Help Text',
     secondButtonForFocus: true,
@@ -105,7 +108,8 @@ test('mdc-password', async ({ componentsPage, browserName }) => {
       await expect(password).toHaveAttribute('help-text', 'Help Text');
       const helpText = password.locator('mdc-text[part="help-text"]');
       await expect(helpText).toHaveText('Help Text');
-      await expect(password).toHaveAttribute('show-hide-button-aria-label', 'show-hide button aria-label');
+      await expect(password).toHaveAttribute('show-button-aria-label', 'show button aria-label');
+      await expect(password).toHaveAttribute('hide-button-aria-label', 'hide button aria-label');
     });
 
     await test.step('should the required attribute be present in the component when it sets', async () => {
@@ -148,15 +152,18 @@ test('mdc-password', async ({ componentsPage, browserName }) => {
       await expect(password).toHaveAttribute('size', '10');
     });
 
-    await test.step('should the show-hide-button-aria-label attribute be present in the component when it sets', async () => {
+    await test.step('should the show- & hide-button-aria-label attribute be present in the component when it sets', async () => {
       await setup(defaultSetupOptions);
       await componentsPage.setAttributes(password, {
-        'show-hide-button-aria-label': 'show/hide password',
+        'show-button-aria-label': 'show password',
+        'hide-button-aria-label': 'hide password',
         value: 'test',
       });
       const trailingButton = password.locator('mdc-button[part="trailing-button"]');
       await expect(trailingButton).toBeVisible();
-      await expect(trailingButton).toHaveAttribute('aria-label', 'show/hide password');
+      await expect(trailingButton).toHaveAttribute('aria-label', 'show password');
+      await trailingButton.click();
+      await expect(trailingButton).toHaveAttribute('aria-label', 'hide password');
     });
 
     await test.step('should the autofocus attribute be present in the component when it sets', async () => {
@@ -186,7 +193,8 @@ test('mdc-password', async ({ componentsPage, browserName }) => {
       await setup({
         componentsPage,
         trailingButton: true,
-        showHideButtonAriaLabel: 'show/hide button',
+        showButtonAriaLabel: 'show button',
+        hideButtonAriaLabel: 'hide button',
         secondButtonForFocus: true,
       });
       const showHideButton = password.locator('mdc-button[part="trailing-button"]');
@@ -210,7 +218,8 @@ test('mdc-password', async ({ componentsPage, browserName }) => {
         componentsPage,
         readonly: true,
         value: 'Readonly',
-        showHideButtonAriaLabel: 'show/hide password',
+        showButtonAriaLabel: 'show button',
+        hideButtonAriaLabel: 'hide button',
         secondButtonForFocus: true,
       });
       const trailingButton = password.locator('mdc-button[part="trailing-button"]');
@@ -226,7 +235,8 @@ test('mdc-password', async ({ componentsPage, browserName }) => {
     await test.step('should the password element type toggle between text and password when the trailingbutton is clicked', async () => {
       password = await setup({
         componentsPage,
-        showHideButtonAriaLabel: 'show/hide password',
+        showButtonAriaLabel: 'show button',
+        hideButtonAriaLabel: 'hide button',
         secondButtonForFocus: true,
       });
       const trailingButton = password.locator('mdc-button[part="trailing-button"]');
@@ -253,7 +263,8 @@ test('mdc-password', async ({ componentsPage, browserName }) => {
         componentsPage,
         value: 'this is readonly data',
         readonly: true,
-        showHideButtonAriaLabel: 'show/hide password',
+        showButtonAriaLabel: 'show button',
+        hideButtonAriaLabel: 'hide button',
         secondButtonForFocus: true,
       });
       const trailingButton = password.locator('mdc-button[part="trailing-button"]');
@@ -428,7 +439,8 @@ test('mdc-password', async ({ componentsPage, browserName }) => {
               maxlength="10"
               help-text="Please provide a valid password"
               help-text-type="default"
-              show-hide-button-aria-label="Show or hide password"
+              show-button-aria-label="Show password"
+              hide-button-aria-label="Hide password"
             ></mdc-password>
             <div style="display: flex; gap: 0.25rem; margin-top: 0.25rem">
               <mdc-button type="submit" size="24">Submit</mdc-button>
@@ -517,7 +529,8 @@ test('mdc-password', async ({ componentsPage, browserName }) => {
       placeholder: 'Placeholder',
       label: 'Label',
       'help-text': 'Help Text',
-      'show-hide-button-aria-label': 'show/hide password',
+      'show-button-aria-label': 'show password',
+      'hide-button-aria-label': 'hide password',
     };
     const inputStickerSheet = new StickerSheet(componentsPage, 'mdc-password');
 

--- a/packages/components/src/components/password/password.feature
+++ b/packages/components/src/components/password/password.feature
@@ -10,7 +10,7 @@ Feature: Password Component
   Scenario: Show/Hide button replaces Clear button
     Given the password component is rendered
     Then the trailing button should be a show/hide button instead of a clear button
-    And the button should use the showHideButtonAriaLabel attribute for accessibility
+    And the button should use the showButtonAriaLabel & hideButtonAriaLabel attribute for accessibility
 
   Scenario: Toggle password visibility
     Given the password component is rendered

--- a/packages/components/src/components/password/password.stories.ts
+++ b/packages/components/src/components/password/password.stories.ts
@@ -44,7 +44,8 @@ const render = (args: Args) => {
     pattern="${ifDefined(args.pattern)}"
     list="${ifDefined(args.list)}"
     size="${ifDefined(args.size)}"
-    show-hide-button-aria-label="${args['show-hide-button-aria-label']}"
+    show-button-aria-label="${args['show-button-aria-label']}"
+    hide-button-aria-label="${args['hide-button-aria-label']}"
   ></mdc-password>`;
 };
 const meta: Meta = {
@@ -69,7 +70,10 @@ const meta: Meta = {
       control: 'text',
       description: 'The name of the password field. It is used to identify the password field in a form.',
     },
-    'show-hide-button-aria-label': {
+    'show-button-aria-label': {
+      control: 'text',
+    },
+    'hide-button-aria-label': {
       control: 'text',
     },
     label: {
@@ -167,7 +171,8 @@ export const Example: StoryObj = {
     readonly: false,
     disabled: false,
     required: true,
-    'show-hide-button-aria-label': 'Show or hide password',
+    'show-button-aria-label': 'Show password',
+    'hide-button-aria-label': 'Hide password',
     'validation-message': '',
   },
 };
@@ -205,7 +210,8 @@ export const FormFieldPassword: StoryObj = {
     required: true,
     'help-text': 'Enter a strong password',
     'help-text-type': 'default',
-    'show-hide-button-aria-label': 'Show or hide password',
+    'show-button-aria-label': 'Show password',
+    'hide-button-aria-label': 'Hide password',
     'validation-message': 'Password must be between 5 and 10 characters.',
     minlength: 5,
     maxlength: 10,
@@ -269,7 +275,8 @@ export const FormFieldPasswordWithHelpTextValidation: StoryObj = {
             maxlength=${ifDefined(args.maxlength)}
             help-text=${args['help-text']}
             help-text-type=${args['help-text-type']}
-            show-hide-button-aria-label=${args['show-hide-button-aria-label']}
+            show-button-aria-label=${args['show-button-aria-label']}
+            hide-button-aria-label=${args['hide-button-aria-label']}
           ></mdc-password>
           <div style="display: flex; gap: 0.25rem; margin-top: 0.25rem">
             <mdc-button type="submit" size="24">Submit</mdc-button>
@@ -288,7 +295,8 @@ export const FormFieldPasswordWithHelpTextValidation: StoryObj = {
     maxlength: 10,
     'help-text': 'Please provide a valid password',
     'help-text-type': 'default',
-    'show-hide-button-aria-label': 'Show or hide password',
+    'show-button-aria-label': 'Show password',
+    'hide-button-aria-label': 'Hide password',
   },
 };
 
@@ -299,7 +307,8 @@ export const DefaultValidation: StoryObj = {
     'help-text-type': 'default',
     placeholder: 'Enter password',
     value: 'default_password123',
-    'show-hide-button-aria-label': 'Toggle password visibility',
+    'show-button-aria-label': 'Show password',
+    'hide-button-aria-label': 'Hide password',
   },
 };
 
@@ -310,7 +319,8 @@ export const ErrorValidation: StoryObj = {
     'help-text-type': 'error',
     placeholder: 'Enter password',
     value: 'error_password123',
-    'show-hide-button-aria-label': 'Toggle password visibility',
+    'show-button-aria-label': 'Show password',
+    'hide-button-aria-label': 'Hide password',
   },
 };
 
@@ -321,6 +331,7 @@ export const SuccessValidation: StoryObj = {
     'help-text-type': 'success',
     placeholder: 'Enter password',
     value: 'success_password123',
-    'show-hide-button-aria-label': 'Toggle password visibility',
+    'show-button-aria-label': 'Show password',
+    'hide-button-aria-label': 'Hide password',
   },
 };


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

**API Breaking Change:**
- [Password] Changed showHideButtonAriaLabel to 2 separate attributes (showButtonAriaLabel and hideButtonAriaLabel) for more explicit aria labeling