### PR TITLE
fix(spatialnavigation): scroll in scrollable areas for oversized items

### DIFF
--- a/packages/components/src/components/list/list.e2e-test.ts
+++ b/packages/components/src/components/list/list.e2e-test.ts
@@ -439,19 +439,28 @@ test('mdc-list', async ({ componentsPage }) => {
 
       await keyboard.press(KEYS.ARROW_UP);
       await expect(listItems.nth(3)).toBeFocused();
-      expect(await list.evaluate(l => l.scrollTop)).toBe(384);
 
-      await keyboard.press(KEYS.ARROW_UP);
-      await expect(listItems.nth(3)).toBeFocused();
-      expect(await list.evaluate(l => l.scrollTop)).toBe(284);
+      // Skip these steps on Webkit.
+      // When focus moves up and the item need to scroll into view. Chrome and Firefox do the shortest scroll
+      // so the element's bottom will be aligned to the bottom of the viewport, while Webkit will align the element's
+      // top to the top of the viewport.
+      // Spatial navigation used in embedded systems (eg.: TV) which using chromium based browsers. It is Ok to skip it.
+      if (test.info().project.name !== 'webkit') {
+        expect(await list.evaluate(l => l.scrollTop)).toBe(384);
 
-      await keyboard.press(KEYS.ARROW_UP);
-      await expect(listItems.nth(3)).toBeFocused();
-      expect(await list.evaluate(l => l.scrollTop)).toBe(184);
+        await keyboard.press(KEYS.ARROW_UP);
+        await expect(listItems.nth(3)).toBeFocused();
+        expect(await list.evaluate(l => l.scrollTop)).toBe(284);
 
-      await keyboard.press(KEYS.ARROW_UP);
-      await expect(listItems.nth(3)).toBeFocused();
-      expect(await list.evaluate(l => l.scrollTop)).toBe(84);
+        await keyboard.press(KEYS.ARROW_UP);
+        await expect(listItems.nth(3)).toBeFocused();
+        expect(await list.evaluate(l => l.scrollTop)).toBe(184);
+
+        await keyboard.press(KEYS.ARROW_UP);
+        await expect(listItems.nth(3)).toBeFocused();
+        expect(await list.evaluate(l => l.scrollTop)).toBe(84);
+
+      }
 
       await keyboard.press(KEYS.ARROW_UP);
       await expect(listItems.nth(2)).toBeFocused();

--- a/packages/components/src/components/list/list.e2e-test.ts
+++ b/packages/components/src/components/list/list.e2e-test.ts
@@ -380,6 +380,82 @@ test('mdc-list', async ({ componentsPage }) => {
         await expect(beforeBtn).toBeFocused();
       });
     });
