### PR TITLE
docs: added docs to the repo for adrs and project briefs

### DIFF
--- a/.docs/decisions/00_ADR-TEMPLATE.md
+++ b/.docs/decisions/00_ADR-TEMPLATE.md
@@ -1,0 +1,21 @@
+# Use PostgreSQL for primary data store
+
+**For title:** Use {yyyy-m-d}_{title of document}
+
+Date: 2024-03-15
+
+## Status
+In Discussion, Approved, Rejected
+
+## Context
+What is the issue motivating this decision? What forces are at play —
+technical, business, organizational? This section is descriptive, not
+prescriptive. It explains the situation that requires a decision.
+
+## Decision
+What we decided to do, stated in active voice. "We will use PostgreSQL..."
+not "PostgreSQL should be used..."
+
+## Consequences
+What becomes easier or harder as a result. Both positive and negative.
+What new constraints does this place on future work?

--- a/.docs/decisions/2026-5-3_architectural-decision-records.md
+++ b/.docs/decisions/2026-5-3_architectural-decision-records.md
@@ -1,0 +1,15 @@
+# Begin Using Architectural Decision Records for Records
+
+Date: 2026-5-3
+
+## Status
+In discussion
+
+## Context
+The Momentum Team would like to record architectural decisions in a centralized location for reference by other stakeholders or to review previous, determined decisions. We believe this will allow us to operate in much smoother and consistent alignment with one another, particularly as more collaboration is necessary.
+
+## Decision
+**Still under discussion** We need to decide on formatting and location. This is currrently a proposal.
+
+## Consequences
+It becoming difficult to make sure that all stakeholders are aware of conversations and decisions. This is creating duplicative work across members of the team. 

--- a/.docs/decisions/_OVERVIEW.md
+++ b/.docs/decisions/_OVERVIEW.md
@@ -1,0 +1,3 @@
+# Architecture Decision Records
+
+These documents detail the key arrchitectural or design decisions of the Momentum Design System Team. They are record to keep alignment between team members to help facilitated better collaboration across our various initiatives. 

--- a/.docs/projects/2026-5-3_knowledge-base.md
+++ b/.docs/projects/2026-5-3_knowledge-base.md
@@ -2,15 +2,15 @@
 
 ## Overview
 
-The **Knowledge Base** will become the authoritative home for Momentum Design System content: the one place product, design, engineering teams, or even AI can go to understand what the system is, how it works, what to use, and how to use it correctly. Today, our guidance lives across figma, our storybook, and vidcast; this project will consolidate that material into a structured, searchable, and maintainable experience so **design documentation, guidelines, and patterns stay aligned with coded tokens, components, and assets**.
+The **Knowledge Base** will become the authoritative home for Momentum Design System content: the one place product, design, engineering teams, or even AI can go to understand what the system is, how it works, what to use, and how to use it correctly. Today, our guidance lives across Figma, our Storybook, and Vidcast; this project will consolidate that material into a structured, searchable, and maintainable experience so **design documentation, guidelines, and patterns stay aligned with coded tokens, components, and assets**.
 
 This **will become our single source of truth** for all Momentum Design System information. 
 
 ## Problem
-Currently infomation for the Momentum Design System is in a variety of places and very difficult to obtain. Inforrmation in Figma is hard to search for and find, particularly by non-designers. Infomation in Storybook or on the website is difficult for designers to update if necessary. Connected information, or related information might be found in multiple places and be out of date with each other.
+Currently information for the Momentum Design System is in a variety of places and very difficult to obtain. Information in Figma is hard to search for and find, particularly by non-designers. Information in Storybook or on the website is difficult for designers to update if necessary. Connected information, or related information might be found in multiple places and be out of date with each other.
 
 ## Background
-The Momentum Design Team has historically kept all design system related guidance within its figma projects. Once we begane work on the Web UI Toolkit, we also stated keeping developer documentation on our website and storybook. 
+The Momentum Design Team has historically kept all design system related guidance within its Figma projects. Once we began work on the Web UI Toolkit, we also started keeping developer documentation on our website and Storybook. 
 
 **User Research Findings**
 Designer User Research was performed at the end of 2025 finding that design system information was particularly difficult for designers to find. Developers using our system are completely unaware of design guidelines and documentation, relying solely on the website. 
