### PR TITLE
fix(spatialnavigation): exclude elements from spatial navigation

### DIFF
--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
@@ -49,6 +49,9 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  * Elements with `data-spatial-focusable` are treated as focusable even if they would otherwise not be
  * (e.g., `tabindex="-1"`).
  *
+ * Elements with `data-spatial-exclude` are excluded (with its subtree) from the navigation, even if they
+ * are focusable.
+ *
  * ### Overwrite next element
  *
  * Override automatic navigation by adding one of these attributes to a focusable element:
@@ -99,7 +102,8 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  * | `data-spatial-right`   | element id  | N/A     | Focus this element when Right is pressed                                            |
  * | `data-spatial-down`    | element id  | N/A     | Focus this element when Down is pressed                                             |
  * | `data-spatial-go-back` | N/A         | N/A     | First focusable element with this attribute is clicked on Back/Escape               |
- * | `data-spatial-focusable` | N/A       | N/A     | Treat element as focusable even if it normally is not (e.g., `tabindex="-1"`)      |
+ * | `data-spatial-focusable` | N/A       | N/A     | Treat element as focusable even if it normally is not (e.g., `tabindex="-1"`)       |
+ * | `data-spatial-exclude` | N/A         | N/A     | Exclude focusable element (and its subtree) from the navigation                     |
  *
  * ## Event emitting order
  *
@@ -378,6 +382,7 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
           ...findFocusable(el, {
             excludedElements: checkedFocusArea ? [checkedFocusArea] : undefined,
             includeSelectors: ['[data-spatial-focusable]'],
+            excludeSelectors: ['[data-spatial-exclude]'],
           }),
         );
         const result = this.focusNextInFocusableAria(focusableElements, direction);

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.e2e-test.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.e2e-test.ts
@@ -390,7 +390,22 @@ test('mdc-spatialnavigationprovider', async ({ componentsPage }) => {
       await keyboard.press('ArrowDown');
       await expect(locators.btn1).toBeFocused();
 
-      // skip btn2 and focus btn3
+      // skip btn4 and focus btn7
+      await keyboard.press('ArrowDown');
+      await expect(locators.btn7).toBeFocused();
+    });
+
+    await test.step('data-spatial-exclude make element not navigable', async () => {
+      const locators = await setup({ componentsPage });
+      const { keyboard } = componentsPage.page;
+
+      await componentsPage.setAttributes(locators.btn4, { 'data-spatial-exclude': '' });
+
+      // initial focus on btn1
+      await keyboard.press('ArrowDown');
+      await expect(locators.btn1).toBeFocused();
+
+      // skip btn4 and focus btn7
       await keyboard.press('ArrowDown');
       await expect(locators.btn7).toBeFocused();
     });

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.stories.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.stories.ts
@@ -17,3 +17,14 @@ export default meta;
 export const Example: StoryObj = spatialNavigationStoryWrapper({
   render: () => html` <mdc-avatarbutton initials="MD"></mdc-avatarbutton> `,
 });
+
+export const WithExclude: StoryObj = spatialNavigationStoryWrapper({
+  parameters: {
+    docs: {
+      description: {
+        story: 'Avatar button is excluded from spatial navigation using `data-spatial-exclude` attribute.',
+      },
+    },
+  },
+  render: () => html` <mdc-avatarbutton data-spatial-exclude initials="MD"></mdc-avatarbutton> `,
+});

--- a/packages/components/src/utils/dom.ts
+++ b/packages/components/src/utils/dom.ts
@@ -6,10 +6,14 @@ import type { OverflowMixinInterface } from './mixins/OverflowMixin';
  * Options for finding focusable elements.
  */
 type FindFocusableOptions = {
-  /** Elements to exclude from the search. */
+  /** Elements to include (and its subtree) in the search. */
+  includeElements?: HTMLElement[];
+  /** Elements to exclude (and its subtree) from the search. */
   excludedElements?: HTMLElement[];
   /** Selectors to include in the search. */
   includeSelectors?: string[];
+  /** Selectors to exclude from the search. */
+  excludeSelectors?: string[];
   /**
    * When true, elements with `tabindex="-1"` and their subtrees are excluded from the search.
    * This supports composite widget patterns (e.g., roving tabindex in lists) where
@@ -219,8 +223,9 @@ export const findFocusable = (
 
   const excludesSet = new Set(options?.excludedElements ?? []);
   const includeSelectors = options?.includeSelectors ?? [];
+  const excludeSelectors = options?.excludeSelectors ?? [];
   const stopAtNonTabbable = options?.stopAtNonTabbable ?? false;
-  const matches = new Set<HTMLElement>();
+  const matches = new Set<HTMLElement>(options.includeElements ?? []);
 
   const focusableCheck = (element: HTMLElement) => {
     if (!(element instanceof HTMLSlotElement) && (isHidden(element) || isDisabled(element))) {
@@ -243,7 +248,7 @@ export const findFocusable = (
   };
 
   const finder = (root: ShadowRoot | HTMLElement) => {
-    if (excludesSet.has(root as HTMLElement)) {
+    if (excludesSet.has(root as HTMLElement) || (root instanceof HTMLElement && isMatchAny(root, excludeSelectors))) {
       return;
     }
     if (root instanceof HTMLElement && focusableCheck(root) === 'focusable') {

--- a/packages/components/src/utils/dom.ts
+++ b/packages/components/src/utils/dom.ts
@@ -228,7 +228,10 @@ export const findFocusable = (
   const matches = new Set<HTMLElement>(options.includeElements ?? []);
 
   const focusableCheck = (element: HTMLElement) => {
-    if (!(element instanceof HTMLSlotElement) && (isHidden(element) || isDisabled(element))) {
+    if (
+      !(element instanceof HTMLSlotElement) &&
+      (isHidden(element) || isDisabled(element) || isMatchAny(element, excludeSelectors))
+    ) {
       return 'stop';
     }
     if (stopAtNonTabbable && !(element instanceof HTMLSlotElement) && element.getAttribute('tabindex') === '-1') {


### PR DESCRIPTION
### Description

Add option to remove focusable elements from spatial navigation with the `data-spatial-exclude` HTML attribute.

Breaking change: no

