### PR TITLE
fix(popover): show on hover when trigger lives inside shadow DOM

### DIFF
--- a/packages/components/src/components/popover/popover.component.ts
+++ b/packages/components/src/components/popover/popover.component.ts
@@ -950,14 +950,33 @@ class Popover
   }
 
   /**
+   * Determines whether a delegated `mouseover`/`mouseout` event is movement that stays within the
+   * trigger's subtree rather than a genuine enter/leave of the trigger.
+   *
+   * Both events fire repeatedly while the pointer moves between elements inside the trigger
+   * (e.g. an icon with internal SVG elements). `relatedTarget` is the element on the other side of
+   * the boundary (the element being left for `mouseover`, or entered for `mouseout`); if it
+   * resolves to the trigger or one of its shadow hosts, the pointer has not crossed the trigger
+   * boundary and the event should be ignored.
+   * @internal
+   */
+  private isHoverWithinTrigger = (event: Event): boolean => {
+    const { triggerElement } = this;
+    const { relatedTarget } = event as MouseEvent;
+    if (triggerElement && relatedTarget instanceof Element) {
+      return getHostComposePath(relatedTarget).includes(triggerElement);
+    }
+    return false;
+  };
+
+  /**
    * Handles the pointer moving over the trigger element (delegated `mouseover`).
    * This method sets the `isHovered` flag to true and shows the popover.
-   * `mouseover` also fires for descendants of the trigger, but `show()` is idempotent so the
-   * repeated calls while moving within the trigger are harmless.
    * @internal
    */
   private handleMouseEnter = (event: Event) => {
     if (!this.isEventFromTrigger(event)) return;
+    if (this.isHoverWithinTrigger(event)) return;
 
     this.isHovered = true;
     this.show();
@@ -971,17 +990,7 @@ class Popover
    */
   private handleMouseLeave = (event: Event) => {
     if (!this.isEventFromTrigger(event)) return;
-
-    // `mouseout` also fires while the pointer moves between elements inside the trigger
-    // (e.g. an icon with internal SVG elements). Only close if the pointer has actually left the
-    // trigger's subtree — i.e. the element being entered is not the trigger or one of its hosts.
-    const mouseEvent = event as MouseEvent;
-    const { triggerElement } = this;
-    if (triggerElement && mouseEvent.relatedTarget instanceof Element) {
-      if (getHostComposePath(mouseEvent.relatedTarget).includes(triggerElement)) {
-        return;
-      }
-    }
+    if (this.isHoverWithinTrigger(event)) return;
 
     this.isHovered = false;
     this.startCloseDelay();

--- a/packages/components/src/components/popover/popover.component.ts
+++ b/packages/components/src/components/popover/popover.component.ts
@@ -527,14 +527,6 @@ class Popover
   /** @internal */
   private floatingUICleanupFunction: (() => void) | null = null;
 
-  /**
-   * Tracks the element currently bound to the mouseenter/mouseleave hover listeners.
-   * Required so `removeTriggerListeners` always detaches from the same element it attached to,
-   * even if `triggerElement` has since been swapped or moved.
-   * @internal
-   */
-  private hoverListenerTarget: HTMLElement | null = null;
-
   /** @internal */
   protected shouldSuppressOpening: boolean = false;
 
@@ -594,29 +586,15 @@ class Popover
   protected override async firstUpdated(changedProperties: PropertyValues) {
     super.firstUpdated(changedProperties);
 
-    // Safety net: if the trigger was not in the DOM at connectedCallback time, the mouseenter
-    // listener will not have been attached. By firstUpdated, sibling rendering in the same Lit
-    // batch is normally complete, so try once more. Idempotency in setupTriggerListeners makes
-    // this safe to call even if the listener is already bound.
-    if (this.trigger.includes('mouseenter') && !this.hoverListenerTarget) {
-      this.setupTriggerListeners();
-    }
-
     PopoverEventManager.onCreatedPopover(this);
   }
 
   override connectedCallback(): void {
     super.connectedCallback();
 
-    // setupTriggerListeners must run BEFORE setupAppendTo: the trigger lookup uses
-    // getRootNode().querySelector(...), which is reliable while the popover still shares a root
-    // with its siblings. After setupAppendTo moves the popover to <body>, getRootNode() becomes
-    // `document` and shadow-DOM-nested triggers become unfindable. The disconnect/reconnect cycle
-    // that setupAppendTo's appendChild triggers is safely handled by setupTriggerListeners'
-    // idempotency guard (it no-ops if already bound to the current triggerElement).
-    this.setupTriggerListeners();
-
     this.utils.setupAppendTo();
+
+    this.setupTriggerListeners();
   }
 
   override async disconnectedCallback() {
@@ -644,19 +622,16 @@ class Popover
    * Sets up the trigger related event listeners, based on the trigger type.
    * Includes fallback for mouseenter trigger to also handle focusin for non-interactive popovers.
    *
-   * We use capture phase for click/focusin/focusout listeners (which remain on `document`) to make
-   * sure we capture trigger events even when they are not propagated during the bubble phase (e.g.:
-   * buttons in list item).
+   * We use capture phase on `document` for all trigger listeners to make sure we capture trigger
+   * events even when they are not propagated during the bubble phase (e.g.: buttons in list item).
    *
-   * mouseenter/mouseleave are bound directly to the trigger element rather than to `document`,
-   * because those events are spec'd as `composed: false` and would not reach a document-level
-   * listener when the trigger lives inside a shadow root (e.g. wrapped in `mdc-iconprovider` or
-   * `mdc-themeprovider`). Direct binding also makes capture vs bubble irrelevant for these
-   * non-bubbling events.
-   *
-   * This method is idempotent: if the hover listeners are already bound to the current
-   * `triggerElement`, the mouseenter branch no-ops. This protects against double-binding when
-   * `connectedCallback`, `firstUpdated`, and the `updated()` rebind paths overlap.
+   * Hover is detected via `mouseover`/`mouseout` (not `mouseenter`/`mouseleave`). The latter are
+   * spec'd as `composed: false` and do not bubble, so a document-level listener never sees them
+   * when the trigger lives inside a shadow root (e.g. wrapped in `mdc-iconprovider` or
+   * `mdc-themeprovider`). `mouseover`/`mouseout` are `composed: true` and bubble, so they cross
+   * shadow boundaries and reach `document`, letting us keep event delegation (no direct reference
+   * to the trigger element and no dependency on its mount/unmount lifecycle). The handlers filter
+   * out movements that stay within the trigger's subtree, recreating enter/leave semantics.
    * @internal
    */
   private setupTriggerListeners = () => {
@@ -671,20 +646,8 @@ class Popover
       hoverBridge?.addEventListener('mouseenter', this.show);
       this.addEventListener('mouseenter', this.cancelCloseDelay);
       this.addEventListener('mouseleave', this.startCloseDelay);
-
-      const currentTrigger = this.triggerElement;
-      if (currentTrigger && this.hoverListenerTarget !== currentTrigger) {
-        // Detach from any stale target before re-binding (e.g. trigger swapped).
-        if (this.hoverListenerTarget) {
-          this.hoverListenerTarget.removeEventListener('mouseenter', this.handleMouseEnter);
-          this.hoverListenerTarget.removeEventListener('mouseleave', this.handleMouseLeave);
-        }
-        currentTrigger.addEventListener('mouseenter', this.handleMouseEnter);
-        currentTrigger.addEventListener('mouseleave', this.handleMouseLeave);
-        this.hoverListenerTarget = currentTrigger;
-      }
-      // If currentTrigger is null, skip silently — firstUpdated or the opportunistic updated()
-      // rebind will pick it up once the trigger appears.
+      document.addEventListener('mouseover', this.handleMouseEnter, { capture: true });
+      document.addEventListener('mouseout', this.handleMouseLeave, { capture: true });
     }
     if (this.trigger.includes('focusin')) {
       document.addEventListener('focusin', this.handleFocusIn, { capture: true });
@@ -704,11 +667,8 @@ class Popover
     // mouseenter trigger
     const hoverBridge = this.renderRoot.querySelector('div[part="popover-hover-bridge"]');
     hoverBridge?.removeEventListener('mouseenter', this.show);
-    if (this.hoverListenerTarget) {
-      this.hoverListenerTarget.removeEventListener('mouseenter', this.handleMouseEnter);
-      this.hoverListenerTarget.removeEventListener('mouseleave', this.handleMouseLeave);
-      this.hoverListenerTarget = null;
-    }
+    document.removeEventListener('mouseover', this.handleMouseEnter, { capture: true });
+    document.removeEventListener('mouseout', this.handleMouseLeave, { capture: true });
     this.removeEventListener('mouseenter', this.cancelCloseDelay);
     this.removeEventListener('mouseleave', this.startCloseDelay);
 
@@ -749,12 +709,6 @@ class Popover
 
     if (changedProperties.has('trigger')) {
       this.parseTrigger();
-      this.removeTriggerListeners();
-      this.setupTriggerListeners();
-    } else if (changedProperties.has('triggerID')) {
-      // triggerID changed but trigger type didn't — rebind hover (and other trigger-bound) listeners
-      // to the new trigger element. With document-level listeners this was unnecessary; with
-      // element-level binding we must explicitly re-target.
       this.removeTriggerListeners();
       this.setupTriggerListeners();
     }
@@ -820,14 +774,6 @@ class Popover
       } else if (this.preventScroll && this.visible) {
         this.activatePreventScroll();
       }
-    }
-
-    // Opportunistic hover-listener rebind: covers the case where a parent component renders the
-    // popover in one commit and the trigger element in a later one. If the mouseenter trigger is
-    // active but no element listener is currently bound, try to attach now. setupTriggerListeners
-    // is idempotent and a no-op if the trigger is still missing.
-    if (this.trigger.includes('mouseenter') && !this.hoverListenerTarget && this.triggerElement) {
-      this.setupTriggerListeners();
     }
   }
 
@@ -1004,8 +950,10 @@ class Popover
   }
 
   /**
-   * Handles mouse enter event on the trigger element.
-   * This method sets the `isHovered` flag to true and shows the popover
+   * Handles the pointer moving over the trigger element (delegated `mouseover`).
+   * This method sets the `isHovered` flag to true and shows the popover.
+   * `mouseover` also fires for descendants of the trigger, but `show()` is idempotent so the
+   * repeated calls while moving within the trigger are harmless.
    * @internal
    */
   private handleMouseEnter = (event: Event) => {
@@ -1016,7 +964,7 @@ class Popover
   };
 
   /**
-   * Handles mouse leave event on the trigger element.
+   * Handles the pointer leaving the trigger element (delegated `mouseout`).
    * This method sets the `isHovered` flag to false and starts the close delay
    * timer to hide the popover.
    * @internal
@@ -1024,9 +972,9 @@ class Popover
   private handleMouseLeave = (event: Event) => {
     if (!this.isEventFromTrigger(event)) return;
 
-    // When the trigger contains shadow DOM children (e.g. an icon with internal SVG elements),
-    // mouseleave fires on internal elements as the mouse moves between them.
-    // Only close if the mouse has actually left the trigger element.
+    // `mouseout` also fires while the pointer moves between elements inside the trigger
+    // (e.g. an icon with internal SVG elements). Only close if the pointer has actually left the
+    // trigger's subtree — i.e. the element being entered is not the trigger or one of its hosts.
     const mouseEvent = event as MouseEvent;
     const { triggerElement } = this;
     if (triggerElement && mouseEvent.relatedTarget instanceof Element) {

--- a/packages/components/src/components/popover/popover.component.ts
+++ b/packages/components/src/components/popover/popover.component.ts
@@ -527,6 +527,14 @@ class Popover
   /** @internal */
   private floatingUICleanupFunction: (() => void) | null = null;
 
