### PR TITLE
fix(timepicker): add prefix-icon and optionLabelFormatter properties

### DIFF
--- a/packages/components/src/components/timepicker/timepicker.component.ts
+++ b/packages/components/src/components/timepicker/timepicker.component.ts
@@ -9,10 +9,11 @@ import { KEYS } from '../../utils/keys';
 import FormfieldWrapper from '../formfieldwrapper/formfieldwrapper.component';
 import { POPOVER_PLACEMENT, TRIGGER, DEFAULTS as POPOVER_DEFAULTS } from '../popover/popover.constants';
 import type { PopoverStrategy } from '../popover/popover.types';
+import type { IconNames } from '../icon/icon.types';
 
 import { ARROW_ICON, DEFAULTS, TIME_FORMAT, TRIGGER_ID, LISTBOX_ID } from './timepicker.constants';
 import styles from './timepicker.styles';
-import type { Placement, TimeFormat } from './timepicker.types';
+import type { OptionLabelFormatter, Placement, TimeFormat } from './timepicker.types';
 
 /**
  * mdc-timepicker is a component that allows users to select a specific time
@@ -70,6 +71,7 @@ import type { Placement, TimeFormat } from './timepicker.types';
  * @csspart separator - The colon separator between spinbuttons.
  * @csspart period - The AM/PM period spinbutton.
  * @csspart icon-container - The dropdown arrow button container.
+ * @csspart leading-icon - The prefix icon element displayed before spinbuttons.
  * @csspart native-input - The hidden native input for form participation.
  * @csspart listbox - The dropdown list container.
  */
