### PR TITLE
fix(spatialnavigation): increase data-spatial-dir attribute priority

### DIFF
--- a/packages/components/src/components/menupopover/menupopover.e2e-test.ts
+++ b/packages/components/src/components/menupopover/menupopover.e2e-test.ts
@@ -861,6 +861,61 @@ test('mdc-menupopover', async ({ componentsPage }) => {
         await expect(triggerElement).toBeFocused();
         await expect(menuItemRadio).toHaveAttribute('aria-checked', 'true');
       });
+
+      await test.step('prevent menu navigation', async () => {
+        const { triggerElement } = await setup({
+          componentsPage,
+          html: `
+          <div id="menupopover-test-wrapper">
+            <mdc-button id="trigger-btn">Options</mdc-button>
+            <mdc-menupopover triggerid="trigger-btn">
+              <mdc-menuitem id="menu-item-1" data-spatial-up="" data-spatial-down="menu-item-3"  label="Profile"></mdc-menuitem>
+              <mdc-menuitem id="menu-item-2" label="Settings"></mdc-menuitem>
+              <mdc-menuitem id="menu-item-3" label="Notifications"></mdc-menuitem>
+              <mdc-menuitem id="menu-item-4" data-spatial-up="menu-item-1" label="Logout"></mdc-menuitem>
+            </mdc-menupopover>
+          </div>
+        `,
+        });
+        await componentsPage.wrapElement({ wrapperTagName: 'mdc-spatialnavigationprovider' });
+        const menuPopover = componentsPage.page.locator('mdc-menupopover[triggerid="trigger-btn"]');
+        const menuItem1 = menuPopover.locator('#menu-item-1');
+        const menuItem3 = menuPopover.locator('#menu-item-3');
+        const menuItem4 = menuPopover.locator('#menu-item-4');
+
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(triggerElement).toBeFocused();
+
+        await keyboard.press(KEYS.ENTER);
+        await expect(menuPopover).toBeVisible();
+
+        await expect(menuItem1).toBeFocused();
+
+        // Jump to item 3
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(menuItem3).toBeFocused();
+
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(menuItem4).toBeFocused();
+
+        // Loop back to the first item
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(menuItem1).toBeFocused();
+
+        // No loop back to the last item since item 1 has data-spatial-up=""
+        await keyboard.press(KEYS.ARROW_UP);
+        await expect(menuItem1).toBeFocused();
+
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(menuItem3).toBeFocused();
+
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(menuItem4).toBeFocused();
+
+        // Jump to item 1
+        await keyboard.press(KEYS.ARROW_UP);
+        await expect(menuItem1).toBeFocused();
+      });
     });
   });
 });

