### PR TITLE
fix(spatialnavigation): add data-spatial-scroll-parent handler

### DIFF
--- a/packages/components/src/components/list/list.e2e-test.ts
+++ b/packages/components/src/components/list/list.e2e-test.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test';
+import { expect , Locator, Keyboard } from '@playwright/test';
 
 import { KEYS } from '../../utils/keys';
 import { ComponentsPage, test } from '../../../config/playwright/setup';
@@ -382,88 +382,115 @@ test('mdc-list', async ({ componentsPage }) => {
     });
 
     await test.step('scroll when items does not fit into the view', async () => {
-      const list = await setup({ componentsPage, children: generateChildren(7), 'header-text': 'List header' });
-      await componentsPage.wrapElement({ wrapperTagName: 'mdc-spatialnavigationprovider' });
-      const { keyboard } = componentsPage.page;
+      const navigationSteps = async (keyboard: Keyboard, scrollRoot: Locator, listItems: Locator) => {
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(listItems.nth(0)).toBeFocused();
 
-      const listItems = list.locator('mdc-listitem');
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(listItems.nth(1)).toBeFocused();
 
-      // change heights
-      await componentsPage.setAttributes(list, { style: 'height: 200px; overflow-y: auto' });
-      await componentsPage.setAttributes(listItems.nth(3), { style: 'height: 400px' });
-      await componentsPage.setAttributes(listItems.nth(5), { style: 'height: 400px', 'data-spatial-noscroll': '' });
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(listItems.nth(2)).toBeFocused();
 
-      await keyboard.press(KEYS.ARROW_DOWN);
-      await expect(listItems.nth(0)).toBeFocused();
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(listItems.nth(3)).toBeFocused();
+        const scrollDownTop = await scrollRoot.evaluate(l => l.scrollTop)
 
-      await keyboard.press(KEYS.ARROW_DOWN);
-      await expect(listItems.nth(1)).toBeFocused();
+        // Remain the focus on element 3 ...
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(listItems.nth(3)).toBeFocused();
+        expect(await scrollRoot.evaluate(l => l.scrollTop)).toBe(scrollDownTop + 100);
 
-      await keyboard.press(KEYS.ARROW_DOWN);
-      await expect(listItems.nth(2)).toBeFocused();
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(listItems.nth(3)).toBeFocused();
+        expect(await scrollRoot.evaluate(l => l.scrollTop)).toBe(scrollDownTop + 200);
 
-      await keyboard.press(KEYS.ARROW_DOWN);
-      await expect(listItems.nth(3)).toBeFocused();
-      expect(await list.evaluate(l => l.scrollTop)).toBe(176);
+        // ... until its last part scroll into view
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(listItems.nth(3)).toBeFocused();
+        expect(await scrollRoot.evaluate(l => l.scrollTop)).toBe(scrollDownTop + 300);
 
-      // Remain the focus on element 3 ...
-      await keyboard.press(KEYS.ARROW_DOWN);
-      await expect(listItems.nth(3)).toBeFocused();
-      expect(await list.evaluate(l => l.scrollTop)).toBe(276);
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(listItems.nth(4)).toBeFocused();
 
-      await keyboard.press(KEYS.ARROW_DOWN);
-      await expect(listItems.nth(3)).toBeFocused();
-      expect(await list.evaluate(l => l.scrollTop)).toBe(376);
+        // No scrolling
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(listItems.nth(5)).toBeFocused();
 
-      // ... until its last part scroll into view
-      await keyboard.press(KEYS.ARROW_DOWN);
-      await expect(listItems.nth(3)).toBeFocused();
-      expect(await list.evaluate(l => l.scrollTop)).toBe(476);
+        await keyboard.press(KEYS.ARROW_DOWN);
+        await expect(listItems.nth(6)).toBeFocused();
 
-      await keyboard.press(KEYS.ARROW_DOWN);
-      await expect(listItems.nth(4)).toBeFocused();
+        // No scrolling
+        await keyboard.press(KEYS.ARROW_UP);
+        await expect(listItems.nth(5)).toBeFocused();
 
-      // No scrolling
-      await keyboard.press(KEYS.ARROW_DOWN);
-      await expect(listItems.nth(5)).toBeFocused();
-
-      await keyboard.press(KEYS.ARROW_DOWN);
-      await expect(listItems.nth(6)).toBeFocused();
-
-      // No scrolling
-      await keyboard.press(KEYS.ARROW_UP);
-      await expect(listItems.nth(5)).toBeFocused();
-
-      await keyboard.press(KEYS.ARROW_UP);
-      await expect(listItems.nth(4)).toBeFocused();
-
-      await keyboard.press(KEYS.ARROW_UP);
-      await expect(listItems.nth(3)).toBeFocused();
-
-      // Skip these steps on Webkit.
-      // When focus moves up and the item need to scroll into view. Chrome and Firefox do the shortest scroll
-      // so the element's bottom will be aligned to the bottom of the viewport, while Webkit will align the element's
-      // top to the top of the viewport.
-      // Spatial navigation used in embedded systems (eg.: TV) which using chromium based browsers. It is Ok to skip it.
-      if (test.info().project.name !== 'webkit') {
-        expect(await list.evaluate(l => l.scrollTop)).toBe(384);
+        await keyboard.press(KEYS.ARROW_UP);
+        await expect(listItems.nth(4)).toBeFocused();
 
         await keyboard.press(KEYS.ARROW_UP);
         await expect(listItems.nth(3)).toBeFocused();
-        expect(await list.evaluate(l => l.scrollTop)).toBe(284);
+
+        // Skip these steps on Webkit.
+        // When focus moves up and the item need to scroll into view. Chrome and Firefox do the shortest scroll
+        // so the element's bottom will be aligned to the bottom of the viewport, while Webkit will align the element's
+        // top to the top of the viewport.
+        // Spatial navigation used in embedded systems (eg.: TV) which using chromium based browsers. It is Ok to skip it.
+        if (test.info().project.name !== 'webkit') {
+          const scrollUpTop = await scrollRoot.evaluate(l => l.scrollTop);
+
+          await keyboard.press(KEYS.ARROW_UP);
+          await expect(listItems.nth(3)).toBeFocused();
+          expect(await scrollRoot.evaluate(l => l.scrollTop)).toBe(scrollUpTop - 100);
+
+          await keyboard.press(KEYS.ARROW_UP);
+          await expect(listItems.nth(3)).toBeFocused();
+          expect(await scrollRoot.evaluate(l => l.scrollTop)).toBe(scrollUpTop - 200);
+
+          await keyboard.press(KEYS.ARROW_UP);
+          await expect(listItems.nth(3)).toBeFocused();
+          expect(await scrollRoot.evaluate(l => l.scrollTop)).toBe(scrollUpTop - 300);
+        }
 
         await keyboard.press(KEYS.ARROW_UP);
-        await expect(listItems.nth(3)).toBeFocused();
-        expect(await list.evaluate(l => l.scrollTop)).toBe(184);
+        await expect(listItems.nth(2)).toBeFocused();
+      };
 
-        await keyboard.press(KEYS.ARROW_UP);
-        await expect(listItems.nth(3)).toBeFocused();
-        expect(await list.evaluate(l => l.scrollTop)).toBe(84);
+      await test.step('scroll root is the parent', async () => {
+        const list = await setup({ componentsPage, children: generateChildren(7), 'header-text': 'List header' });
+        await componentsPage.wrapElement({ wrapperTagName: 'mdc-spatialnavigationprovider' });
+        const { keyboard } = componentsPage.page;
 
-      }
+        const listItems = list.locator('mdc-listitem');
 
-      await keyboard.press(KEYS.ARROW_UP);
-      await expect(listItems.nth(2)).toBeFocused();
+        // change heights
+        await componentsPage.setAttributes(list, { style: 'height: 200px; overflow-y: auto' });
+        await componentsPage.setAttributes(listItems.nth(3), { style: 'height: 400px' });
+        await componentsPage.setAttributes(listItems.nth(5), { style: 'height: 400px', 'data-spatial-noscroll': '' });
+
+        await navigationSteps(keyboard, list, listItems);
+      });
+
+      await test.step('scroll is not the direct parent of the focusables', async () => {
+        const list = await setup({ componentsPage, children: generateChildren(7), 'header-text': 'List header' });
+        await componentsPage.wrapElement({ wrapperTagName: 'mdc-spatialnavigationprovider' });
+        const { keyboard } = componentsPage.page;
+
+        const listItems = list.locator('mdc-listitem');
+
+        const listParent = componentsPage.page.locator('mdc-spatialnavigationprovider > div');
+
+        // change heights
+        await componentsPage.setAttributes(listParent, { style: 'height: 200px; overflow-y: auto', id: 'scroll-root' });
+        await listItems.evaluateAll(items => {
+          items.forEach(item => {
+            item.setAttribute('data-spatial-scroll-parent', 'scroll-root');
+          });
+        });
+        await componentsPage.setAttributes(listItems.nth(3), { style: 'height: 404px' });
+        await componentsPage.setAttributes(listItems.nth(5), { style: 'height: 404px', 'data-spatial-noscroll': '' });
+
+        await navigationSteps(keyboard, listParent, listItems);
+      });
     });
   });
 

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
@@ -122,16 +122,17 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  *
  * Supported data attributes:
  *
