### PR TITLE
fix(select): focus getting trapped on select element and escape not bubbling

### DIFF
--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -637,34 +637,40 @@ class Select
     if (this.disabled || this.softDisabled || this.readonly) {
       return;
     }
+
     switch (event.key) {
       case KEYS.ARROW_DOWN:
       case KEYS.ARROW_UP:
       case KEYS.ENTER:
       case KEYS.SPACE:
         this.displayPopover = true;
+        event.preventDefault();
         event.stopPropagation();
         break;
       case KEYS.HOME: {
         this.displayPopover = true;
         this.resetTabIndexAndSetFocusAfterUpdate(0);
+        event.preventDefault();
+        event.stopPropagation();
         break;
       }
       case KEYS.END: {
         this.displayPopover = true;
         this.resetTabIndexAndSetFocusAfterUpdate(this.navItems.length - 1);
+        event.preventDefault();
+        event.stopPropagation();
         break;
       }
       default: {
         if (event.key.length === 1) {
           this.displayPopover = true;
           this.handleSelectedOptionByKeyInput(event.key);
+          event.preventDefault();
+          event.stopPropagation();
         }
         break;
       }
     }
-    event.preventDefault();
-    event.stopPropagation();
   }
 
   private resetTabIndexAndSetFocusAfterUpdate(newOptionIndex: number): void {

--- a/packages/components/src/components/select/select.e2e-test.ts
+++ b/packages/components/src/components/select/select.e2e-test.ts
@@ -924,5 +924,14 @@ test('mdc-select', async ({ componentsPage }) => {
         await expect(select.locator('mdc-option').nth(1)).toHaveAttribute('value', 'option3');
       });
     });
+
+    await test.step('should handle tab correctly when dropdown is closed', async () => {
+      const form = await setup({ componentsPage, children: defaultChildren() }, true);
+      await componentsPage.actionability.pressTab();
+      await expect(form.locator('mdc-select')).toBeFocused();
+
+      await componentsPage.actionability.pressTab();
+      await expect(form.locator('mdc-button')).toBeFocused();
+    });
   });
 });


### PR DESCRIPTION
### Description

**Bug fixes:**
Fix Tab and Escape keys not bubbling above a select element making a focus trap.