--- a/packages/components/src/components/menupopover/menupopover.stories.ts
+++ b/packages/components/src/components/menupopover/menupopover.stories.ts
@@ -350,6 +350,7 @@ export const CustomMenu: StoryObj = {
         flex-wrap: wrap;
         gap: 0.25rem;
         width: 21rem;
+        flex-direction: row;
       }
 
       .layout-section::part(header-text) {
@@ -385,13 +386,35 @@ export const CustomMenu: StoryObj = {
     ${createPopover(
       args,
       html` <mdc-menusection headerText="Layout" class="layout-section">
-          <mdc-menuitemradio name="layout" label="Grid" checked indicator="none">
+          <mdc-menuitemradio
+            data-spatial-focusable
+            data-spatial-up="notification-menu-item"
+            data-spatial-down="enable-feature"
+            name="layout"
+            label="Grid"
+            checked
+            indicator="none"
+          >
             <mdc-icon name="video-layout-equal-light" size="2" slot="leading-controls" length-unit="rem"></mdc-icon>
           </mdc-menuitemradio>
-          <mdc-menuitemradio name="layout" label="Stack" indicator="none">
+          <mdc-menuitemradio
+            data-spatial-focusable
+            data-spatial-up="notification-menu-item"
+            data-spatial-down="enable-feature"
+            name="layout"
+            label="Stack"
+            indicator="none"
+          >
             <mdc-icon name="video-layout-stack-light" size="2" slot="leading-controls" length-unit="rem"></mdc-icon>
           </mdc-menuitemradio>
-          <mdc-menuitemradio name="layout" label="Side by side" indicator="none">
+          <mdc-menuitemradio
+            data-spatial-focusable
+            data-spatial-up="notification-menu-item"
+            data-spatial-down="enable-feature"
+            name="layout"
+            label="Side by side"
+            indicator="none"
+          >
             <mdc-icon
               name="layout-side-by-side-vertical-light"
               size="2"
@@ -402,11 +425,11 @@ export const CustomMenu: StoryObj = {
         </mdc-menusection>
         <mdc-divider></mdc-divider>
         <mdc-menusection headerText="Preferences">
-          <mdc-menuitemcheckbox label="Enable feature"></mdc-menuitemcheckbox>
+          <mdc-menuitemcheckbox id="enable-feature" label="Enable feature"></mdc-menuitemcheckbox>
           <mdc-menuitemcheckbox label="Beta mode" checked></mdc-menuitemcheckbox>
         </mdc-menusection>
         <mdc-divider></mdc-divider>
-        <mdc-menuitem label="Notifications"></mdc-menuitem>`,
+        <mdc-menuitem id="notification-menu-item" label="Notifications"></mdc-menuitem>`,
     )}
   `,
 };

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
@@ -18,24 +18,43 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
 
 // AI-Assisted
 /**
- * This component manages focus using spatial navigation and provides context for child components.
- *
- * Place it at the root of the application.
+ * Spatial navigation focus manager
  *
  * [Spatial navigation](https://en.wikipedia.org/wiki/Spatial_navigation) lets users move focus among
  * elements on a 2D plane, common on TVs and game consoles with remotes or gamepads.
+ *
+ * It should have only one instance and it should placed at the root of the application.
  *
  * ## Focus management
  *
  * The provider listens to keyboard events and moves focus among elements based on arrow key input.
  * You can influence or override this behavior.
  *
- * Note: The algorithm is distance-based, so the UI should be designed so focusable elements are
- * predictably reachable. Relative element positions should remain stable; responsive layouts can
- * make navigation unpredictable. This is less of an issue on fixed-size TV UIs but can show unexpected
- * behavior in Storybook when resizing. See the "Limitations" section.
+ * ### Steps
  *
- * ### Automatic
+ * Spatial navigation goes trough the following steps after each keydown:
+ *
+ * 1. Handle `keydown` in the capture phase.
+ *    When active element has `data-spatial-{direction}` attribute then prevent all component navigation and call the
+ *    provider own `keydown` handler (see step 3).
+ * 2. Component own `keydown` handler executed (bubble phase) (e.g., list moves focus internally) it it was not
+ *    prevented.
+ * 3. Spatial Navigation Provider's `keydown` handler executed (bubble phase)
+ *    - If key event was not prevented in step 1. emit `navbeforeprocess` to check if any component want to handle
+ *      the key event itself. If `navbeforeprocess` event is prevented, stop here.
+ *    - If the component did not handle `keydown`, it calculate the next focusable item
+ *      - if the active element has `data-spatial-{direction}` attribute, it will try to focus the element with the id.
+ *      - Otherwise calculate the next focused item based on the direction and distances.
+ *    - If there is no next item, it emits `navnotarget` event
+ *    - Otherwise emit `navbeforefocus`,
+ *      - If this event prevented, nothing happens
+ *      - Otherwise the focus moves to the next element
+ *
+ * ### Determine next focus
+ *
+ * The provider use multiple ways to determine the next focused element. The order defined in the "Steps" section.
+ *
+ * #### Calculated focus
  *
  * By default, the next focus target is computed from element positions:
  *
@@ -52,9 +71,14 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  * Elements with `data-spatial-exclude` are excluded (with its subtree) from the navigation, even if they
  * are focusable.
  *
- * ### Overwrite next element
+ * Note: The algorithm is distance-based, so the UI should be designed to focusable elements are
+ * predictably reachable. Relative element positions should remain stable; responsive layouts can
+ * make navigation unpredictable. This is less of an issue on fixed-size TV UIs but can show unexpected
+ * behavior in Storybook when resizing. See the "Limitations" section.
  *
- * Override automatic navigation by adding one of these attributes to a focusable element:
+ * #### Overwrite next element
+ *
+ * Override calculated navigation by adding one of these attributes to a focusable element:
  *
  * - `data-spatial-up`
  * - `data-spatial-down`
@@ -63,7 +87,7 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  *
  * Each attribute value must be the id of the element to focus when the corresponding key is pressed.
  *
- * ### Element internal navigation
+ * #### Element internal navigation
  *
  * Complex components (List, Combobox, Tree, etc.) may handle their own navigation. For example, a List moves
  * focus internally on Down until the last item, after which Down should fall back to provider navigation.
@@ -95,15 +119,15 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  *
  * Supported data attributes:
  *
- * | Attribute              | Value       | Default | Description                                                                         |
- * |------------------------|-------------|---------|-------------------------------------------------------------------------------------|
- * | `data-spatial-left`    | element id  | N/A     | Focus this element when Left is pressed                                             |
- * | `data-spatial-up`      | element id  | N/A     | Focus this element when Up is pressed                                               |
- * | `data-spatial-right`   | element id  | N/A     | Focus this element when Right is pressed                                            |
- * | `data-spatial-down`    | element id  | N/A     | Focus this element when Down is pressed                                             |
- * | `data-spatial-go-back` | N/A         | N/A     | First focusable element with this attribute is clicked on Back/Escape               |
- * | `data-spatial-focusable` | N/A       | N/A     | Treat element as focusable even if it normally is not (e.g., `tabindex="-1"`)       |
- * | `data-spatial-exclude` | N/A         | N/A     | Exclude focusable element (and its subtree) from the navigation                     |
+ * | Attribute                | Value                     | Default | Description                                                                   |
+ * |--------------------------|---------------------------|---------|-------------------------------------------------------------------------------|
+ * | `data-spatial-left`      | empty string / element id | N/A     | Prevent native navigation in Left direction and focus element if exists       |
+ * | `data-spatial-up`        | empty string / element id | N/A     | Prevent native navigation in Up direction and focus element if exists         |
+ * | `data-spatial-right`     | empty string / element id | N/A     | Prevent native navigation in Right direction and focus element if exists      |
+ * | `data-spatial-down`      | empty string / element id | N/A     | Prevent native navigation in Down direction and focus element if exists       |
+ * | `data-spatial-go-back`   | N/A                       | N/A     | First focusable element with this attribute is clicked on Back/Escape         |
+ * | `data-spatial-focusable` | N/A                       | N/A     | Treat element as focusable even if it normally is not (e.g., `tabindex="-1"`) |
+ * | `data-spatial-exclude`   | N/A                       | N/A     | Exclude focusable element (and its subtree) from the navigation               |
  *
  * ## Event emitting order
  *
@@ -271,7 +295,7 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
   /**
    * List of navigation keys
    */
-  get navigationKeys() {
+  isNavigationKey(key: string): boolean {
     return [
       this.navigationKeyMapping.up,
       this.navigationKeyMapping.down,
@@ -279,7 +303,19 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
       this.navigationKeyMapping.right,
       this.navigationKeyMapping.enter,
       this.navigationKeyMapping.escape,
-    ];
+    ].includes(key);
+  }
+
+  /**
+   * List of navigation keys
+   */
+  isDirectionKey(key: string): boolean {
+    return [
+      this.navigationKeyMapping.up,
+      this.navigationKeyMapping.down,
+      this.navigationKeyMapping.left,
+      this.navigationKeyMapping.right,
+    ].includes(key);
   }
 
   constructor() {
@@ -293,6 +329,7 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
   override connectedCallback() {
     super.connectedCallback();
 
+    document.addEventListener('keydown', this.handleKeyDownBefore, { capture: true });
     document.addEventListener('keydown', this.handleKeyDown);
     document.addEventListener('focus', this.handleFocus);
     this.initActiveElement();
@@ -300,6 +337,7 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
 
   override disconnectedCallback() {
     super.disconnectedCallback();
+    document.removeEventListener('keydown', this.handleKeyDownBefore, { capture: true });
     document.removeEventListener('keydown', this.handleKeyDown);
     document.removeEventListener('focus', this.handleFocus);
 
@@ -418,6 +456,23 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
   }
 
   /**
+   * Check if the current active element has instruction to find the next focusable
+   * We look for the element in all the shadow DOMs in the composed path of the active element,
+   * so mdc component can use this feature as well.
+   *
+   * @param currentDomActiveElement - The current active element in the DOM
+   * @param direction - Direction
+   */
+  private getElementIdForDirectionAttr(
+    currentDomActiveElement: HTMLElement | null,
+    direction: Direction,
+  ): string | undefined {
+    const dataAttrName = `data-spatial-${direction}`;
+
+    return currentDomActiveElement?.getAttribute(dataAttrName) ?? undefined;
+  }
+
+  /**
    * Focus the next element in the given direction.
    *
    * @param elements - List of focusable elements
@@ -426,11 +481,6 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
    * @internal
    */
   private focusNextInFocusableAria(elements: HTMLElement[], direction: Direction): HTMLElement | undefined {
-    // Do nothing when there is no focusable element
-    if (elements.length === 0) {
-      return undefined;
-    }
-
     let currentActiveElement = this.getActiveElement();
     const currentDomActiveElement = getDomActiveElement() as HTMLElement | null;
 
@@ -451,11 +501,6 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
       this.setActiveElement(currentActiveElement);
     }
 
-    // If DOM active element is not in the ficus area then move focus back to the current active element
-    if (currentActiveElement !== getDomActiveElement()) {
-      return currentActiveElement;
-    }
-
     // Check if the current active element has instruction to find the next focusable
     // We look for the element in all the shadow DOMs in the composed path of the active element,
     // so mdc component can use this feature as well.
@@ -472,6 +517,16 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
           return nextElement;
         }
       }
+    }
+
+    // If DOM active element is not in the focus area then move focus back to the current active element
+    if (currentActiveElement !== getDomActiveElement()) {
+      return currentActiveElement;
+    }
+
+    // Do nothing when there is no focusable element
+    if (elements.length === 0) {
+      return undefined;
     }
 
     // Find the closest element in the given direction
@@ -534,6 +589,24 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
     return this.activeElement?.deref();
   }
 
+  private handleKeyDownBefore = (evt: KeyboardEvent) => {
+    if (evt.shiftKey || evt.ctrlKey || evt.altKey || evt.metaKey || !this.isNavigationKey(evt.key)) {
+      return;
+    }
+    const action = this.context.value!.keyToActionMap[evt.key];
+    if (
+      this.isDirectionKey(evt.key) &&
+      this.getElementIdForDirectionAttr(evt.target as HTMLElement, action as Direction) !== undefined
+    ) {
+      // prevent native key events
+      evt.preventDefault();
+      // prevent MDC component key events
+      evt.stopImmediatePropagation();
+      // Need to call Spatial navigation key handler manually after all propagation stopped
+      this.handleKeyDown(evt);
+    }
+  };
+
   /**
    * Handle keydown event
    *
@@ -541,7 +614,7 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
    * @internal
    */
   private handleKeyDown = (evt: KeyboardEvent) => {
-    if (evt.shiftKey || evt.ctrlKey || evt.altKey || evt.metaKey || !this.navigationKeys.includes(evt.key)) {
+    if (evt.shiftKey || evt.ctrlKey || evt.altKey || evt.metaKey || !this.isNavigationKey(evt.key)) {
       return;
     }
     const action = this.context.value!.keyToActionMap[evt.key];


### PR DESCRIPTION
### Description

Prevent all other navigation when any of the `data-spatial-{left|right|up|down}` attribute defined on the active element.

This helps to handle edge cases where default navigation behaviour is incorrect, or it is not user-friendly

Breaking change: none