@@ -21,22 +21,22 @@ Designer User Research was performed at the end of 2025 finding that design syst
 Trip Carroll has put together a small amount of work on this knowledge base. A branch with the work can be found here: [knowledge-base-project branch](https://github.com/tricarro/momentum-design/tree/knowledge-base-project). This work can be used as a starting place or discarded as project owners see fit. 
 
 ## Goals
-1. Architectural proposal for this knowledge base. This proposal should seek to wholistically solve the problems identified in this design brief. 
-2. Creation of a single source of truth for all Momentum Design System related information. This should a a knowledge base made up of markdown files that is both human and machine readible. 
-3. Linking this knowledge base externally. These markdown files will be used as the source of truth for any external facing information; ie our website and it's storybook should directly reference the information in this knowledge base. If the knowledge base is updated, our website is updated. 
-4. This knowledge base will be used as a key resource inside our Momentum MCP Server. This should be considered in its architecture. 
-
+1. **Architectural proposal** — End-to-end design for the knowledge base (information architecture, repo layout, authoring and review workflow) that addresses the problems in this brief.
+2. **Markdown as the canonical source** — A single, structured knowledge base that is the authoritative place for Momentum Design System information and is both human- and machine-readable.
+3. **External consumption model** — Clear plan for how public surfaces (e.g. website, Storybook) **consume** the same markdown so guidance stays in sync; implementation and wiring can land in follow-on work (see Non-Goals).
+4. **MCP-ready architecture** — The design explicitly supports the Momentum MCP server as a consumer (stable paths, chunking, or metadata as needed).
+5. **Access and security posture** — Proposal covers what is public vs internal-only and how to maintain that boundary over time.
 
 ## Non-Goals
-1. Linking knowledge base to our website/storybook. This should be done eventually, but it is not necessarily part of this work.
+1. Linking knowledge base to our website/Storybook. This should be done eventually, but it is not necessarily part of this work.
 
 ## Users
 Any designer, engineer, product manager, or user of Momentum (including AI tools).  
 
 ## Requirements
-This knowledge base should be human and AI legible.
-
-Proposal for linking content from knowledge base to external surfaces (like storybook).
+- **Canonical markdown** — All substantive design-system guidance ultimately lives in this knowledge base; other surfaces derive from or deep-link to it rather than duplicating truth.
+- **Human- and AI-legible** — Content is structured (consistent headings, predictable hierarchy, and conventions suitable for search, docs tooling, and MCP retrieval).
+- **Architectural deliverable** — The proposal must spell out integration touchpoints: website and Storybook (consumption pattern), MCP consumption, and **public vs internal** content handling at a minimum.
 
 ## Success Metrics
 
@@ -44,8 +44,12 @@ Proposal for linking content from knowledge base to external surfaces (like stor
 Should images be included in this knowledge base? All Momentum's design documentation contains images. Should we build this in a way where those images can continue to be used? 
 
 ## Stakeholders
+**Owners**
 Supriya Minnasandram, Software Engineer
 Morgan Bathe, Lead Product Designer
+
+**Keep in the loop**
+Trip Carroll, Momentum Lead
 
 
 

--- a/.docs/projects/2026-5-3_knowledge-base.md
+++ b/.docs/projects/2026-5-3_knowledge-base.md
@@ -1,0 +1,52 @@
+# Knowledge Base
+
+## Overview
+
+The **Knowledge Base** will become the authoritative home for Momentum Design System content: the one place product, design, engineering teams, or even AI can go to understand what the system is, how it works, what to use, and how to use it correctly. Today, our guidance lives across figma, our storybook, and vidcast; this project will consolidate that material into a structured, searchable, and maintainable experience so **design documentation, guidelines, and patterns stay aligned with coded tokens, components, and assets**.
+
+This **will become our single source of truth** for all Momentum Design System information. 
+
+## Problem
+Currently infomation for the Momentum Design System is in a variety of places and very difficult to obtain. Inforrmation in Figma is hard to search for and find, particularly by non-designers. Infomation in Storybook or on the website is difficult for designers to update if necessary. Connected information, or related information might be found in multiple places and be out of date with each other.
+
+## Background
+The Momentum Design Team has historically kept all design system related guidance within its figma projects. Once we begane work on the Web UI Toolkit, we also stated keeping developer documentation on our website and storybook. 
+
+**User Research Findings**
+Designer User Research was performed at the end of 2025 finding that design system information was particularly difficult for designers to find. Developers using our system are completely unaware of design guidelines and documentation, relying solely on the website. 
+
+[Link to user research.](https://www.figma.com/design/IqaWb8V5D9ekZlFWpObJOD/2025-2026-Momentum-Research?node-id=90-398&t=xSclmonSgD6oH6BX-11). Speak to Claire Kim or Shannon Kha for more information or to ask for a recording.
+
+**Beginning work**
+Trip Carroll has put together a small amount of work on this knowledge base. A branch with the work can be found here: [knowledge-base-project branch](https://github.com/tricarro/momentum-design/tree/knowledge-base-project). This work can be used as a starting place or discarded as project owners see fit. 
+
+## Goals
+1. Architectural proposal for this knowledge base. This proposal should seek to wholistically solve the problems identified in this design brief. 
+2. Creation of a single source of truth for all Momentum Design System related information. This should a a knowledge base made up of markdown files that is both human and machine readible. 
+3. Linking this knowledge base externally. These markdown files will be used as the source of truth for any external facing information; ie our website and it's storybook should directly reference the information in this knowledge base. If the knowledge base is updated, our website is updated. 
+4. This knowledge base will be used as a key resource inside our Momentum MCP Server. This should be considered in its architecture. 
+
+
+## Non-Goals
+1. Linking knowledge base to our website/storybook. This should be done eventually, but it is not necessarily part of this work.
+
+## Users
+Any designer, engineer, product manager, or user of Momentum (including AI tools).  
+
+## Requirements
+This knowledge base should be human and AI legible.
+
+Proposal for linking content from knowledge base to external surfaces (like storybook).
+
+## Success Metrics
+
+## Open Questions
+Should images be included in this knowledge base? All Momentum's design documentation contains images. Should we build this in a way where those images can continue to be used? 
+
+## Stakeholders
+Supriya Minnasandram, Software Engineer
+Morgan Bathe, Lead Product Designer
+
+
+
+

--- a/.docs/projects/_OVERVIEW.md
+++ b/.docs/projects/_OVERVIEW.md
@@ -1,0 +1,40 @@
+# Projects Overview
+
+This document contains design briefs for key projects that Momentum Design System team members are working on. These documents will be used to align on project goals and define project success.
+
+Here is the standard format of a Project Design Brief:
+
+# Project Title
+
+## Overview
+General idea or summary of the project.
+
+## Problem
+The primary (and secondary) problems that this work will solve.
+
+## Background
+Background information on this work. 
+
+## Goals
+Specific, achieveable goals for the work. 
+
+## Non-Goals
+Any non-goals that should not be considered in the specific work. 
+
+## Users
+The target audience for the specific project.
+
+## Requirements
+Specific requirements for the work. 
+
+## Timeline
+A timeline for when to deliver the work. 
+
+## Success Metrics
+Any specific success metrics to be tracked.
+
+## Open Questions
+Any open questions that should be discussed
+
+## Stakeholders
+Team members or project stakeholders that will collaborate together. 


### PR DESCRIPTION
### Description

Created a new root folder: .docs. This folder will contain documentation for key decision, projects, or other related materials that we would like to store for our collaborative efforts. 

There are two subfolders within the .docs folder: "decisions" and "projects". The decisions folder will contain Architectural Decision Records. These are key decisions we make as a team related to the products that we build.

The project folder will contain project briefs for specific projects or initiatives that we undertake. 

There are proposed templates for each document type. 
