### PR TITLE
fix(virtualizedlist): introduce isItemNavigable to allow keyboard navigation to work with headers and disabled items

### DIFF
--- a/packages/components/src/components/virtualizedlist/helpers/virtualizedWrapperWithHeaders.stories.utils.ts
+++ b/packages/components/src/components/virtualizedlist/helpers/virtualizedWrapperWithHeaders.stories.utils.ts
@@ -1,0 +1,115 @@
+// AI-Assisted
+import { html } from 'lit';
+import { state, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+
+import { Component } from '../../../models';
+import '../../list';
+import '../../listitem';
+import '../../listheader';
+import { VirtualData, type VirtualizedListVirtualItemsChangeEvent, VirtualizerProps } from '../virtualizedlist.types';
+
+const ITEMS_PER_GROUP = 10;
+const GROUP_COUNT = 2;
+
+type ListEntry = { type: 'header'; label: string; key: string } | { type: 'item'; label: string; key: string };
+
+function buildEntries(): ListEntry[] {
+  const entries: ListEntry[] = [];
+  for (let g = 0; g < GROUP_COUNT; g += 1) {
+    entries.push({ type: 'header', label: `Group ${g + 1}`, key: `header-${g}` });
+    for (let i = 0; i < ITEMS_PER_GROUP; i += 1) {
+      const itemIndex = g * ITEMS_PER_GROUP + i;
+      entries.push({ type: 'item', label: `List item number ${itemIndex + 1}`, key: `item-${itemIndex}` });
+    }
+  }
+  return entries;
+}
+
+const ALL_ENTRIES = buildEntries();
+
+export class VirtualizedWrapperWithHeadersStoriesUtils extends Component {
+  public override onscroll: ((this: GlobalEventHandlers, ev: Event) => void) | null;
+
+  @property({ type: Object, attribute: 'virtualizerprops' })
+  virtualizerProps: VirtualizerProps = {
+    count: ALL_ENTRIES.length,
+    estimateSize: () => 36,
+    getItemKey: index => ALL_ENTRIES[index]?.key ?? String(index),
+    isItemNavigable: index => ALL_ENTRIES[index].type === 'item',
+  };
+
+  @property({ type: String, reflect: true })
+  loop: 'true' | 'false' = 'false';
+
+  @property({ type: Number, reflect: true, attribute: 'initial-focus' })
+  initialFocus: number = 0;
+
+  @state()
+  virtualData: VirtualData = { virtualItems: [] };
+
+  constructor() {
+    super();
+    this.onscroll = null;
+  }
+
+  private renderEntry(index: number) {
+    const entry = ALL_ENTRIES[index];
+    if (!entry) return html``;
+
+    if (entry.type === 'header') {
+      return html`<mdc-listheader data-index=${index} header-text="${entry.label}"></mdc-listheader>`;
+    }
+
+    return html`<mdc-listitem data-index=${index} label="${entry.label}"></mdc-listitem>`;
+  }
+
+  private handleVirtualItemsChange = (event: VirtualizedListVirtualItemsChangeEvent) => {
+    this.virtualData = event.detail;
+  };
+
+  protected override createRenderRoot(): HTMLElement | DocumentFragment {
+    return this;
+  }
+
+  override render() {
+    return html`
+      <div id="VirtualizedWrapperWithHeaders--wrapper">
+        <mdc-virtualizedlist
+          @scroll=${this.onscroll}
+          @virtualitemschange=${this.handleVirtualItemsChange}
+          .virtualizerProps=${this.virtualizerProps}
+          initial-focus=${this.initialFocus}
+          loop=${this.loop}
+        >
+          ${repeat(
+            this.virtualData.virtualItems,
+            ({ key }) => key,
+            ({ index }) => this.renderEntry(index),
+          )}
+        </mdc-virtualizedlist>
+      </div>
+      <style>
+        mdc-virtualizedwrapperwithheaders {
+          display: block;
+          width: 100%;
+          height: 100%;
+          flex: 1 1 auto;
+        }
+        #VirtualizedWrapperWithHeaders--wrapper {
+          width: 500px;
+          height: 500px;
+        }
+      </style>
+    `;
+  }
+}
+
+VirtualizedWrapperWithHeadersStoriesUtils.register('mdc-virtualizedwrapperwithheaders');
+
+declare global {
+  interface HTMLElementTagNameMap {
+    ['mdc-virtualizedwrapperwithheaders']: VirtualizedWrapperWithHeadersStoriesUtils;
+  }
+}
+// End AI-Assisted

--- a/packages/components/src/components/virtualizedlist/helpers/virtualizedlist.e2e-test.utils.ts
+++ b/packages/components/src/components/virtualizedlist/helpers/virtualizedlist.e2e-test.utils.ts
@@ -17,7 +17,7 @@ function generateUUID(): string {
   return `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 }
 
-type Item = { id: string; message: string; size?: number };
+type Item = { id: string; message: string; size?: number; disabled?: boolean; header?: true };
 
 export class VirtualizedListE2E extends Component {
   @property({ type: Number, reflect: true, attribute: 'item-height' })
@@ -83,8 +83,9 @@ export class VirtualizedListE2E extends Component {
   private getVirtualizerProps(): VirtualizerProps {
     return {
       count: this.items.length,
-      estimateSize: () => this.itemHeight,
+      estimateSize: index => (this.items[index].header ? 36 : this.itemHeight),
       getItemKey: index => this.items[index]?.id,
+      isItemNavigable: index => !this.items[index]?.disabled && !this.items[index]?.header,
     };
   }
 
@@ -160,13 +161,18 @@ export class VirtualizedListE2E extends Component {
   }
 
   private generateListItem({ index }: VirtualItem): TemplateResult {
-    const { message, size } = this.items[index];
+    const { message, size, header, disabled } = this.items[index];
+
+    if (header) {
+      return html`<mdc-listheader data-index=${index} header-text="${message}"></mdc-listheader>`;
+    }
 
     return html`
       <mdc-listitem
         data-index=${index}
         label=${message}
         style=${styleMap({ '--mdc-listitem-height': size ? `${size}px` : undefined })}
+        ?disabled=${disabled}
       >
         <mdc-button slot="trailing-controls" variant="secondary" size="24" id="btn-${index}">Label</mdc-button>
         ${this.withTooltip

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.component.ts
@@ -106,6 +106,14 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
   public virtualizerProps: VirtualizerProps = DEFAULTS.VIRTUALIZER_PROPS;
 
   /**
+   * Returns the isItemNavigable callback, falling back to the default that treats all items as navigable.
+   * @internal
+   */
+  private get isItemNavigable(): (index: number) => boolean {
+    return this.virtualizerProps.isItemNavigable ?? DEFAULTS.VIRTUALIZER_PROPS.isItemNavigable;
+  }
+
+  /**
    * Whether to loop navigation when reaching the end of the list.
    * If 'true', pressing the down arrow on the last item will focus the first item,
    * and pressing the up arrow on the first item will focus the last item.
@@ -588,6 +596,20 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
       // eslint-disable-next-line no-param-reassign
       item.tabIndex = tabable ? 0 : -1;
 
+      // onStoreUpdate fires before the item enters the cache, so super.navItems is still empty
+      // for the first navigable item. If selectedIndex targets a non-navigable item,
+      // fall back to this first navigable item.
+      if (!tabable && super.navItems.length === 0) {
+        if (!this.isItemNavigable(this.selectedIndex)) {
+          // eslint-disable-next-line no-param-reassign
+          item.tabIndex = 0;
+          const itemIndex = this.virtualizer?.indexFromElement(item);
+          if (itemIndex !== undefined) {
+            this.setSelectedIndex(itemIndex);
+          }
+        }
+      }
+
       this.setAriaSetSize(item);
     } else if (changeType === 'removed') {
       if (item.tabIndex === 0) {
@@ -691,6 +713,19 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
     this.setSelectedIndex(index);
   }
 
+  /**
+   * Finds the next navigable index using the isItemNavigable callback.
+   * Returns null if no navigable item exists in the given direction.
+   */
+  private findNextNavigableIndex(fromIndex: number, direction: 1 | -1): number | null {
+    const { count } = this.virtualizerProps;
+
+    for (let i = fromIndex; i >= 0 && i < count; i += direction) {
+      if (this.isItemNavigable(i)) return i;
+    }
+    return null;
+  }
+
   protected override resetTabIndexAndSetFocus(
     newIndex: number,
     oldIndex?: number,
@@ -700,6 +735,16 @@ class VirtualizedList extends DataAriaLabelMixin(List) {
     const elementToFocus = this.navItems.find(element => this.virtualizer?.indexFromElement(element) === newIndex);
 
     if (elementToFocus === undefined) {
+      // If the target is non-navigable (e.g. disabled or header), skip to the next navigable index.
+      if (!this.isItemNavigable(newIndex) && oldIndex !== undefined) {
+        const direction = newIndex >= oldIndex ? 1 : -1;
+        const nextNavigable = this.findNextNavigableIndex(newIndex + direction, direction);
+        if (nextNavigable !== null) {
+          return this.resetTabIndexAndSetFocus(nextNavigable, oldIndex, focusNewItem, scrollToNewItem);
+        }
+        return false;
+      }
+
       this.scrollToIndex(newIndex, {});
       this.endOfScrollQueue.push(() => {
         super.resetTabIndexAndSetFocus(newIndex, oldIndex, focusNewItem, scrollToNewItem);

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.constants.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.constants.ts
@@ -7,6 +7,7 @@ export const DEFAULTS = {
     count: 0,
     estimateSize: () => 0,
     getItemKey: (index: number) => index,
+    isItemNavigable: () => true,
   },
   LOOP: 'false',
   SCROLL_ANCHORING: false,

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.e2e-test.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.e2e-test.ts
@@ -530,6 +530,74 @@ test('mdc-virtualizedlist', async ({ componentsPage }) => {
     });
   });
 
+  await test.step('navigating via keyboard should skip disabled items', async () => {
+    const { wrapper, vlist } = await setup();
+
+    await wrapper.evaluate((wrapperEl: VirtualizedListE2E) => {
+      wrapperEl.addItem('Disabled Item 1', undefined, { disabled: true });
+      wrapperEl.addItem('Item 2');
+      wrapperEl.addItem('Item 3');
+      wrapperEl.addItem('Disabled Item 4', undefined, { disabled: true });
+      wrapperEl.addItem('Item 5');
+      wrapperEl.addItem('Disabled Item 6', undefined, { disabled: true });
+      wrapperEl.addItem('Disabled Item 7', undefined, { disabled: true });
+      wrapperEl.addItem('Item 8');
+    });
+
+    await expect(listItemLocator(vlist, 0)).toHaveAttribute('disabled');
+    await expect(listItemLocator(vlist, 3)).toHaveAttribute('disabled');
+    await expect(listItemLocator(vlist, 5)).toHaveAttribute('disabled');
+    await expect(listItemLocator(vlist, 6)).toHaveAttribute('disabled');
+
+    await componentsPage.actionability.pressTab();
+    await expect(listItemLocator(vlist, 1)).toBeFocused();
+
+    await componentsPage.page.keyboard.press('ArrowDown');
+    await componentsPage.page.keyboard.press('ArrowDown');
+    await expect(listItemLocator(vlist, 4)).toBeFocused();
+
+    await componentsPage.page.keyboard.press('ArrowDown');
+    await expect(listItemLocator(vlist, 7)).toBeFocused();
+  });
+
+  await test.step('navigating via keyboard should skip disabled items even when they are not rendered', async () => {
+    const { wrapper, vlist } = await setup();
+
+    await wrapper.evaluate((wrapperEl: VirtualizedListE2E) => {
+      wrapperEl.addItem('Item 1');
+      for (let i = 0; i < 50; i += 1) {
+        wrapperEl.addItem(`Disabled Item ${i + 1}`, undefined, { disabled: true });
+      }
+      wrapperEl.addItem('Item End');
+    });
+
+    await componentsPage.actionability.pressTab();
+    await expect(listItemLocator(vlist, 0)).toBeFocused();
+
+    await componentsPage.page.keyboard.press('ArrowDown');
+    await expect(listItemLocator(vlist, 51)).toBeFocused();
+  });
+
+  await test.step('navigating via keyboard should skip listheaders in the list body', async () => {
+    const { wrapper, vlist } = await setup();
+
+    await wrapper.evaluate((wrapperEl: VirtualizedListE2E) => {
+      wrapperEl.addItem('Header 1', undefined, { header: true });
+      wrapperEl.addItem('Item 1');
+      wrapperEl.addItem('Item 2');
+      wrapperEl.addItem('Header 2', undefined, { header: true });
+      wrapperEl.addItem('Item 3');
+      wrapperEl.addItem('Item 4');
+    });
+
+    await componentsPage.actionability.pressTab();
+    await expect(listItemLocator(vlist, 1)).toBeFocused();
+
+    await componentsPage.page.keyboard.press('ArrowDown');
+    await componentsPage.page.keyboard.press('ArrowDown');
+    await expect(listItemLocator(vlist, 4)).toBeFocused();
+  });
+
   await test.step('scroll anchoring', async () => {
     await test.step('observe-size-changes = false', async () => {
       const { wrapper, vlist } = await setup({ scrollAnchoring: true, initialItemCount: 100, initialFocus: 50 });

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.stories.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.stories.ts
@@ -129,12 +129,5 @@ export const WithPaddingAndGaps: StoryObj = {
 };
 
 export const WithHeaders: StoryObj = {
-  parameters: {
-    docs: {
-      description: {
-        story: html`<p>Test</p>`,
-      },
-    },
-  },
   render: () => html` <mdc-virtualizedwrapperwithheaders></mdc-virtualizedwrapperwithheaders>`,
 };

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.stories.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.stories.ts
@@ -8,6 +8,7 @@ import './helpers/chatExample.stories.utils';
 import './helpers/virtualizedDynamicList.stories.utils';
 import './helpers/virtualizedDynamicListContent.stories.utils';
 import './helpers/virtualizedWrapper.stories.utils';
+import './helpers/virtualizedWrapperWithHeaders.stories.utils';
 import { hideControls } from '../../../config/storybook/utils';
 
 const render = (args: Args) =>
@@ -125,4 +126,15 @@ export const WithPaddingAndGaps: StoryObj = {
           margin-bottom: 0.25rem;
         }
       </style> `,
+};
+
+export const WithHeaders: StoryObj = {
+  parameters: {
+    docs: {
+      description: {
+        story: html`<p>Test</p>`,
+      },
+    },
+  },
+  render: () => html` <mdc-virtualizedwrapperwithheaders></mdc-virtualizedwrapperwithheaders>`,
 };

--- a/packages/components/src/components/virtualizedlist/virtualizedlist.types.ts
+++ b/packages/components/src/components/virtualizedlist/virtualizedlist.types.ts
@@ -26,6 +26,16 @@ export interface Events {
 export type Virtualizer = TanstackVirtualizer<Element, Element>;
 export type VirtualizerOptions = TanstackVirtualizerOptions<Element, Element>;
 export type VirtualizerProps = Omit<Partial<VirtualizerOptions>, 'getScrollElement'> &
-  Required<Pick<VirtualizerOptions, 'count' | 'estimateSize' | 'getItemKey'>>;
+  Required<Pick<VirtualizerOptions, 'count' | 'estimateSize' | 'getItemKey'>> & {
+    /**
+     * Optional callback to determine if an item at a given index is navigable.
+     * When provided, keyboard navigation will skip items where this returns false
+     * without needing to scroll them into view.
+     *
+     * @param index - The index of the item to check.
+     * @returns true if the item is navigable; false if it should be skipped.
+     */
+    isItemNavigable?: (index: number) => boolean;
+  };
 
 export type AtBottomValue = 'no' | 'yes' | 're-evaluate';


### PR DESCRIPTION
### Description

- [virtualizedlist] Introduce `isItemNavigation` virtualizerProp to tell the virtualized list whether an element is enabled so keyboard navigation will know which is the next element to focus.

**Breaking Changes**: None, default for `isItemNavigation` will return true for all items