### PR TITLE
fix: navmenuitem a11y fixes

### DIFF
--- a/packages/components/src/components/navmenuitem/navmenuitem.component.ts
+++ b/packages/components/src/components/navmenuitem/navmenuitem.component.ts
@@ -1,4 +1,4 @@
-import type { CSSResult, TemplateResult } from 'lit';
+import type { CSSResult, PropertyValues, TemplateResult } from 'lit';
 import { html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -14,6 +14,7 @@ import { TAG_NAME as TOOLTIP_TAG_NAME } from '../tooltip/tooltip.constants';
 import type { IconNames } from '../icon/icon.types';
 import type { PopoverPlacement } from '../popover/popover.types';
 import { getIconNameWithoutStyle } from '../button/button.utils';
+import type { TooltipType } from '../tooltip/tooltip.types';
 
 import type { BadgeType } from './navmenuitem.types';
 import { ALLOWED_BADGE_TYPES, DEFAULTS, ICON_NAME } from './navmenuitem.constants';
@@ -170,6 +171,17 @@ class NavMenuItem extends MenuItem {
   tooltipPlacement: PopoverPlacement = 'right';
 
   /**
+   * The type of tooltip to display.
+   * Options are 'description', 'label', or 'none'.
+   *
+   * Choose none to not apply any aria-attributes - this
+   * is useful if the navmenuitem has a aria-label already set.
+   * @default undefined
+   */
+  @property({ type: String, reflect: true, attribute: 'tooltip-type' })
+  tooltipType?: TooltipType;
+
+  /**
    * The appearance behavior of the tooltip.
    * Options are 'when-collapsed' (default) or 'always'.
    *
@@ -231,6 +243,14 @@ class NavMenuItem extends MenuItem {
     this.removeTooltip();
   }
 
+  protected override firstUpdated(_changedProperties: PropertyValues): void {
+    super.firstUpdated(_changedProperties);
+    // if active on initial render, set aria-current
+    if (this.active && !this.disableAriaCurrent && !this.cannotActivate) {
+      this.setAttribute('aria-current', 'page');
+    }
+  }
+
   protected override updated(changedProperties: Map<string, any>): void {
     super.updated(changedProperties);
 
@@ -279,6 +299,9 @@ class NavMenuItem extends MenuItem {
     tooltip.setAttribute('triggerid', this.id);
     tooltip.setAttribute('show-arrow', '');
     tooltip.setAttribute('placement', this.tooltipPlacement);
+    if (this.tooltipType) {
+      tooltip.setAttribute('tooltip-type', this.tooltipType);
+    }
     tooltip.setAttribute('boundary-padding', this.tooltipBoundaryPadding?.toString() || '0');
 
     // Set the slot attribute if the parent element has a slot.

--- a/packages/components/src/components/navmenuitem/navmenuitem.e2e-test.ts
+++ b/packages/components/src/components/navmenuitem/navmenuitem.e2e-test.ts
@@ -13,6 +13,7 @@ type SetupOptions = {
   'badge-type'?: string;
   counter?: number;
   'tooltip-text'?: string;
+  'tooltip-type'?: string;
   'max-counter'?: number;
   'nav-id'?: string;
   'show-label'?: boolean;
@@ -41,6 +42,7 @@ const setup = async (args: SetupOptions) => {
         ${restArgs.counter ? `counter="${restArgs.counter}"` : ''}
         ${restArgs['max-counter'] ? `max-counter="${restArgs['max-counter']}"` : ''}
         ${restArgs['tooltip-text'] ? `tooltip-text="${restArgs['tooltip-text']}"` : ''}
+        ${restArgs['tooltip-type'] ? `tooltip-type="${restArgs['tooltip-type']}"` : ''}
         ${restArgs['nav-id'] ? `nav-id="${restArgs['nav-id']}"` : ''}
         ${restArgs['show-label'] ? 'show-label' : ''}
         ${restArgs['aria-label'] ? `aria-label="${restArgs['aria-label']}"` : ''}
@@ -231,8 +233,9 @@ test.describe('NavMenuItem Feature Scenarios', () => {
           active: true,
         });
 
-        await test.step('should have active attribute', async () => {
+        await test.step('should have active attribute & aria-current="page"', async () => {
           await expect(navmenuitem).toHaveAttribute('active');
+          await expect(navmenuitem).toHaveAttribute('aria-current', 'page');
         });
 
         await test.step('should modify icon to filled variant when active', async () => {
@@ -512,6 +515,22 @@ test.describe('NavMenuItem Feature Scenarios', () => {
         });
 
         await expect(navmenuitem).toHaveAttribute('aria-label', primaryLabel);
+      });
+
+      await test.step('depending on tooltip type aria-describedby or aria-label is set', async () => {
+        // When tooltip-text is provided and tooltip-type is not "none", no aria-labelledby and aria-describedby should be set
+        const navmenuitemWithTooltip = await setup({
+          componentsPage,
+          label: primaryLabel,
+          'icon-name': iconName,
+          'nav-id': navId,
+          'show-label': false,
+          'tooltip-text': 'This is a tooltip',
+          'tooltip-type': 'none',
+        });
+
+        await expect(navmenuitemWithTooltip).not.toHaveAttribute('aria-labelledby');
+        await expect(navmenuitemWithTooltip).not.toHaveAttribute('aria-describedby');
       });
     });
 

--- a/packages/components/src/components/navmenuitem/navmenuitem.stories.ts
+++ b/packages/components/src/components/navmenuitem/navmenuitem.stories.ts
@@ -32,6 +32,8 @@ const render = (args: Args) => html`
       aria-label=${ifDefined(args['aria-label'])}
       tooltip-text=${args['tooltip-text']}
       tooltip-placement=${args['tooltip-placement']}
+      tooltip-type=${args['tooltip-type']}
+      tooltip-appearance=${args['tooltip-appearance']}
       tooltip-boundary-padding=${args['tooltip-boundary-padding']}
     ></mdc-navmenuitem>
   </div>
@@ -78,6 +80,14 @@ const meta: Meta = {
     'tooltip-placement': {
       control: 'select',
       options: Object.values(POPOVER_PLACEMENT),
+    },
+    'tooltip-type': {
+      control: 'select',
+      options: ['description', 'label', 'none'],
+    },
+    'tooltip-appearance': {
+      control: 'select',
+      options: ['when-collapsed', 'always'],
     },
     'tooltip-boundary-padding': {
       control: 'number',

--- a/packages/components/src/components/tooltip/tooltip.constants.ts
+++ b/packages/components/src/components/tooltip/tooltip.constants.ts
@@ -7,7 +7,7 @@ const TOOLTIP_TYPES = {
   DESCRIPTION: 'description',
   LABEL: 'label',
   NONE: 'none',
-};
+} as const;
 
 const DEFAULTS = {
   BACKDROP: false,


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

- [NavMenuItem] - fixes an issues where if the NavMenuItem is active on render, it is not setting aria-current="page" as expected
- [NavMenuItem] - passing through tooltip-type attribute to give more control to users if a tooltip should apply aria-attributes or not (useful for collapsed case where the aria-label might be the same as tooltip = Screenreader reading out the same label twice)
