### PR TITLE
fix(spatialnavigation): modify data-spatial-scroll-parent handler

### DIFF
--- a/packages/components/src/components/list/list.e2e-test.ts
+++ b/packages/components/src/components/list/list.e2e-test.ts
@@ -480,12 +480,7 @@ test('mdc-list', async ({ componentsPage }) => {
         const listParent = componentsPage.page.locator('mdc-spatialnavigationprovider > div');
 
         // change heights
-        await componentsPage.setAttributes(listParent, { style: 'height: 200px; overflow-y: auto', id: 'scroll-root' });
-        await listItems.evaluateAll(items => {
-          items.forEach(item => {
-            item.setAttribute('data-spatial-scroll-parent', 'scroll-root');
-          });
-        });
+        await componentsPage.setAttributes(listParent, { style: 'height: 200px; overflow-y: auto', id: 'scroll-root', 'data-spatial-scroll-parent': '' });
         await componentsPage.setAttributes(listItems.nth(3), { style: 'height: 404px' });
         await componentsPage.setAttributes(listItems.nth(5), { style: 'height: 404px', 'data-spatial-noscroll': '' });
 

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
@@ -122,17 +122,17 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  *
  * Supported data attributes:
  *
- * | Attribute                    | Value                         | Default | Description                                                                         |
- * |------------------------------|-------------------------------|---------|-------------------------------------------------------------------------------------|
- * | `data-spatial-left`          | empty string /  id / selector | N/A     | Prevent native navigation in Left direction and focus element if exists             |
- * | `data-spatial-up`            | empty string /  id / selector | N/A     | Prevent native navigation in Up direction and focus element if exists               |
- * | `data-spatial-right`         | empty string /  id / selector | N/A     | Prevent native navigation in Right direction and focus element if exists            |
- * | `data-spatial-down`          | empty string /  id / selector | N/A     | Prevent native navigation in Down direction and focus element if exists             |
- * | `data-spatial-go-back`       | N/A                           | N/A     | First focusable element with this attribute is clicked on Back/Escape               |
- * | `data-spatial-focusable`     | N/A                           | N/A     | Treat element as focusable even if it normally is not (e.g., `tabindex="-1"`)       |
- * | `data-spatial-exclude`       | N/A                           | N/A     | Exclude focusable element (and its subtree) from the navigation                     |
- * | `data-spatial-noscroll`      | N/A                           | N/A     | Prevent scroll for active element in scrollable area even if the is not fit in view |
- * | `data-spatial-scroll-parent` | id                            | N/A     | Id of the closest scrollable area if it is not the parent                           |
+ * | Attribute                    | Value                         | Default | Description                                                                                                             |
+ * |------------------------------|-------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------|
+ * | `data-spatial-left`          | empty string /  id / selector | N/A     | Prevent native navigation in Left direction and focus element if exists                                                 |
+ * | `data-spatial-up`            | empty string /  id / selector | N/A     | Prevent native navigation in Up direction and focus element if exists                                                   |
+ * | `data-spatial-right`         | empty string /  id / selector | N/A     | Prevent native navigation in Right direction and focus element if exists                                                |
+ * | `data-spatial-down`          | empty string /  id / selector | N/A     | Prevent native navigation in Down direction and focus element if exists                                                 |
+ * | `data-spatial-go-back`       | N/A                           | N/A     | First focusable element with this attribute is clicked on Back/Escape                                                   |
+ * | `data-spatial-focusable`     | N/A                           | N/A     | Treat element as focusable even if it normally is not (e.g., `tabindex="-1"`)                                           |
+ * | `data-spatial-exclude`       | N/A                           | N/A     | Exclude focusable element (and its subtree) from the navigation                                                         |
+ * | `data-spatial-noscroll`      | N/A                           | N/A     | Prevent scroll for active element in scrollable area even if the is not fit in view                                     |
+ * | `data-spatial-scroll-parent` | N/A                           | N/A     | When the focusable item in not a direct child of the scrollable aria use this attribute to mark scrollable area element |                           |
  *
  * ## Event emitting order
  *
@@ -607,13 +607,7 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
 
     // Handle over sized elements inside scrollable area
     if (target.parentElement && !target.hasAttribute('data-spatial-noscroll')) {
-      let parent
-      if (target.hasAttribute('data-spatial-scroll-parent')) {
-        parent = (target.getRootNode() as Document | ShadowRoot)?.getElementById(target.getAttribute('data-spatial-scroll-parent')!) as HTMLElement | null;
-      }
-      if (!parent) {
-        parent = target.parentElement as HTMLElement;
-      }
+      const parent = target.closest('[data-spatial-scroll-parent]') ?? target.parentElement;
 
       const targetScrollAxis = getScrollableAxis(parent);
       if (targetScrollAxis) {

--- a/packages/components/src/utils/dom.ts
+++ b/packages/components/src/utils/dom.ts
@@ -79,7 +79,7 @@ export const hasZeroDimensions = (element: HTMLElement) => {
  * @param element - The element to check.
  * @returns True if the element is scrollable.
  */
-export const getScrollableAxis = (element: HTMLElement): null | 'horizontal' | 'vertical' | 'both' => {
+export const getScrollableAxis = (element: Element | null): null | 'horizontal' | 'vertical' | 'both' => {
   if (!(element instanceof Element)) return null;
   const computedStyle = getComputedStyle(element);
   const { overflowX, overflowY } = computedStyle;


### PR DESCRIPTION
### Description

Instead of flag each focusable inside the scroll area with `data-spatial-scroll-parent` attribute, it is used for mark the actul scroll area if it is not the parent.

Breaking change: none