### PR TITLE
fix: Judge the background color of the buttons below the dialog box

### DIFF
--- a/packages/components/src/utils/mixins/FooterMixin.ts
+++ b/packages/components/src/utils/mixins/FooterMixin.ts
@@ -50,16 +50,18 @@ export const FooterMixin = <T extends Constructor<LitElement>>(superClass: T) =>
      *
      * @internal
      */
-    protected updateFooterButtonColors(variant: string) {
+  protected updateFooterButtonColors(variant: string) {
       const footerButtons = [...(this.footerButtonPrimary || []), ...(this.footerButtonSecondary || [])];
       footerButtons?.forEach(button => {
-        if (variant === VARIANTS.PROMOTIONAL) {
-          button.setAttribute('color', BUTTON_COLORS.PROMOTIONAL);
-        } else {
-          button.setAttribute('color', BUTTON_COLORS.DEFAULT);
+        if (!button.hasAttribute('color')) {
+          if (variant === VARIANTS.PROMOTIONAL) {
+            button.setAttribute('color', BUTTON_COLORS.PROMOTIONAL);
+          } else {
+            button.setAttribute('color', BUTTON_COLORS.DEFAULT);
+          }
         }
       });
-    }
+  }
 
     /**
      * Filters and renders only the following content into the footer section and removes anything other than it


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

This PR fixes an issue where the FooterMixin was overriding the color attribute of footer buttons even when a color was already set.  The logic now respects existing color attributes and only applies the default or promotional colors when none are defined.
