### PR TITLE
chore(tab): add size 28 tab

### DIFF
--- a/packages/components/src/components/tab/tab.component.ts
+++ b/packages/components/src/components/tab/tab.component.ts
@@ -5,14 +5,14 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import type { IconNames } from '../icon/icon.types';
 import { getIconNameWithoutStyle } from '../button/button.utils';
 import Buttonsimple from '../buttonsimple/buttonsimple.component';
-import { ButtonSize, ButtonType } from '../buttonsimple/buttonsimple.types';
+import type { ButtonType } from '../buttonsimple/buttonsimple.types';
 import { TYPE, VALID_TEXT_TAGS } from '../text/text.constants';
 import { IconNameMixin } from '../../utils/mixins/IconNameMixin';
 import { ROLE } from '../../utils/roles';
 import { LifeCycleMixin } from '../../utils/mixins/lifecycle/LifeCycleMixin';
 
-import type { Variant } from './tab.types';
-import { DEFAULTS, TAB_VARIANTS } from './tab.constants';
+import type { TabSize, Variant } from './tab.types';
+import { DEFAULTS, TAB_SIZES, TAB_VARIANTS } from './tab.constants';
 import styles from './tab.styles';
 
 /**
@@ -109,6 +109,15 @@ class Tab extends IconNameMixin(LifeCycleMixin(Buttonsimple)) {
   variant: Variant = DEFAULTS.VARIANT;
 
   /**
+   * Size of the tab in pixels.
+   * - `32`: Default size (2rem)
+   * - `28`: Compact size (1.75rem)
+   * @default 32
+   */
+  @property({ type: Number, reflect: true })
+  override size: TabSize = DEFAULTS.SIZE;
+
+  /**
    * Id of the tab (used as a identificator when used in the tablist)
    * Note: has to be unique!
    *
@@ -120,7 +129,6 @@ class Tab extends IconNameMixin(LifeCycleMixin(Buttonsimple)) {
   override connectedCallback(): void {
     super.connectedCallback();
     this.role = ROLE.TAB;
-    this.size = undefined as unknown as ButtonSize;
     this.type = undefined as unknown as ButtonType;
 
     this.ariaStateKey = 'aria-selected';
@@ -139,6 +147,17 @@ class Tab extends IconNameMixin(LifeCycleMixin(Buttonsimple)) {
    */
   private setVariant(variant: Variant): void {
     this.setAttribute('variant', Object.values(TAB_VARIANTS).includes(variant) ? variant : DEFAULTS.VARIANT);
+  }
+
+  /**
+   * Sets the size attribute for the tab component.
+   * If the provided size is not included in TAB_SIZES,
+   * it defaults to the value specified in DEFAULTS.SIZE.
+   *
+   * @param size - The size to set.
+   */
+  private setSize(size: TabSize): void {
+    this.setAttribute('size', Object.values(TAB_SIZES).includes(size) ? `${size}` : DEFAULTS.SIZE.toString());
   }
 
   /**
@@ -176,6 +195,9 @@ class Tab extends IconNameMixin(LifeCycleMixin(Buttonsimple)) {
 
   public override update(changedProperties: PropertyValues): void {
     super.update(changedProperties);
+    if (changedProperties.has('size')) {
+      this.setSize(this.size);
+    }
     if (changedProperties.has('variant')) {
       this.setVariant(this.variant);
     }

--- a/packages/components/src/components/tab/tab.constants.ts
+++ b/packages/components/src/components/tab/tab.constants.ts
@@ -8,9 +8,15 @@ const TAB_VARIANTS = {
   PILL: 'pill',
 } as const;
 
+const TAB_SIZES = {
+  32: 32,
+  28: 28,
+} as const;
+
 const DEFAULTS = {
   VARIANT: TAB_VARIANTS.PILL,
   ACTIVE: false,
+  SIZE: TAB_SIZES[32],
 } as const;
 
-export { DEFAULTS, TAG_NAME, TAB_VARIANTS };
+export { DEFAULTS, TAG_NAME, TAB_VARIANTS, TAB_SIZES };

--- a/packages/components/src/components/tab/tab.e2e-test.ts
+++ b/packages/components/src/components/tab/tab.e2e-test.ts
@@ -4,8 +4,8 @@ import { ComponentsPage, test } from '../../../config/playwright/setup';
 import StickerSheet from '../../../config/playwright/setup/utils/Stickersheet';
 import type { IconNames } from '../icon/icon.types';
 
-import { DEFAULTS, TAB_VARIANTS } from './tab.constants';
-import type { Variant } from './tab.types';
+import { DEFAULTS, TAB_SIZES, TAB_VARIANTS } from './tab.constants';
+import type { TabSize, Variant } from './tab.types';
 
 type SetupOptions = {
   componentsPage: ComponentsPage;
@@ -14,6 +14,7 @@ type SetupOptions = {
   softDisabled?: boolean;
   iconName?: IconNames;
   role?: string;
+  size?: TabSize;
   tabIndex?: number;
   text?: string;
   variant?: Variant;
@@ -32,6 +33,7 @@ const setup = async (args: SetupOptions) => {
         ${restArgs.disabled ? 'disabled' : ''}
         ${restArgs.softDisabled ? 'soft-disabled' : ''}
         ${restArgs.iconName ? `icon-name="${restArgs.iconName}"` : ''}
+        ${restArgs.size ? `size="${restArgs.size}"` : ''}
         ${restArgs.tabIndex ? `tabindex="${restArgs.tabIndex}"` : ''}
         ${restArgs.text ? `text="${restArgs.text}"` : ''}
         ${restArgs.variant ? `variant="${restArgs.variant}"` : DEFAULTS.VARIANT}>
@@ -66,6 +68,7 @@ test('mdc-tab', async ({ componentsPage }) => {
         await expect(tab).toHaveAttribute('aria-selected', 'false');
         await expect(tab).toHaveRole('tab');
         await expect(tab).toHaveAttribute('tabindex', '0');
+        await expect(tab).toHaveAttribute('size', `${DEFAULTS.SIZE}`);
         await expect(tab).toHaveAttribute('text', 'Label');
         await expect(tab).toHaveAttribute('variant', DEFAULTS.VARIANT);
         await expect(tab).not.toHaveAttribute('active');
@@ -140,15 +143,30 @@ test('mdc-tab', async ({ componentsPage }) => {
         await componentsPage.setAttributes(tab, { tabindex: '0' });
       });
 
+      // size
+      await Object.values(TAB_SIZES).reduce(async (previous, tabSize) => {
+        await previous;
+        await test.step(`attribute size ${tabSize} should be present as expected`, async () => {
+          await componentsPage.setAttributes(tab, { size: `${tabSize}` });
+          await expect(tab).toHaveAttribute('size', `${tabSize}`);
+        });
+      }, Promise.resolve());
+
+      // invalid tab size
+      const tabSize = '99';
+      await test.step(`attribute size with invalid value ${tabSize}, it should update to default`, async () => {
+        await componentsPage.setAttributes(tab, { size: tabSize });
+        await expect(tab).toHaveAttribute('size', `${DEFAULTS.SIZE}`);
+      });
+
       // variant
-      // eslint-disable-next-line no-restricted-syntax
-      for (const tabVariant of Object.values(TAB_VARIANTS)) {
-        // eslint-disable-next-line no-await-in-loop
+      await Object.values(TAB_VARIANTS).reduce(async (previous, tabVariant) => {
+        await previous;
         await test.step(`attribute variant ${tabVariant} should be present as expected`, async () => {
           await componentsPage.setAttributes(tab, { variant: tabVariant });
           await expect(tab).toHaveAttribute('variant', tabVariant);
         });
-      }
+      }, Promise.resolve());
 
       // invalid tab variant
       const tabVariant = 'invalid-variant';

--- a/packages/components/src/components/tab/tab.stories.ts
+++ b/packages/components/src/components/tab/tab.stories.ts
@@ -10,7 +10,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { hideAllControls, hideControls, readOnlyControls } from '../../../config/storybook/utils';
 import { ROLE } from '../../utils/roles';
 
-import { TAB_VARIANTS } from './tab.constants';
+import { TAB_SIZES, TAB_VARIANTS } from './tab.constants';
 
 const render = (args: Args) =>
   html`<div role="tablist">
@@ -25,6 +25,7 @@ const render = (args: Args) =>
       ?disabled="${args.disabled}"
       ?soft-disabled="${args['soft-disabled']}"
       icon-name="${ifDefined(args['icon-name'])}"
+      size="${ifDefined(args.size)}"
       tabIndex="${ifDefined(args.tabIndex)}"
       text="${ifDefined(args.text)}"
       variant="${ifDefined(args.variant)}"
@@ -56,6 +57,11 @@ const meta: Meta = {
     tabIndex: {
       control: 'number',
     },
+    size: {
+      control: 'select',
+      options: Object.values(TAB_SIZES),
+      description: 'Size of the tab in pixels.',
+    },
     text: {
       control: 'text',
     },
@@ -66,7 +72,7 @@ const meta: Meta = {
     'auto-focus-on-mount': {
       control: 'boolean',
     },
-    ...hideControls(['role', 'size', 'type', 'Slot Name: ""']),
+    ...hideControls(['role', 'type', 'Slot Name: ""']),
   },
 };
 
@@ -77,6 +83,7 @@ const defaultArgs = {
   disabled: false,
   'icon-name': 'placeholder-bold',
   role: 'tab',
+  size: TAB_SIZES[32],
   tabIndex: 0,
   text: 'Label',
   variant: TAB_VARIANTS.PILL,
@@ -146,6 +153,7 @@ export const CustomPrefixSlot: StoryObj = {
         aria-label="${ifDefined(args.text ? nothing : 'Label')}"
         ?disabled="${args.disabled}"
         ?soft-disabled="${args['soft-disabled']}"
+        size="${ifDefined(args.size)}"
         tabIndex="${ifDefined(args.tabIndex)}"
         text="${ifDefined(args.text)}"
         variant="${ifDefined(args.variant)}"

--- a/packages/components/src/components/tab/tab.styles.ts
+++ b/packages/components/src/components/tab/tab.styles.ts
@@ -37,6 +37,10 @@ const styles = [
       border-radius: var(--mdc-tab-border-radius);
     }
 
+    :host([size='28']) {
+      --mdc-tab-height: 1.75rem;
+    }
+
     :host::part(container) {
       display: flex;
       width: 100%;

--- a/packages/components/src/components/tab/tab.types.ts
+++ b/packages/components/src/components/tab/tab.types.ts
@@ -1,11 +1,12 @@
 import { TypedCustomEvent, ValueOf } from '../../utils/types';
 
 import type Tab from './tab.component';
-import { TAB_VARIANTS } from './tab.constants';
+import { TAB_SIZES, TAB_VARIANTS } from './tab.constants';
 
 type Variant = ValueOf<typeof TAB_VARIANTS>;
+type TabSize = ValueOf<typeof TAB_SIZES>;
 interface Events {
   onActiveChangeEvent: TypedCustomEvent<Tab, { tabId: string; active: boolean }>;
 }
 
-export type { Variant, Events };
+export type { Variant, TabSize, Events };

--- a/packages/components/src/components/tablist/tablist.stories.ts
+++ b/packages/components/src/components/tablist/tablist.stories.ts
@@ -4,7 +4,7 @@ import '.';
 import { html } from 'lit';
 
 import { describeStory, hideControls } from '../../../config/storybook/utils';
-import { TAB_VARIANTS } from '../tab/tab.constants';
+import { TAB_SIZES, TAB_VARIANTS } from '../tab/tab.constants';
 import '../badge';
 import '../tab';
 import { ROLE } from '../../utils/roles';
@@ -16,6 +16,7 @@ const render = (args: Args) =>
       data-aria-label=${args['data-aria-label']}
     >
       <mdc-tab
+        size=${args.tabsize}
         variant=${args.tabvariant}
         text="Calls"
         icon-name="audio-call-bold"
@@ -24,6 +25,7 @@ const render = (args: Args) =>
       >
       </mdc-tab>
       <mdc-tab
+        size=${args.tabsize}
         variant=${args.tabvariant}
         text="Videos"
         icon-name="video-bold"
@@ -33,6 +35,7 @@ const render = (args: Args) =>
         <mdc-badge slot="postfix" type="counter" counter="5" aria-label="5 New videos"></mdc-badge>
       </mdc-tab>
       <mdc-tab
+        size=${args.tabsize}
         variant=${args.tabvariant}
         text="Music"
         icon-name="file-music-bold"
@@ -41,6 +44,7 @@ const render = (args: Args) =>
       >
       </mdc-tab>
       <mdc-tab
+        size=${args.tabsize}
         variant=${args.tabvariant}
         text="Documents"
         icon-name="document-bold"
@@ -49,6 +53,7 @@ const render = (args: Args) =>
       >
       </mdc-tab>
       <mdc-tab
+        size=${args.tabsize}
         variant=${args.tabvariant}
         text="Meetings"
         icon-name="calendar-month-bold"
@@ -97,6 +102,11 @@ const meta: Meta = {
       description: 'Set the variant of tab inside the tablist',
       options: Object.values(TAB_VARIANTS),
     },
+    tabsize: {
+      control: 'select',
+      description: 'Set the size of tabs inside the tablist',
+      options: Object.values(TAB_SIZES),
+    },
     ...hideControls(['itemsStore']),
   },
 };
@@ -107,6 +117,7 @@ export const Example: StoryObj = {
   args: {
     'active-tab-id': 'documents-tab',
     'data-aria-label': 'Media types',
+    tabsize: TAB_SIZES[32],
     tabvariant: 'line',
   },
 };
@@ -136,6 +147,7 @@ export const TablistWithPanels: StoryObj = {
         data-aria-label=${args['data-aria-label']}
       >
         <mdc-tab
+          size=${args.tabsize}
           variant=${args.tabvariant}
           text="Calls"
           icon-name="audio-call-bold"
@@ -144,6 +156,7 @@ export const TablistWithPanels: StoryObj = {
         >
         </mdc-tab>
         <mdc-tab
+          size=${args.tabsize}
           variant=${args.tabvariant}
           text="Videos"
           icon-name="video-bold"
@@ -153,6 +166,7 @@ export const TablistWithPanels: StoryObj = {
           <mdc-badge slot="badge" type="counter" counter="5" aria-label="5 New videos"></mdc-badge>
         </mdc-tab>
         <mdc-tab
+          size=${args.tabsize}
           variant=${args.tabvariant}
           text="Music"
           icon-name="file-music-bold"
@@ -161,6 +175,7 @@ export const TablistWithPanels: StoryObj = {
         >
         </mdc-tab>
         <mdc-tab
+          size=${args.tabsize}
           variant=${args.tabvariant}
           text="Documents"
           icon-name="document-bold"
@@ -169,6 +184,7 @@ export const TablistWithPanels: StoryObj = {
         >
         </mdc-tab>
         <mdc-tab
+          size=${args.tabsize}
           variant=${args.tabvariant}
           text="Meetings"
           icon-name="calendar-month-bold"
@@ -199,6 +215,7 @@ This markup is not part of the component and is only provided for context. -->
   },
   args: {
     tabvariant: 'glass',
+    tabsize: TAB_SIZES[32],
     'active-tab-id': 'documents-tab',
     'data-aria-label': 'Media types',
   },


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

Adds explicit public `size` support to `mdc-tab`, aligned with the existing button-style API, while limiting valid values to `32` and `28`. The new compact size only changes the tab height; typography and the rest of the tab styling remain unchanged. This also updates the tab and tablist Storybook examples to expose the size option and adds tab e2e coverage for supported sizes plus invalid-size fallback behavior.
