### PR TITLE
fix: add focusable element to the list when delegate focus is true

### DIFF
--- a/packages/components/src/components/dialog/dialog.e2e-test.ts
+++ b/packages/components/src/components/dialog/dialog.e2e-test.ts
@@ -740,6 +740,72 @@ test('mdc-dialog', async ({ componentsPage }) => {
         /* eslint-enable no-await-in-loop */
       });
       // End AI-Assisted
+
+      // AI-Assisted
+      await test.step('focus trap should include searchfield input when dialog contains a searchfield with delegatesFocus', async () => {
+        /**
+         * mdc-searchfield has a shadow root with delegatesFocus: true. Its internal container
+         * div has tabindex="-1". The findFocusable() function with stopAtNonTabbable: true must
+         * NOT stop traversal at that div because the shadow root uses delegatesFocus. This ensures
+         * the native <input> inside the searchfield is included in the dialog's focus trap cycle.
+         */
+        const dialogWithSearchfield = {
+          id: 'dialog',
+          triggerId: 'trigger-btn',
+          ariaLabel: 'dialog with searchfield',
+          visible: false,
+          variant: 'default',
+          closeButtonAriaLabel: 'Close button label',
+          headerText: 'Dialog with Searchfield',
+          children: `
+            <div slot="dialog-body">
+              <mdc-searchfield
+                id="dialog-searchfield"
+                label="Search"
+                placeholder="Type to search"
+                clear-aria-label="clear"
+              ></mdc-searchfield>
+              <mdc-button id="extra-btn">Extra</mdc-button>
+            </div>
+          `,
+        };
+
+        const { dialog } = await setup({ componentsPage, ...dialogWithSearchfield });
+        await dialog.evaluate(d => d.toggleAttribute('visible'));
+        await expect(dialog).toBeVisible();
+
+        const closeButton = componentsPage.page.locator('mdc-button[part="dialog-close-btn"]');
+        const searchfield = componentsPage.page.locator('mdc-searchfield#dialog-searchfield');
+        const searchInput = searchfield.locator('input');
+        const extraButton = componentsPage.page.locator('mdc-button#extra-btn');
+
+        // After dialog opens, close button has initial focus
+        await expect(closeButton).toBeFocused();
+
+        // Tab → searchfield input (input must be reachable via focus trap despite
+        // the internal div[tabindex="-1"] inside the delegatesFocus shadow root)
+        await componentsPage.actionability.pressTab();
+        await expect(searchInput).toBeFocused();
+
+        // Tab → extra button
+        await componentsPage.actionability.pressTab();
+        await expect(extraButton).toBeFocused();
+
+        // Tab → wraps back to close button (focus trap cycle)
+        await componentsPage.actionability.pressTab();
+        await expect(closeButton).toBeFocused();
+
+        // Shift+Tab backwards through the same cycle
+        await componentsPage.actionability.pressShiftTab();
+        await expect(extraButton).toBeFocused();
+
+        await componentsPage.actionability.pressShiftTab();
+        await expect(searchInput).toBeFocused();
+
+        await componentsPage.actionability.pressShiftTab();
+        await expect(closeButton).toBeFocused();
+      });
+      // End AI-Assisted
     });
 
     await test.step('spatial navigation', async () => {

--- a/packages/components/src/utils/dom.ts
+++ b/packages/components/src/utils/dom.ts
@@ -227,7 +227,15 @@ export const findFocusable = (
       return 'stop';
     }
     if (stopAtNonTabbable && !(element instanceof HTMLSlotElement) && element.getAttribute('tabindex') === '-1') {
-      return 'stop';
+      // AI-Assisted
+      // Do not stop traversal for elements inside a shadow root with delegatesFocus: true.
+      // Components like mdc-searchfield use delegatesFocus and have internal container divs
+      // with tabindex="-1" that should not block finding the actual focusable element (e.g., input).
+      const rootNode = element.getRootNode();
+      if (!(rootNode instanceof ShadowRoot && rootNode.delegatesFocus)) {
+        return 'stop';
+      }
+      // End AI-Assisted
     }
     return isMatchAny(element, includeSelectors) || (isTabbable(element) && isInteractiveElement(element))
       ? 'focusable'


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

* src/utils/dom.ts] - In `focusableCheck` when `stopAtNonTabbable` would stop traversal at an element with tabindex="-1", skip the stop if the element is inside a shadow root with `delegatesFocus: true`. This preserves the roving-tabindex exclusion for list items (light DOM) while allowing traversal into components like `mdc-searchfield` that use `delegatesFocus`.

* src/components/dialog/dialog.e2e-test.ts -  Added an e2e test that opens a dialog containing an `mdc-searchfield` and an extra button, and asserts the full forward and reverse Tab cycle correctly visits: close button → searchfield input → extra button → (wrap).

### Breaking change
* None
