### PR TITLE
fix(input): propagate input event if not composed

### DIFF
--- a/packages/components/src/components/input/input.component.ts
+++ b/packages/components/src/components/input/input.component.ts
@@ -254,10 +254,17 @@ class Input
    * Updates the value and sets the validity of the input field.
    * @internal
    */
-  protected onInput() {
+  protected onInput(event: Event) {
     this.updateValue();
     this.setInputValidity();
     this.checkValidity();
+
+    // Some versions of the 'input' event are not composed.
+    // If the event is not composed, we need to re-dispatch the same event to ensure it is propagated correctly.
+    if (!event.composed) {
+      const EventConstructor = event.constructor as typeof Event;
+      this.dispatchEvent(new EventConstructor(event.type, event));
+    }
   }
 
   /**

--- a/packages/components/src/components/input/input.e2e-test.ts
+++ b/packages/components/src/components/input/input.e2e-test.ts
@@ -612,6 +612,58 @@ test.describe('mdc-input', () => {
       ]).toContain(validationMessage);
     });
 
+    await test.step('noncomposed change event is propagated to mdc-input when dispatched on internal input element', async () => {
+      const mdcInput = await setup({ componentsPage, id: 'test-mdc-input', placeholder: 'Placeholder' });
+      const innerInput = mdcInput.locator('input');
+
+      // Register listener on the host before dispatching so it is captured
+      const waitForChangeOnHost = await componentsPage.waitForEvent(mdcInput, 'change');
+
+      // The 'change' event is never composed, so the component's onChange handler always
+      // re-dispatches it on the host to ensure it propagates outside the shadow DOM.
+      await innerInput.evaluate((el: HTMLInputElement) => {
+        el.dispatchEvent(new Event('change', { bubbles: true, composed: false }));
+      });
+
+      await expect(waitForChangeOnHost).toEventEmitted();
+    });
+
+    await test.step('composed input event is propagated to mdc-input only once when dispatched on internal input element', async () => {
+      const mdcInput = await setup({ componentsPage, id: 'test-mdc-input', placeholder: 'Placeholder' });
+
+      // Register a counter listener on the host and dispatch in the same evaluate call so
+      // the synchronous shadow-DOM propagation is captured atomically.
+      // A composed event naturally crosses the shadow boundary — onInput must NOT re-dispatch
+      // it, otherwise the host would receive it twice.
+      const eventCount = await mdcInput.evaluate((host: HTMLElement) => {
+        let count = 0;
+        host.addEventListener('input', () => {
+          count += 1;
+        });
+        const inner = host.shadowRoot!.querySelector('input')!;
+        inner.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+        return count;
+      });
+
+      expect(eventCount).toBe(1);
+    });
+
+    await test.step('noncomposed input event is propagated to mdc-input when dispatched on internal input element', async () => {
+      const mdcInput = await setup({ componentsPage, id: 'test-mdc-input', placeholder: 'Placeholder' });
+      const innerInput = mdcInput.locator('input');
+
+      // Register listener on the host before dispatching so it is captured
+      const waitForInputOnHost = await componentsPage.waitForEvent(mdcInput, 'input');
+
+      // Dispatch a non-composed input event directly on the internal <input> element.
+      // The component's onInput handler re-dispatches it on the host when composed is false.
+      await innerInput.evaluate((el: HTMLInputElement) => {
+        el.dispatchEvent(new Event('input', { bubbles: true, composed: false }));
+      });
+
+      await expect(waitForInputOnHost).toEventEmitted();
+    });
+
     await test.step('spatial navigation', async () => {
       const form = await setup(
         {

--- a/packages/components/src/components/input/input.stories.ts
+++ b/packages/components/src/components/input/input.stories.ts
@@ -404,3 +404,19 @@ export const SlottedInputElement: StoryObj = {
     },
   },
 };
+
+export const EmailInput: StoryObj = {
+  render: () => html`
+    <form @submit=${(e: Event) => e.preventDefault()} style="width: 300px;">
+      <mdc-input
+        label="Email"
+        placeholder="Enter your email"
+        type="email"
+        help-text="We'll never share your email."
+        required
+        @input=${e => console.log('mdc-input', e)}
+        @change=${e => console.log('mdc-input', e)}
+      ></mdc-input>
+    </form>
+  `,
+};

--- a/packages/components/src/components/input/input.stories.ts
+++ b/packages/components/src/components/input/input.stories.ts
@@ -404,19 +404,3 @@ export const SlottedInputElement: StoryObj = {
     },
   },
 };
-
-export const EmailInput: StoryObj = {
-  render: () => html`
-    <form @submit=${(e: Event) => e.preventDefault()} style="width: 300px;">
-      <mdc-input
-        label="Email"
-        placeholder="Enter your email"
-        type="email"
-        help-text="We'll never share your email."
-        required
-        @input=${e => console.log('mdc-input', e)}
-        @change=${e => console.log('mdc-input', e)}
-      ></mdc-input>
-    </form>
-  `,
-};


### PR DESCRIPTION
### Description

- [input] propagate the input event from the internal input to mdc-input if the event is not composed

**Breaking Changes:** If the input event fired on the internal input was not composed, the event will now be re-dispatched by the mdc-input component. This could cause 2 input events to be received if a consumer was listening to both the input event on the internal input and the mdc-input component.