+
+    await test.step('scroll when items does not fit into the view', async () => {
+      const list = await setup({ componentsPage, children: generateChildren(7), 'header-text': 'List header' });
+      await componentsPage.wrapElement({ wrapperTagName: 'mdc-spatialnavigationprovider' });
+      const { keyboard } = componentsPage.page;
+
+      const listItems = list.locator('mdc-listitem');
+
+      // change heights
+      await componentsPage.setAttributes(list, { style: 'height: 200px; overflow-y: auto' });
+      await componentsPage.setAttributes(listItems.nth(3), { style: 'height: 400px' });
+      await componentsPage.setAttributes(listItems.nth(5), { style: 'height: 400px', 'data-spatial-noscroll': '' });
+
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(listItems.nth(0)).toBeFocused();
+
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(listItems.nth(1)).toBeFocused();
+
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(listItems.nth(2)).toBeFocused();
+
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(listItems.nth(3)).toBeFocused();
+      expect(await list.evaluate(l => l.scrollTop)).toBe(176);
+
+      // Remain the focus on element 3 ...
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(listItems.nth(3)).toBeFocused();
+      expect(await list.evaluate(l => l.scrollTop)).toBe(276);
+
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(listItems.nth(3)).toBeFocused();
+      expect(await list.evaluate(l => l.scrollTop)).toBe(376);
+
+      // ... until its last part scroll into view
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(listItems.nth(3)).toBeFocused();
+      expect(await list.evaluate(l => l.scrollTop)).toBe(476);
+
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(listItems.nth(4)).toBeFocused();
+
+      // No scrolling
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(listItems.nth(5)).toBeFocused();
+
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(listItems.nth(6)).toBeFocused();
+
+      // No scrolling
+      await keyboard.press(KEYS.ARROW_UP);
+      await expect(listItems.nth(5)).toBeFocused();
+
+      await keyboard.press(KEYS.ARROW_UP);
+      await expect(listItems.nth(4)).toBeFocused();
+
+      await keyboard.press(KEYS.ARROW_UP);
+      await expect(listItems.nth(3)).toBeFocused();
+      expect(await list.evaluate(l => l.scrollTop)).toBe(384);
+
+      await keyboard.press(KEYS.ARROW_UP);
+      await expect(listItems.nth(3)).toBeFocused();
+      expect(await list.evaluate(l => l.scrollTop)).toBe(284);
+
+      await keyboard.press(KEYS.ARROW_UP);
+      await expect(listItems.nth(3)).toBeFocused();
+      expect(await list.evaluate(l => l.scrollTop)).toBe(184);
+
+      await keyboard.press(KEYS.ARROW_UP);
+      await expect(listItems.nth(3)).toBeFocused();
+      expect(await list.evaluate(l => l.scrollTop)).toBe(84);
+
+      await keyboard.press(KEYS.ARROW_UP);
+      await expect(listItems.nth(2)).toBeFocused();
+    });
   });
 
   /**

--- a/packages/components/src/components/list/list.stories.ts
+++ b/packages/components/src/components/list/list.stories.ts
@@ -14,6 +14,7 @@ import '../avatarbutton';
 import '../badge';
 import '../button';
 import '../checkbox';
+import '../chip';
 import '../divider';
 import '../icon';
 import '../listitem';
@@ -463,3 +464,118 @@ export const NestedList: StoryObj = {
   },
 };
 // End AI-Assisted
+
+export const ScrollableListWithLongListItems: StoryObj = {
+  parameters: {
+    docs: {
+      description: {
+        story: html` <mdc-text tagname="h1" type="body-large-bold"
+            >Handle list with oversized items in spatial navigation</mdc-text
+          >
+          <mdc-text tagname="p" type="body-large-bold">List item marked:</mdc-text>
+          <ul>
+            <li style="padding-block-end: 0.5rem">
+              <mdc-chip
+                color="lime"
+                label="Scroll active element in the given direction when it does not fit into the scroll view"
+              ></mdc-chip>
+            </li>
+            <li><mdc-chip color="pink" label="No scroll"></mdc-chip></li>
+          </ul>`,
+      },
+    },
+  },
+  render: args => html`
+    <style>
+      mdc-listitem {
+        outline: 2px solid var(--mds-color-theme-background-label-lime-active);
+        outline-offset: -3px;
+      }
+      mdc-listitem[data-spatial-noscroll] {
+        outline: 2px solid var(--mds-color-theme-background-label-pink-active);
+      }
+    </style>
+    <mdc-list
+      aria-label="${args['aria-label']}"
+      style="height: 200px; overflow-y: auto; padding: 0.5rem"
+      id="scrollable-list"
+    >
+      <mdc-listitem @click="${action('onclick')}" variant="${LISTITEM_VARIANTS.INSET_RECTANGLE}">
+        <mdc-text slot="content">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium erat ac egestas molestie.
+        </mdc-text>
+      </mdc-listitem>
+      <mdc-listitem @click="${action('onclick')}" variant="${LISTITEM_VARIANTS.INSET_RECTANGLE}">
+        <mdc-text slot="content">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium erat ac egestas molestie.
+          Vestibulum lobortis sollicitudin arcu ultricies tristique. Pellentesque iaculis risus condimentum purus ornare
+          egestas. Proin vitae augue libero.
+        </mdc-text>
+      </mdc-listitem>
+      <mdc-listitem @click="${action('onclick')}" variant="${LISTITEM_VARIANTS.INSET_RECTANGLE}">
+        <mdc-text slot="content">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium erat ac egestas molestie.
+          Vestibulum lobortis sollicitudin arcu ultricies tristique. Pellentesque iaculis risus condimentum purus ornare
+          egestas. Proin vitae augue libero. Vestibulum lacinia dignissim efficitur. Ut quis velit at lectus ultricies
+          faucibus at a risus. Nunc accumsan augue euismod nibh bibendum ullamcorper. Mauris bibendum elit nec orci
+          eleifend, ut ornare risus rutrum. Maecenas sit amet magna placerat, ultricies lectus in, malesuada quam. Donec
+          vestibulum nisi eu viverra vehicula. Morbi sem tellus, faucibus ac ligula interdum, suscipit porttitor nunc.
+          Nullam sit amet justo eros. Curabitur et tincidunt justo. Mauris lobortis velit nec porttitor gravida. Proin
+          elementum aliquet ante at tincidunt.
+        </mdc-text>
+      </mdc-listitem>
+      <mdc-listitem @click="${action('onclick')}" variant="${LISTITEM_VARIANTS.INSET_RECTANGLE}">
+        <mdc-text slot="content">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium erat ac egestas molestie.
+          Vestibulum lobortis sollicitudin arcu ultricies tristique. Pellentesque iaculis risus condimentum purus ornare
+          egestas. Proin vitae augue libero.
+        </mdc-text>
+      </mdc-listitem>
+      <mdc-listitem @click="${action('onclick')}" variant="${LISTITEM_VARIANTS.INSET_RECTANGLE}">
+        <mdc-text slot="content">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium erat ac egestas molestie.
+          Vestibulum lobortis sollicitudin arcu ultricies tristique. Pellentesque iaculis risus condimentum purus ornare
+          egestas. Proin vitae augue libero. Vestibulum lacinia dignissim efficitur. Ut quis velit at lectus ultricies
+          faucibus at a risus. Nunc accumsan augue euismod nibh bibendum ullamcorper. Mauris bibendum elit nec orci
+          eleifend, ut ornare risus rutrum. Maecenas sit amet magna placerat, ultricies lectus in, malesuada quam. Donec
+          vestibulum nisi eu viverra vehicula. Morbi sem tellus, faucibus ac ligula interdum, suscipit porttitor nunc.
+          Nullam sit amet justo eros. Curabitur et tincidunt justo. Mauris lobortis velit nec porttitor gravida. Proin
+          elementum aliquet ante at tincidunt.
+        </mdc-text>
+      </mdc-listitem>
+      <mdc-listitem @click="${action('onclick')}" variant="${LISTITEM_VARIANTS.INSET_RECTANGLE}">
+        <mdc-text slot="content">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium erat ac egestas molestie.
+        </mdc-text>
+      </mdc-listitem>
+      <mdc-listitem @click="${action('onclick')}" variant="${LISTITEM_VARIANTS.INSET_RECTANGLE}" data-spatial-noscroll>
+        <mdc-text slot="content">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium erat ac egestas molestie.
+          Vestibulum lobortis sollicitudin arcu ultricies tristique. Pellentesque iaculis risus condimentum purus ornare
+          egestas. Proin vitae augue libero.
+        </mdc-text>
+      </mdc-listitem>
+      <mdc-listitem @click="${action('onclick')}" variant="${LISTITEM_VARIANTS.INSET_RECTANGLE}" data-spatial-noscroll>
+        <mdc-text slot="content">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium erat ac egestas molestie.
+          Vestibulum lobortis sollicitudin arcu ultricies tristique. Pellentesque iaculis risus condimentum purus ornare
+          egestas. Proin vitae augue libero. Vestibulum lacinia dignissim efficitur. Ut quis velit at lectus ultricies
+          faucibus at a risus. Nunc accumsan augue euismod nibh bibendum ullamcorper. Mauris bibendum elit nec orci
+          eleifend, ut ornare risus rutrum. Maecenas sit amet magna placerat, ultricies lectus in, malesuada quam. Donec
+          vestibulum nisi eu viverra vehicula. Morbi sem tellus, faucibus ac ligula interdum, suscipit porttitor nunc.
+          Nullam sit amet justo eros. Curabitur et tincidunt justo. Mauris lobortis velit nec porttitor gravida. Proin
+          elementum aliquet ante at tincidunt.
+        </mdc-text>
+      </mdc-listitem>
+      <mdc-listitem @click="${action('onclick')}" variant="${LISTITEM_VARIANTS.INSET_RECTANGLE}">
+        <mdc-text slot="content">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium erat ac egestas molestie.
+        </mdc-text>
+      </mdc-listitem>
+    </mdc-list>
+  `,
+  args: {
+    textPassedToListHeader: 'Scrollable Participants List',
+    'aria-label': 'View all participants',
+  },
+};

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
@@ -223,12 +223,6 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  * - Avoid nested focusable elements where possible.
  * - Tune algorithm weights to match your UI layout.
  *
- * ### Scrollable containers
- *
- * Content scrolling is not supported yet, e.g.:
- * - Focused element larger than the viewport.
- * - Scrollable content without interactive children.
- *
  * ### Nested providers
  *
  * Only one provider instance is supported in the application at a time.

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
@@ -1,7 +1,7 @@
 import { property } from 'lit/decorators.js';
 
 import { Provider } from '../../models';
-import { findFocusable, getDomActiveElement, getHostComposePath, isScrollable } from '../../utils/dom';
+import { findFocusable, getDomActiveElement, getHostComposePath, getScrollableAxis } from '../../utils/dom';
 import { FocusTrapStack } from '../../utils/mixins/focus/FocusTrapStack';
 
 import SpatialNavigationProviderContext from './spatialnavigationprovider.context';
@@ -35,8 +35,11 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  * Spatial navigation goes trough the following steps after each keydown:
  *
  * 1. Handle `keydown` in the capture phase.
- *    When active element has `data-spatial-{direction}` attribute then prevent all component navigation and call the
- *    provider own `keydown` handler (see step 3).
+ *    - When active element has `data-spatial-{direction}` attribute then prevent all component navigation and call the
+ *      provider own `keydown` handler (see step 3).
+ *    - When active element's parent is scrollable and it is not fully visible in the given direction and it does not
+ *      have `data-spatial-noscroll` attribute, prevent all navigation and scroll in the give direction half size of the
+ *      scroll view.
  * 2. Component own `keydown` handler executed (bubble phase) (e.g., list moves focus internally) it it was not
  *    prevented.
  * 3. Spatial Navigation Provider's `keydown` handler executed (bubble phase)
@@ -119,15 +122,16 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  *
  * Supported data attributes:
  *
- * | Attribute                | Value                     | Default | Description                                                                   |
- * |--------------------------|---------------------------|---------|-------------------------------------------------------------------------------|
- * | `data-spatial-left`      | empty string / element id | N/A     | Prevent native navigation in Left direction and focus element if exists       |
- * | `data-spatial-up`        | empty string / element id | N/A     | Prevent native navigation in Up direction and focus element if exists         |
- * | `data-spatial-right`     | empty string / element id | N/A     | Prevent native navigation in Right direction and focus element if exists      |
- * | `data-spatial-down`      | empty string / element id | N/A     | Prevent native navigation in Down direction and focus element if exists       |
- * | `data-spatial-go-back`   | N/A                       | N/A     | First focusable element with this attribute is clicked on Back/Escape         |
- * | `data-spatial-focusable` | N/A                       | N/A     | Treat element as focusable even if it normally is not (e.g., `tabindex="-1"`) |
- * | `data-spatial-exclude`   | N/A                       | N/A     | Exclude focusable element (and its subtree) from the navigation               |
+ * | Attribute                | Value                     | Default | Description                                                                        |
+ * |--------------------------|---------------------------|---------|------------------------------------------------------------------------------------|
+ * | `data-spatial-left`      | empty string / element id | N/A     | Prevent native navigation in Left direction and focus element if exists            |
+ * | `data-spatial-up`        | empty string / element id | N/A     | Prevent native navigation in Up direction and focus element if exists              |
+ * | `data-spatial-right`     | empty string / element id | N/A     | Prevent native navigation in Right direction and focus element if exists           |
+ * | `data-spatial-down`      | empty string / element id | N/A     | Prevent native navigation in Down direction and focus element if exists            |
+ * | `data-spatial-go-back`   | N/A                       | N/A     | First focusable element with this attribute is clicked on Back/Escape              |
+ * | `data-spatial-focusable` | N/A                       | N/A     | Treat element as focusable even if it normally is not (e.g., `tabindex="-1"`)      |
+ * | `data-spatial-exclude`   | N/A                       | N/A     | Exclude focusable element (and its subtree) from the navigation                    |
+ * | `data-spatial-noscroll`  | N/A                       | N/A     | Prevent scroll for ative element in scrollable area even if the is not fit in view |
  *
  * ## Event emitting order
  *
@@ -414,7 +418,7 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
     path = path.includes(this.root) ? path : [this.root];
     // Walk through the composed path to find the focus areas (scrollable or focus trap)
     for (const el of path) {
-      if (el === activeTrap || el === this.root || isScrollable(el)) {
+      if (el === activeTrap || el === this.root || getScrollableAxis(el)) {
         // Find focusable elements within the current focus area (excluding the already checked focus areas)
         focusableElements.push(
           ...findFocusable(el, {
@@ -593,17 +597,58 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
     if (evt.shiftKey || evt.ctrlKey || evt.altKey || evt.metaKey || !this.isNavigationKey(evt.key)) {
       return;
     }
+    let eventHandled = false;
+    const target = evt.target as HTMLElement;
     const action = this.context.value!.keyToActionMap[evt.key];
     if (
       this.isDirectionKey(evt.key) &&
-      this.getElementIdForDirectionAttr(evt.target as HTMLElement, action as Direction) !== undefined
+      this.getElementIdForDirectionAttr(target as HTMLElement, action as Direction) !== undefined
     ) {
+      eventHandled = true;
+      // Need to call Spatial navigation key handler manually after all propagation stopped
+      this.handleKeyDown(evt);
+    }
+
+    // Handle over sized elements inside scrollable area
+    if (target.parentElement && !target.hasAttribute('data-spatial-noscroll')) {
+      const parent = target.parentElement as HTMLElement;
+      const targetScrollAxis = getScrollableAxis(parent);
+      if (targetScrollAxis) {
+        const targetBB = target.getBoundingClientRect();
+        const parentBB = parent.getBoundingClientRect();
+
+        // Vertical scrolling
+        if (targetScrollAxis === 'vertical' || targetScrollAxis === 'both') {
+          if (action === 'up' && targetBB.top < parentBB.top && parent.scrollTop > 0) {
+            parent.scrollTo({ top: parent.scrollTop - parentBB.height / 2, behavior: 'auto' });
+            eventHandled = true;
+          }
+          if (action === 'down' && targetBB.bottom > parentBB.bottom && (parent.scrollTop + parentBB.height) < parent.scrollHeight) {
+            parent.scrollTo({ top: parent.scrollTop + parentBB.height / 2, behavior: 'auto' });
+            eventHandled = true;
+          }
+        }
+
+        // horizontal scrolling
+        if (targetScrollAxis === 'horizontal' || targetScrollAxis === 'both') {
+          if (action === 'right' && targetBB.left < parentBB.left &&parent.scrollLeft > 0) {
+            parent.scrollTo({ left: parent.scrollLeft - parentBB.width / 2, behavior: 'auto' });
+            eventHandled = true;
+          }
+
+          if (action === 'left' && targetBB.right > parentBB.right && (parent.scrollLeft + parentBB.width) < parent.scrollWidth) {
+            parent.scrollTo({ left: parent.scrollLeft + parentBB.width / 2, behavior: 'auto' });
+            eventHandled = true;
+          }
+        }
+      }
+    }
+
+    if (eventHandled) {
       // prevent native key events
       evt.preventDefault();
       // prevent MDC component key events
       evt.stopImmediatePropagation();
-      // Need to call Spatial navigation key handler manually after all propagation stopped
-      this.handleKeyDown(evt);
     }
   };
 

--- a/packages/components/src/utils/dom.ts
+++ b/packages/components/src/utils/dom.ts
@@ -79,13 +79,18 @@ export const hasZeroDimensions = (element: HTMLElement) => {
  * @param element - The element to check.
  * @returns True if the element is scrollable.
  */
-export const isScrollable = (element: HTMLElement): boolean => {
-  if (!(element instanceof Element)) return false;
+export const getScrollableAxis = (element: HTMLElement): null | 'horizontal' | 'vertical' | 'both' => {
+  if (!(element instanceof Element)) return null;
   const computedStyle = getComputedStyle(element);
   const { overflowX, overflowY } = computedStyle;
 
-  // Check if overflow is set to scrollable values
-  return overflowX === 'auto' || overflowX === 'scroll' || overflowY === 'auto' || overflowY === 'scroll';
+  const horizontal = overflowX === 'auto' || overflowX === 'scroll'
+  const vertical = overflowY === 'auto' || overflowY === 'scroll';
+
+  if (horizontal && vertical) return 'both';
+  if (horizontal) return 'horizontal';
+  if (vertical) return 'vertical';
+  return null;
 };
 
 /**


### PR DESCRIPTION

<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

In scrollable areas, direction keys do scrolling instead of moving focus when the active element is not fully visible in the scroll view in the given direction (top, bottom, left and right).
This applies when using Spatial Navigation.

Breaking change: none