- * | Attribute                | Value                         | Default | Description                                                                        |
- * |--------------------------|-------------------------------|---------|------------------------------------------------------------------------------------|
- * | `data-spatial-left`      | empty string /  id / selector | N/A     | Prevent native navigation in Left direction and focus element if exists            |
- * | `data-spatial-up`        | empty string /  id / selector | N/A     | Prevent native navigation in Up direction and focus element if exists              |
- * | `data-spatial-right`     | empty string /  id / selector | N/A     | Prevent native navigation in Right direction and focus element if exists           |
- * | `data-spatial-down`      | empty string /  id / selector | N/A     | Prevent native navigation in Down direction and focus element if exists            |
- * | `data-spatial-go-back`   | N/A                           | N/A     | First focusable element with this attribute is clicked on Back/Escape              |
- * | `data-spatial-focusable` | N/A                           | N/A     | Treat element as focusable even if it normally is not (e.g., `tabindex="-1"`)      |
- * | `data-spatial-exclude`   | N/A                           | N/A     | Exclude focusable element (and its subtree) from the navigation                    |
- * | `data-spatial-noscroll`  | N/A                           | N/A     | Prevent scroll for ative element in scrollable area even if the is not fit in view |
+ * | Attribute                    | Value                         | Default | Description                                                                         |
+ * |------------------------------|-------------------------------|---------|-------------------------------------------------------------------------------------|
+ * | `data-spatial-left`          | empty string /  id / selector | N/A     | Prevent native navigation in Left direction and focus element if exists             |
+ * | `data-spatial-up`            | empty string /  id / selector | N/A     | Prevent native navigation in Up direction and focus element if exists               |
+ * | `data-spatial-right`         | empty string /  id / selector | N/A     | Prevent native navigation in Right direction and focus element if exists            |
+ * | `data-spatial-down`          | empty string /  id / selector | N/A     | Prevent native navigation in Down direction and focus element if exists             |
+ * | `data-spatial-go-back`       | N/A                           | N/A     | First focusable element with this attribute is clicked on Back/Escape               |
+ * | `data-spatial-focusable`     | N/A                           | N/A     | Treat element as focusable even if it normally is not (e.g., `tabindex="-1"`)       |
+ * | `data-spatial-exclude`       | N/A                           | N/A     | Exclude focusable element (and its subtree) from the navigation                     |
+ * | `data-spatial-noscroll`      | N/A                           | N/A     | Prevent scroll for active element in scrollable area even if the is not fit in view |
+ * | `data-spatial-scroll-parent` | id                            | N/A     | Id of the closest scrollable area if it is not the parent                           |
  *
  * ## Event emitting order
  *
@@ -606,7 +607,14 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
 
     // Handle over sized elements inside scrollable area
     if (target.parentElement && !target.hasAttribute('data-spatial-noscroll')) {
-      const parent = target.parentElement as HTMLElement;
+      let parent
+      if (target.hasAttribute('data-spatial-scroll-parent')) {
+        parent = (target.getRootNode() as Document | ShadowRoot)?.getElementById(target.getAttribute('data-spatial-scroll-parent')!) as HTMLElement | null;
+      }
+      if (!parent) {
+        parent = target.parentElement as HTMLElement;
+      }
+
       const targetScrollAxis = getScrollableAxis(parent);
       if (targetScrollAxis) {
         const targetBB = target.getBoundingClientRect();


### PR DESCRIPTION

### Description

In many case the scrollable area is not the direct parent of the focusable element. For these cases the element can tell which element is the actual focusable area with the `data-spatial-scroll-parent` attribute. It accepts only IDs.

Breaking change: none