### PR TITLE
fix(searchpopver): if display-popover is true and input gets focus, show popover

### DIFF
--- a/packages/components/src/components/searchpopover/searchpopover.component.ts
+++ b/packages/components/src/components/searchpopover/searchpopover.component.ts
@@ -1,6 +1,6 @@
 import { CSSResult, html } from 'lit';
 import { classMap } from 'lit-html/directives/class-map.js';
-import { property } from 'lit/decorators.js';
+import { property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
 
@@ -9,6 +9,7 @@ import { KEYS } from '../../utils/keys';
 import { POPOVER_PLACEMENT, DEFAULTS as POPOVER_DEFAULTS } from '../popover/popover.constants';
 import { DEFAULTS as FORMFIELD_DEFAULTS } from '../formfieldwrapper/formfieldwrapper.constants';
 import { ROLE } from '../../utils/roles';
+import type Popover from '../popover/popover.component';
 
 import styles from './searchpopover.styles';
 import { DEFAULTS, TRIGGER_ID, POPOVER_ID } from './searchpopover.constants';
@@ -84,6 +85,9 @@ import type { Placement } from './searchpopover.types';
  * @csspart popover-content - The popover content element.
  */
 class Searchpopover extends Searchfield {
+  @query(`#${POPOVER_ID}`)
+  protected popoverElement!: Popover;
+
   /**
    * Whether to display the popover.
    * @default false
@@ -119,6 +123,12 @@ class Searchpopover extends Searchfield {
   @property({ type: String, reflect: true, attribute: 'popover-aria-label' })
   popoverAriaLabel?: string;
 
+  private onInputFocus() {
+    if (this.displayPopover) {
+      this.popoverElement.show();
+    }
+  }
+
   protected override renderInputElement() {
     const placeholderText = this.hasInputChips ? '' : this.placeholder;
 
@@ -152,6 +162,7 @@ class Searchpopover extends Searchfield {
       @input=${this.onInput}
       @change=${this.onChange}
       @keydown=${this.handleKeyDown}
+      @focus=${this.onInputFocus}
       role=${ifDefined(ROLE.COMBOBOX)}
     />`;
   }

--- a/packages/components/src/components/searchpopover/searchpopover.e2e-test.ts
+++ b/packages/components/src/components/searchpopover/searchpopover.e2e-test.ts
@@ -232,5 +232,12 @@ test('mdc-searchpopover', async ({ componentsPage }) => {
       await expect(clearBtn).not.toBeFocused();
       await expect(firstListItemInPopover).toBeFocused();
     });
+
+    await test.step('popover should show again when the input is focused and display-popover is true', async () => {
+      await componentsPage.page.keyboard.press('Escape');
+      await firstListItemInPopover.waitFor({ state: 'hidden' });
+      await inputEl.focus();
+      await expect(firstListItemInPopover).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
### Description

- [searchpopover] If the display-popover prop is true and the input is focused, show the popover again
  - Right now if the user clicks outside the popover or presses escape, the popover will not be displayed again unless the display-popover prop is removed and readded.

**Breaking Changes:**

- No API changes.
- Changes current behaviour, the popover will now show when the display-popover prop is true and the input gets focus.