+  /**
+   * Tracks the element currently bound to the mouseenter/mouseleave hover listeners.
+   * Required so `removeTriggerListeners` always detaches from the same element it attached to,
+   * even if `triggerElement` has since been swapped or moved.
+   * @internal
+   */
+  private hoverListenerTarget: HTMLElement | null = null;
+
   /** @internal */
   protected shouldSuppressOpening: boolean = false;
 
@@ -586,15 +594,29 @@ class Popover
   protected override async firstUpdated(changedProperties: PropertyValues) {
     super.firstUpdated(changedProperties);
 
+    // Safety net: if the trigger was not in the DOM at connectedCallback time, the mouseenter
+    // listener will not have been attached. By firstUpdated, sibling rendering in the same Lit
+    // batch is normally complete, so try once more. Idempotency in setupTriggerListeners makes
+    // this safe to call even if the listener is already bound.
+    if (this.trigger.includes('mouseenter') && !this.hoverListenerTarget) {
+      this.setupTriggerListeners();
+    }
+
     PopoverEventManager.onCreatedPopover(this);
   }
 
   override connectedCallback(): void {
     super.connectedCallback();
 
-    this.utils.setupAppendTo();
-
+    // setupTriggerListeners must run BEFORE setupAppendTo: the trigger lookup uses
+    // getRootNode().querySelector(...), which is reliable while the popover still shares a root
+    // with its siblings. After setupAppendTo moves the popover to <body>, getRootNode() becomes
+    // `document` and shadow-DOM-nested triggers become unfindable. The disconnect/reconnect cycle
+    // that setupAppendTo's appendChild triggers is safely handled by setupTriggerListeners'
+    // idempotency guard (it no-ops if already bound to the current triggerElement).
     this.setupTriggerListeners();
+
+    this.utils.setupAppendTo();
   }
 
   override async disconnectedCallback() {
@@ -622,8 +644,19 @@ class Popover
    * Sets up the trigger related event listeners, based on the trigger type.
    * Includes fallback for mouseenter trigger to also handle focusin for non-interactive popovers.
    *
-   * We are using capture phase for to make sure we capture trigger events even when they are not propagated during the
-   * bubble phase (e.g.: buttons in list item)
+   * We use capture phase for click/focusin/focusout listeners (which remain on `document`) to make
+   * sure we capture trigger events even when they are not propagated during the bubble phase (e.g.:
+   * buttons in list item).
+   *
+   * mouseenter/mouseleave are bound directly to the trigger element rather than to `document`,
+   * because those events are spec'd as `composed: false` and would not reach a document-level
+   * listener when the trigger lives inside a shadow root (e.g. wrapped in `mdc-iconprovider` or
+   * `mdc-themeprovider`). Direct binding also makes capture vs bubble irrelevant for these
+   * non-bubbling events.
+   *
+   * This method is idempotent: if the hover listeners are already bound to the current
+   * `triggerElement`, the mouseenter branch no-ops. This protects against double-binding when
+   * `connectedCallback`, `firstUpdated`, and the `updated()` rebind paths overlap.
    * @internal
    */
   private setupTriggerListeners = () => {
@@ -636,10 +669,22 @@ class Popover
     if (this.trigger.includes('mouseenter')) {
       const hoverBridge = this.renderRoot.querySelector('div[part="popover-hover-bridge"]');
       hoverBridge?.addEventListener('mouseenter', this.show);
-      document.addEventListener('mouseenter', this.handleMouseEnter, { capture: true });
-      document.addEventListener('mouseleave', this.handleMouseLeave, { capture: true });
       this.addEventListener('mouseenter', this.cancelCloseDelay);
       this.addEventListener('mouseleave', this.startCloseDelay);
+
+      const currentTrigger = this.triggerElement;
+      if (currentTrigger && this.hoverListenerTarget !== currentTrigger) {
+        // Detach from any stale target before re-binding (e.g. trigger swapped).
+        if (this.hoverListenerTarget) {
+          this.hoverListenerTarget.removeEventListener('mouseenter', this.handleMouseEnter);
+          this.hoverListenerTarget.removeEventListener('mouseleave', this.handleMouseLeave);
+        }
+        currentTrigger.addEventListener('mouseenter', this.handleMouseEnter);
+        currentTrigger.addEventListener('mouseleave', this.handleMouseLeave);
+        this.hoverListenerTarget = currentTrigger;
+      }
+      // If currentTrigger is null, skip silently — firstUpdated or the opportunistic updated()
+      // rebind will pick it up once the trigger appears.
     }
     if (this.trigger.includes('focusin')) {
       document.addEventListener('focusin', this.handleFocusIn, { capture: true });
@@ -659,8 +704,11 @@ class Popover
     // mouseenter trigger
     const hoverBridge = this.renderRoot.querySelector('div[part="popover-hover-bridge"]');
     hoverBridge?.removeEventListener('mouseenter', this.show);
-    document.removeEventListener('mouseenter', this.handleMouseEnter, { capture: true });
-    document.removeEventListener('mouseleave', this.handleMouseLeave, { capture: true });
+    if (this.hoverListenerTarget) {
+      this.hoverListenerTarget.removeEventListener('mouseenter', this.handleMouseEnter);
+      this.hoverListenerTarget.removeEventListener('mouseleave', this.handleMouseLeave);
+      this.hoverListenerTarget = null;
+    }
     this.removeEventListener('mouseenter', this.cancelCloseDelay);
     this.removeEventListener('mouseleave', this.startCloseDelay);
 
@@ -701,6 +749,12 @@ class Popover
 
     if (changedProperties.has('trigger')) {
       this.parseTrigger();
+      this.removeTriggerListeners();
+      this.setupTriggerListeners();
+    } else if (changedProperties.has('triggerID')) {
+      // triggerID changed but trigger type didn't — rebind hover (and other trigger-bound) listeners
+      // to the new trigger element. With document-level listeners this was unnecessary; with
+      // element-level binding we must explicitly re-target.
       this.removeTriggerListeners();
       this.setupTriggerListeners();
     }
@@ -766,6 +820,14 @@ class Popover
       } else if (this.preventScroll && this.visible) {
         this.activatePreventScroll();
       }
+    }
+
+    // Opportunistic hover-listener rebind: covers the case where a parent component renders the
+    // popover in one commit and the trigger element in a later one. If the mouseenter trigger is
+    // active but no element listener is currently bound, try to attach now. setupTriggerListeners
+    // is idempotent and a no-op if the trigger is still missing.
+    if (this.trigger.includes('mouseenter') && !this.hoverListenerTarget && this.triggerElement) {
+      this.setupTriggerListeners();
     }
   }
 