@@ -194,6 +196,20 @@ class TimePicker extends FormInternalsMixin(DataAriaLabelMixin(FormfieldWrapper)
    */
   @property({ type: String, attribute: 'locale-pm-label' })
   localePmLabel = '';
+
+  /**
+   * The icon name to display as a prefix icon in the timepicker input.
+   */
+  @property({ type: String, reflect: true, attribute: 'prefix-icon' })
+  prefixIcon?: IconNames;
+
+  /**
+   * A callback function to format the label of each dropdown option.
+   * Receives the default label string and the 24h value string, and should return a formatted label.
+   * When not set, the default time formatting is used.
+   */
+  @property({ attribute: false })
+  optionLabelFormatter?: OptionLabelFormatter;
 
   /**
    * Accessible label for the dropdown toggle button.
@@ -875,7 +891,7 @@ class TimePicker extends FormInternalsMixin(DataAriaLabelMixin(FormfieldWrapper)
     return options.map(
       option => html`
         <mdc-option
-          label="${option.label}"
+          label="${this.optionLabelFormatter ? this.optionLabelFormatter(option.label, option.value) : option.label}"
           ?selected="${option.value === currentValue}"
           aria-selected="${option.value === currentValue ? 'true' : 'false'}"
           @click="${() => this.handleOptionClick(option.value)}"
@@ -899,6 +915,9 @@ class TimePicker extends FormInternalsMixin(DataAriaLabelMixin(FormfieldWrapper)
           @click="${this.handleBaseContainerClick}"
           @keydown="${this.handleBaseKeydown}"
         >
+          ${this.prefixIcon
+            ? html`<mdc-icon part="leading-icon" name="${this.prefixIcon}" size="1"></mdc-icon>`
+            : nothing}
           <div part="spinbutton-group">
             <input
               id="hours-spinbutton"

--- a/packages/components/src/components/timepicker/timepicker.e2e-test.ts
+++ b/packages/components/src/components/timepicker/timepicker.e2e-test.ts
@@ -17,6 +17,7 @@ type SetupOptions = {
   min?: string;
   max?: string;
   width?: string;
+  prefixIcon?: string;
 };
 
 const setup = async (args: SetupOptions) => {
@@ -36,6 +37,7 @@ const setup = async (args: SetupOptions) => {
         ${restArgs.helpTextType ? `help-text-type="${restArgs.helpTextType}"` : ''}
         ${restArgs.min ? `min="${restArgs.min}"` : ''}
         ${restArgs.max ? `max="${restArgs.max}"` : ''}
+        ${restArgs.prefixIcon ? `prefix-icon="${restArgs.prefixIcon}"` : ''}
         ${restArgs.width ? `style="--mdc-timepicker-width: ${restArgs.width};"` : ''}
         locale-hours-label="hours"
         locale-minutes-label="minutes"
@@ -754,6 +756,99 @@ test.describe('mdc-timepicker', () => {
       await test.step('error state', async () => {
         await componentsPage.visualRegression.takeScreenshot('mdc-timepicker-error');
       });
+    });
+  });
+
+  test.describe('prefix-icon', () => {
+    test('should render prefix icon in the input container', async ({ componentsPage }) => {
+      const timepicker = await setup({
+        componentsPage,
+        label: 'Start time',
+        value: '08:30',
+        timeFormat: '12h',
+        prefixIcon: 'recents-bold',
+      });
+
+      const prefixIcon = timepicker.locator('mdc-icon[part="leading-icon"]');
+      await expect(prefixIcon).toBeVisible();
+      await expect(prefixIcon).toHaveAttribute('name', 'recents-bold');
+    });
+
+    test('should not render prefix icon when not configured', async ({ componentsPage }) => {
+      const timepicker = await setup({
+        componentsPage,
+        label: 'Start time',
+        value: '08:30',
+        timeFormat: '12h',
+      });
+
+      const prefixIcon = timepicker.locator('mdc-icon[part="leading-icon"]');
+      await expect(prefixIcon).toHaveCount(0);
+    });
+  });
+
+  test.describe('optionLabelFormatter', () => {
+    test('should use custom formatter for option labels', async ({ componentsPage }) => {
+      const timepicker = await setup({
+        componentsPage,
+        label: 'End time',
+        value: '09:00',
+        timeFormat: '12h',
+        min: '08:30',
+        max: '10:00',
+      });
+
+      // Set the optionLabelFormatter via JS property
+      await timepicker.evaluate(async (el: any) => {
+        Object.assign(el, { optionLabelFormatter: (label: string) => `${label} (custom)` });
+        await el.updateComplete;
+      });
+
+      const dropdownButton = timepicker.locator('mdc-button[part="icon-container"]');
+      await dropdownButton.click();
+
+      const firstOption = timepicker.locator('mdc-option').first();
+      await expect(firstOption).toHaveAttribute('label', '8:30 AM (custom)');
+    });
+
+    test('should use default labels when formatter is not set', async ({ componentsPage }) => {
+      const timepicker = await setup({
+        componentsPage,
+        label: 'Start time',
+        value: '08:30',
+        timeFormat: '12h',
+        min: '08:00',
+        max: '09:00',
+      });
+
+      const dropdownButton = timepicker.locator('mdc-button[part="icon-container"]');
+      await dropdownButton.click();
+
+      const firstOption = timepicker.locator('mdc-option').first();
+      await expect(firstOption).toHaveAttribute('label', '8:00 AM');
+    });
+
+    test('should receive both label and value in formatter callback', async ({ componentsPage }) => {
+      const timepicker = await setup({
+        componentsPage,
+        label: 'End time',
+        value: '09:00',
+        timeFormat: '12h',
+        min: '09:00',
+        max: '10:00',
+      });
+
+      // Set formatter that includes the 24h value in the label
+      await timepicker.evaluate(async (el: any) => {
+        Object.assign(el, { optionLabelFormatter: (label: string, value: string) => `${label} [${value}]` });
+        await el.updateComplete;
+      });
+
+      const dropdownButton = timepicker.locator('mdc-button[part="icon-container"]');
+      await dropdownButton.click();
+
+      const firstOption = timepicker.locator('mdc-option').first();
+      await expect(firstOption).toHaveAttribute('label', '9:00 AM [09:00]');
     });
   });
 });

--- a/packages/components/src/components/timepicker/timepicker.stories.ts
+++ b/packages/components/src/components/timepicker/timepicker.stories.ts
@@ -366,3 +366,105 @@ export const VerticalLayout: StoryObj = {
   `,
   ...hideAllControls(),
 };
+
+export const WithPrefixIcon: StoryObj = {
+  render: () => html`
+    <mdc-timepicker
+      label="Start time"
+      value="08:30"
+      time-format="12h"
+      prefix-icon="recents-bold"
+      locale-hours-label="hours"
+      locale-minutes-label="minutes"
+      locale-period-label="period"
+      locale-hours-placeholder="hh"
+      locale-minutes-placeholder="mm"
+      locale-period-placeholder="--"
+      locale-am-label="AM"
+      locale-pm-label="PM"
+      locale-show-time-picker-label="Show time picker"
+      locale-time-options-label="Time options"
+      locale-spinbutton-description="To set value, use the up/down arrow keys or type a value"
+    ></mdc-timepicker>
+  `,
+  ...hideAllControls(),
+};
+
+export const WithOptionLabelFormatter: StoryObj = {
+  render: () => {
+    const startTime = '08:30';
+    const formatter = (label: string, value: string) => {
+      const [startH, startM] = startTime.split(':').map(Number);
+      const [h, m] = value.split(':').map(Number);
+      const diffMinutes = h * 60 + m - (startH * 60 + startM);
+      if (diffMinutes <= 0) return label;
+      const hours = Math.floor(diffMinutes / 60);
+      const mins = diffMinutes % 60;
+      const duration = hours > 0 ? `${hours}h ${mins > 0 ? `${mins}m` : ''}`.trim() : `${mins}m`;
+      return `${label} (${duration})`;
+    };
+
+    return html`
+      <mdc-timepicker
+        label="End time"
+        value="09:00"
+        time-format="12h"
+        min="08:30"
+        max="17:00"
+        .optionLabelFormatter="${formatter}"
+        locale-hours-label="hours"
+        locale-minutes-label="minutes"
+        locale-period-label="period"
+        locale-hours-placeholder="hh"
+        locale-minutes-placeholder="mm"
+        locale-period-placeholder="--"
+        locale-am-label="AM"
+        locale-pm-label="PM"
+        locale-show-time-picker-label="Show time picker"
+        locale-time-options-label="Time options"
+        locale-spinbutton-description="To set value, use the up/down arrow keys or type a value"
+      ></mdc-timepicker>
+    `;
+  },
+  ...hideAllControls(),
+};
+
+export const WithPrefixIconAndFormatter: StoryObj = {
+  render: () => {
+    const startTime = '08:30';
+    const formatter = (label: string, value: string) => {
+      const [startH, startM] = startTime.split(':').map(Number);
+      const [h, m] = value.split(':').map(Number);
+      const diffMinutes = h * 60 + m - (startH * 60 + startM);
+      if (diffMinutes <= 0) return label;
+      const hours = Math.floor(diffMinutes / 60);
+      const mins = diffMinutes % 60;
+      const duration = hours > 0 ? `${hours}h ${mins > 0 ? `${mins}m` : ''}`.trim() : `${mins}m`;
+      return `${label} (${duration})`;
+    };
+
+    return html`
+      <mdc-timepicker
+        label="End time"
+        value="09:00"
+        time-format="12h"
+        min="08:30"
+        max="17:00"
+        prefix-icon="recents-bold"
+        .optionLabelFormatter="${formatter}"
+        locale-hours-label="hours"
+        locale-minutes-label="minutes"
+        locale-period-label="period"
+        locale-hours-placeholder="hh"
+        locale-minutes-placeholder="mm"
+        locale-period-placeholder="--"
+        locale-am-label="AM"
+        locale-pm-label="PM"
+        locale-show-time-picker-label="Show time picker"
+        locale-time-options-label="Time options"
+        locale-spinbutton-description="To set value, use the up/down arrow keys or type a value"
+      ></mdc-timepicker>
+    `;
+  },
+  ...hideAllControls(),
+};

--- a/packages/components/src/components/timepicker/timepicker.types.ts
+++ b/packages/components/src/components/timepicker/timepicker.types.ts
@@ -20,4 +20,12 @@ interface Events {
 
 type Placement = Extract<PopoverPlacement, 'bottom-start' | 'top-start'>;
 
-export type { Events, Placement, TimeFormat, TimePickerChangeEvent, TimePickerInputEvent };
+/**
+ * A callback function to format the label of each dropdown option.
+ * @param label - The default formatted label string (e.g., "1:30 PM" or "13:30").
+ * @param value - The 24-hour time value string (e.g., "13:30").
+ * @returns The formatted label string to display.
+ */
+type OptionLabelFormatter = (label: string, value: string) => string;
+
+export type { Events, OptionLabelFormatter, Placement, TimeFormat, TimePickerChangeEvent, TimePickerInputEvent };


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

Add two new properties to mdc-timepicker:

- `prefix-icon`: Renders an icon in the input container before the
  spinbuttons. Accepts any valid icon name (e.g., "recents-bold").
  Exposed as csspart "leading-icon" for styling.

- `optionLabelFormatter`: A callback function that receives the
  default label and 24h value string, allowing consumers to customize
  dropdown option labels (e.g., appending duration text).

Add storybook stories (WithPrefixIcon, WithOptionLabelFormatter,
WithPrefixIconAndFormatter) and e2e tests for both features.

### Links

NA