--- a/packages/components/src/components/popover/popover.e2e-test.ts
+++ b/packages/components/src/components/popover/popover.e2e-test.ts
@@ -562,6 +562,59 @@ const interactionsTestCases = async (componentsPage: ComponentsPage) => {
       await expect(popover).not.toBeVisible();
     });
 
+    await test.step('shows popover on hover when trigger lives inside a shadow root', async () => {
+      // Regression test for the original shadow-DOM hover bug:
+      // mouseenter/mouseleave are spec'd as `composed: false`, so a document-level listener
+      // never sees those events when the trigger is in a shadow root. Direct element-level
+      // binding on triggerElement is required. We host both the popover and its trigger inside
+      // a single open shadow root so that triggerElement lookup (getRootNode().querySelector)
+      // resolves correctly — isolating the listener-binding fix from any separate deep-shadow
+      // lookup concerns.
+      await componentsPage.mount({
+        html: `<div id="wrapper"><shadow-host-popover-test></shadow-host-popover-test></div>`,
+        clearDocument: true,
+      });
+
+      await componentsPage.page.evaluate(() => {
+        if (!customElements.get('shadow-host-popover-test')) {
+          customElements.define(
+            'shadow-host-popover-test',
+            class extends HTMLElement {
+              connectedCallback() {
+                if (this.shadowRoot) return;
+                const root = this.attachShadow({ mode: 'open' });
+                root.innerHTML = `
+                  <div style="height: 20vh">
+                    <mdc-button id="shadow-trigger-button">Hover me</mdc-button>
+                  </div>
+                  <mdc-popover
+                    id="shadow-popover"
+                    triggerID="shadow-trigger-button"
+                    trigger="mouseenter"
+                    delay="0,100"
+                  >
+                    Shadow popover content
+                  </mdc-popover>
+                `;
+              }
+            },
+          );
+        }
+      });
+
+      const triggerButton = componentsPage.page.locator('shadow-host-popover-test mdc-button#shadow-trigger-button');
+      const popover = componentsPage.page.locator('shadow-host-popover-test mdc-popover#shadow-popover');
+
+      await expect(triggerButton).toBeVisible();
+
+      await triggerButton.hover();
+      await expect(popover).toBeVisible();
+
+      await componentsPage.page.mouse.move(0, 0);
+      await componentsPage.page.waitForTimeout(200);
+      await expect(popover).not.toBeVisible();
+    });
+
     await test.step('should keep popover open when mouse moves between trigger and popover', async () => {
       const ADJUSTMENT = 15;
       const placementsToTest = [

--- a/packages/components/src/components/popover/popover.e2e-test.ts
+++ b/packages/components/src/components/popover/popover.e2e-test.ts
@@ -537,8 +537,8 @@ const interactionsTestCases = async (componentsPage: ComponentsPage) => {
         if (!target) return;
 
         trigger.dispatchEvent(
-          new MouseEvent('mouseleave', {
-            bubbles: false,
+          new MouseEvent('mouseout', {
+            bubbles: true,
             composed: true,
             relatedTarget: target,
           }),
@@ -550,8 +550,8 @@ const interactionsTestCases = async (componentsPage: ComponentsPage) => {
 
       await triggerButton.evaluate(trigger => {
         trigger.dispatchEvent(
-          new MouseEvent('mouseleave', {
-            bubbles: false,
+          new MouseEvent('mouseout', {
+            bubbles: true,
             composed: true,
             relatedTarget: document.body,
           }),
@@ -564,12 +564,11 @@ const interactionsTestCases = async (componentsPage: ComponentsPage) => {
 
     await test.step('shows popover on hover when trigger lives inside a shadow root', async () => {
       // Regression test for the original shadow-DOM hover bug:
-      // mouseenter/mouseleave are spec'd as `composed: false`, so a document-level listener
-      // never sees those events when the trigger is in a shadow root. Direct element-level
-      // binding on triggerElement is required. We host both the popover and its trigger inside
-      // a single open shadow root so that triggerElement lookup (getRootNode().querySelector)
-      // resolves correctly — isolating the listener-binding fix from any separate deep-shadow
-      // lookup concerns.
+      // mouseenter/mouseleave are spec'd as `composed: false`, so a document-level listener never
+      // sees those events when the trigger is in a shadow root. The fix delegates hover via
+      // `mouseover`/`mouseout`, which are `composed: true` and bubble, so they cross the shadow
+      // boundary and reach the document-level listener. We host both the popover and its trigger
+      // inside a single open shadow root to exercise that cross-boundary path.
       await componentsPage.mount({
         html: `<div id="wrapper"><shadow-host-popover-test></shadow-host-popover-test></div>`,
         clearDocument: true,
@@ -610,7 +609,14 @@ const interactionsTestCases = async (componentsPage: ComponentsPage) => {
       await triggerButton.hover();
       await expect(popover).toBeVisible();
 
-      await componentsPage.page.mouse.move(0, 0);
+      // Move the pointer clearly outside the trigger's bounding box. The trigger sits in the
+      // top-left corner, so moving to (0,0) would still land on it; compute an empty point past
+      // its bottom-right edge to guarantee the pointer actually leaves the trigger subtree.
+      const triggerBox = (await triggerButton.boundingBox())!;
+      await componentsPage.page.mouse.move(
+        triggerBox.x + triggerBox.width + 200,
+        triggerBox.y + triggerBox.height + 200,
+      );
       await componentsPage.page.waitForTimeout(200);
       await expect(popover).not.toBeVisible();
     });


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description


Hover triggers used document-level `mouseenter`/`mouseleave` listeners. Those
events are spec'd as `composed: false` and do not bubble, so when the trigger
lives inside a shadow root (e.g. wrapped in `mdc-iconprovider`/`mdc-themeprovider`)
the event path never reaches the document listener and the popover never opens.
Delegate hover via `mouseover`/`mouseout` instead. They are `composed: true` and
bubble, so they cross shadow boundaries and reach the document-level listener,
which lets us keep event delegation — no direct reference to the trigger element
and no dependency on its mount/unmount lifecycle. The handlers reuse the existing
`isEventFromTrigger` (composedPath) check and a subtree guard on `relatedTarget`
to recreate enter/leave semantics and ignore movements within the trigger.


### Links

N/A
