### PR TITLE
fix(spatialnavigation): handle scroll to out of view items

### DIFF
--- a/packages/components/src/components/menupopover/menupopover.stories.ts
+++ b/packages/components/src/components/menupopover/menupopover.stories.ts
@@ -516,8 +516,7 @@ export const DynamicMenu: StoryObj = {
 };
 
 export const MenuXYZ: StoryObj = {
-  render: () => {
-    return html`
+  render: () => html`
           <div id="menupopover-test-wrapper">
             <mdc-button id="trigger-btn">Options</mdc-button>
             <mdc-menupopover triggerid="trigger-btn">
@@ -528,5 +527,4 @@ export const MenuXYZ: StoryObj = {
             </mdc-menupopover>
           </div>
         `
-  }
 }

--- a/packages/components/src/components/menupopover/menupopover.stories.ts
+++ b/packages/components/src/components/menupopover/menupopover.stories.ts
@@ -514,3 +514,19 @@ export const DynamicMenu: StoryObj = {
       </mdc-menupopover>`;
   },
 };
+
+export const MenuXYZ: StoryObj = {
+  render: () => {
+    return html`
+          <div id="menupopover-test-wrapper">
+            <mdc-button id="trigger-btn">Options</mdc-button>
+            <mdc-menupopover triggerid="trigger-btn">
+              <mdc-menuitem id="menu-item-1" data-spatial-up="" data-spatial-down="menu-item-3"  label="Profile"></mdc-menuitem>
+              <mdc-menuitem id="menu-item-2" label="Settings"></mdc-menuitem>
+              <mdc-menuitem id="menu-item-3" label="Notifications"></mdc-menuitem>
+              <mdc-menuitem id="menu-item-4" data-spatial-up="menu-item-1" label="Logout"></mdc-menuitem>
+            </mdc-menupopover>
+          </div>
+        `
+  }
+}

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
@@ -537,12 +537,14 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
         const nextElement = root?.getElementById(nextElementSelector) ?? root?.querySelector(nextElementSelector);
         
         if (nextElement){
-          if (focusableElements.includes(nextElement)) {
+          const isNextElementInFocusables = focusableElements.includes(nextElement)
+
+          focusableElements = focusableElements.filter(el => nextElement.contains(el) && el);
+          if (isNextElementInFocusables || focusableElements.length <= 1) {
             // Use nextElement if it focusable
             return nextElement;
-          } 
-          // Search focusable inside nextElements sub-tree
-          focusableElements = focusableElements.filter(el => nextElement.contains(el));
+          }
+          // Else, fall back to the distance based navigation but search within the targeted element subtree only.
         }
       }
     }
@@ -635,7 +637,7 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
 
     // Handle over sized elements inside scrollable area
     if (target.parentElement && !target.hasAttribute(DATA_ATTRIBUTES.NO_SCROLL)) {
-      const parent = target.closest(`[${DATA_ATTRIBUTES.SCROLL_PARENT}}]`) ?? target.parentElement;
+      const parent = target.closest(`[${DATA_ATTRIBUTES.SCROLL_PARENT}]`) ?? target.parentElement;
 
       const targetScrollAxis = getScrollableAxis(parent);
       if (targetScrollAxis) {

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
@@ -1,15 +1,7 @@
 import { property } from 'lit/decorators.js';
 
 import { Provider } from '../../models';
-import {
-  findFocusable,
-  getDomActiveElement,
-  getHostComposePath,
-  getScrollableAxis,
-  hasNoClientRects,
-  isInteractiveElement,
-  isTabbable,
-} from '../../utils/dom';
+import { findFocusable, getDomActiveElement, getHostComposePath, getScrollableAxis } from '../../utils/dom';
 import { FocusTrapStack } from '../../utils/mixins/focus/FocusTrapStack';
 
 import SpatialNavigationProviderContext from './spatialnavigationprovider.context';
@@ -426,21 +418,8 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
         focusableElements.push(
           ...findFocusable(el, {
             excludedElements: checkedFocusArea ? [checkedFocusArea] : undefined,
-            includeSelectors: [`[${DATA_ATTRIBUTES.FOCUSABLE}]`],
-            excludeSelectors: [`[${DATA_ATTRIBUTES.EXCLUDE}]`],
-            customFocusableCheck: (el, result) => {
-              // Handle elements that are hidden because they are not in the viewpoint of a scrollbar
-              if (
-                result === 'stop' &&
-                hasNoClientRects(el) &&
-                isInteractiveElement(el) &&
-                isTabbable(el) &&
-                el.closest(`[${DATA_ATTRIBUTES.SCROLL_PARENT}]`)
-              ) {
-                return 'focusable';
-              }
-              return result;
-            }
+            includeSelectors: ['[data-spatial-focusable]'],
+            excludeSelectors: ['[data-spatial-exclude]'],
           }),
         );
         const result = this.focusNextInFocusableAria(focusableElements, direction);
@@ -503,7 +482,7 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
   private focusNextInFocusableAria(elements: HTMLElement[], direction: Direction): HTMLElement | undefined {
     let currentActiveElement = this.getActiveElement();
     const currentDomActiveElement = getDomActiveElement() as HTMLElement | null;
-    let focusableElements = elements
+    let focusableElements = elements;
 
     // Sync current active element if necessary
     // It can be out of sync when:
@@ -533,11 +512,11 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
       const nextElementSelector = elementWithDataset?.getAttribute(dataAttrName);
 
       if (elementWithDataset && nextElementSelector) {
-        const root = (elementWithDataset.getRootNode() as Document | ShadowRoot)
+        const root = elementWithDataset.getRootNode() as Document | ShadowRoot;
         const nextElement = root?.getElementById(nextElementSelector) ?? root?.querySelector(nextElementSelector);
-        
-        if (nextElement){
-          const isNextElementInFocusables = focusableElements.includes(nextElement)
+
+        if (nextElement) {
+          const isNextElementInFocusables = focusableElements.includes(nextElement);
 
           focusableElements = focusableElements.filter(el => nextElement.contains(el) && el);
           if (isNextElementInFocusables || focusableElements.length <= 1) {
@@ -560,7 +539,12 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
     }
 
     // Find the closest element in the given direction
-    const results = orderElementsByDistance(currentActiveElement, focusableElements, direction, this.distanceCalculationWeights);
+    const results = orderElementsByDistance(
+      currentActiveElement,
+      focusableElements,
+      direction,
+      this.distanceCalculationWeights,
+    );
     return results[0]?.candidate;
   }
 

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
@@ -418,8 +418,8 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
         focusableElements.push(
           ...findFocusable(el, {
             excludedElements: checkedFocusArea ? [checkedFocusArea] : undefined,
-            includeSelectors: ['[data-spatial-focusable]'],
-            excludeSelectors: ['[data-spatial-exclude]'],
+            includeSelectors: [`[${DATA_ATTRIBUTES.FOCUSABLE}]`],
+            excludeSelectors: [`[${DATA_ATTRIBUTES.EXCLUDE}]`],
           }),
         );
         const result = this.focusNextInFocusableAria(focusableElements, direction);

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
@@ -1,7 +1,15 @@
 import { property } from 'lit/decorators.js';
 
 import { Provider } from '../../models';
-import { findFocusable, getDomActiveElement, getHostComposePath, getScrollableAxis } from '../../utils/dom';
+import {
+  findFocusable,
+  getDomActiveElement,
+  getHostComposePath,
+  getScrollableAxis,
+  hasNoClientRects,
+  isInteractiveElement,
+  isTabbable,
+} from '../../utils/dom';
 import { FocusTrapStack } from '../../utils/mixins/focus/FocusTrapStack';
 
 import SpatialNavigationProviderContext from './spatialnavigationprovider.context';
@@ -12,7 +20,7 @@ import {
   SpatialNavigationActionToKeyMap,
   SpatialNavigationKeyToActionMap,
 } from './spatialnavigationprovider.types';
-import { DEFAULTS } from './spatialnavigationprovider.constants';
+import { DATA_ATTRIBUTES, DEFAULTS } from './spatialnavigationprovider.constants';
 import { orderElementsByDistance } from './spatialnavigationprovider.utils';
 import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
 
@@ -32,30 +40,30 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  *
  * ### Steps
  *
- * Spatial navigation goes trough the following steps after each keydown:
+ * Spatial navigation goes through the following steps after each keydown:
  *
  * 1. Handle `keydown` in the capture phase.
- *    - When active element has `data-spatial-{direction}` attribute then prevent all component navigation and call the
- *      provider own `keydown` handler (see step 3).
- *    - When active element's parent is scrollable and it is not fully visible in the given direction and it does not
- *      have `data-spatial-noscroll` attribute, prevent all navigation and scroll in the give direction half size of the
+ *    - When the active element has a `data-spatial-{direction}` attribute, then prevent all component navigation and call the
+ *      provider's own `keydown` handler (see step 3).
+ *    - When the active element's parent is scrollable and it is not fully visible in the given direction, and it does not
+ *      have a `data-spatial-noscroll` attribute, prevent all navigation and scroll in the given direction half-size of the
  *      scroll view.
  * 2. Component own `keydown` handler executed (bubble phase) (e.g., list moves focus internally) it it was not
  *    prevented.
  * 3. Spatial Navigation Provider's `keydown` handler executed (bubble phase)
- *    - If key event was not prevented in step 1. emit `navbeforeprocess` to check if any component want to handle
+ *    - If a key event was not prevented in step 1. emit `navbeforeprocess` to check if any component want to handle
  *      the key event itself. If `navbeforeprocess` event is prevented, stop here.
- *    - If the component did not handle `keydown`, it calculate the next focusable item
- *      - if the active element has `data-spatial-{direction}` attribute, it will try to focus the element with the id.
+ *    - If the component did not handle `keydown`, it calculates the next focusable item
+ *      - if the active element has a `data-spatial-{direction}` attribute, it will try to focus the element with the id.
  *      - Otherwise calculate the next focused item based on the direction and distances.
  *    - If there is no next item, it emits `navnotarget` event
  *    - Otherwise emit `navbeforefocus`,
- *      - If this event prevented, nothing happens
+ *      - If this event is prevented, nothing happens
  *      - Otherwise the focus moves to the next element
  *
  * ### Determine next focus
  *
- * The provider use multiple ways to determine the next focused element. The order defined in the "Steps" section.
+ * The provider uses multiple ways to determine the next focused element. The order defined in the "Steps" section.
  *
  * #### Calculated focus
  *
@@ -66,9 +74,9 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  * 3. Compute distances from the current element to candidates using the W3C "find the shortest
  *    distance" algorithm: https://www.w3.org/TR/css-nav-1/#find-the-shortest-distance
  * 4. If no candidates are found, repeat from step 1, skipping areas already checked.
- * 5. Focus the closest candidate.
+ * 5. Focus on the closest candidate.
  *
- * Elements with `data-spatial-focusable` are treated as focusable even if they would otherwise not be
+ * Elements with `data-spatial-focusable` are treated as focusable even if they do otherwise not be
  * (e.g., `tabindex="-1"`).
  *
  * Elements with `data-spatial-exclude` are excluded (with its subtree) from the navigation, even if they
@@ -79,7 +87,7 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  * make navigation unpredictable. This is less of an issue on fixed-size TV UIs but can show unexpected
  * behavior in Storybook when resizing. See the "Limitations" section.
  *
- * #### Overwrite next element
+ * #### Overwrite the next element
  *
  * Override calculated navigation by adding one of these attributes to a focusable element:
  *
@@ -122,17 +130,17 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  *
  * Supported data attributes:
  *
- * | Attribute                    | Value                         | Default | Description                                                                                                             |
- * |------------------------------|-------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------|
- * | `data-spatial-left`          | empty string /  id / selector | N/A     | Prevent native navigation in Left direction and focus element if exists                                                 |
- * | `data-spatial-up`            | empty string /  id / selector | N/A     | Prevent native navigation in Up direction and focus element if exists                                                   |
- * | `data-spatial-right`         | empty string /  id / selector | N/A     | Prevent native navigation in Right direction and focus element if exists                                                |
- * | `data-spatial-down`          | empty string /  id / selector | N/A     | Prevent native navigation in Down direction and focus element if exists                                                 |
- * | `data-spatial-go-back`       | N/A                           | N/A     | First focusable element with this attribute is clicked on Back/Escape                                                   |
- * | `data-spatial-focusable`     | N/A                           | N/A     | Treat element as focusable even if it normally is not (e.g., `tabindex="-1"`)                                           |
- * | `data-spatial-exclude`       | N/A                           | N/A     | Exclude focusable element (and its subtree) from the navigation                                                         |
- * | `data-spatial-noscroll`      | N/A                           | N/A     | Prevent scroll for active element in scrollable area even if the is not fit in view                                     |
- * | `data-spatial-scroll-parent` | N/A                           | N/A     | When the focusable item in not a direct child of the scrollable aria use this attribute to mark scrollable area element |                           |
+ * | Attribute                    | Value                         | Default | Description                                                                                                                        |
+ * |------------------------------|-------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------|
+ * | `data-spatial-left`          | empty string /  id / selector | N/A     | Prevent native navigation in the Left direction, focus it if it's focusable otherwise limit the search in the selected container.  |
+ * | `data-spatial-up`            | empty string /  id / selector | N/A     | Prevent native navigation in Up direction, focus it if it's focusable otherwise limit the search in the selected container.        |
+ * | `data-spatial-right`         | empty string /  id / selector | N/A     | Prevent native navigation in the Right direction, focus it if it's focusable otherwise limit the search in the selected container. |
+ * | `data-spatial-down`          | empty string /  id / selector | N/A     | Prevent native navigation in Down direction, focus it if it's focusable otherwise limit the search in the selected container.      |
+ * | `data-spatial-go-back`       | N/A                           | N/A     | First focusable element with this attribute is clicked on Back/Escape                                                              |
+ * | `data-spatial-focusable`     | N/A                           | N/A     | Treat element as focusable even if it normally is not (e.g., `tabindex="-1"`)                                                      |
+ * | `data-spatial-exclude`       | N/A                           | N/A     | Exclude focusable element (and its subtree) from the navigation                                                                    |
+ * | `data-spatial-noscroll`      | N/A                           | N/A     | Prevent scroll for active element in scrollable area even if the is not fit in view                                                |
+ * | `data-spatial-scroll-parent` | N/A                           | N/A     | When the focusable item in not a direct child of the scrollable aria use this attribute to mark scrollable area element            |
  *
  * ## Event emitting order
  *
@@ -171,7 +179,7 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  *
  * ## Platform specific behaviors
  *
- * Consider remote/gamepad constraints. Often focus alone is not enough and users press Enter to "enter" an interactive mode:
+ * Consider remote/gamepad constraints. Often focus alone is not enough, and users press Enter to "enter" an interactive mode:
  * - Select: Enter opens options rather than arrow keys opening a popover.
  * - Text inputs: see the next section.
  * - Slider: Enter to start adjusting, arrow keys to change value, Enter/Escape to stop.
@@ -199,7 +207,7 @@ import { SpatialNavigationEvent } from './spatialnavigationprovider.events';
  * - Escape - Escape
  *
  * With wrapper: wraps the component in a 3x3 grid with surrounding buttons for testing.
- * Without wrapper: renders the component alone.
+ * Without a wrapper: renders the component alone.
  *
  * ### Visual debugger
  *
@@ -418,8 +426,21 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
         focusableElements.push(
           ...findFocusable(el, {
             excludedElements: checkedFocusArea ? [checkedFocusArea] : undefined,
-            includeSelectors: ['[data-spatial-focusable]'],
-            excludeSelectors: ['[data-spatial-exclude]'],
+            includeSelectors: [`[${DATA_ATTRIBUTES.FOCUSABLE}]`],
+            excludeSelectors: [`[${DATA_ATTRIBUTES.EXCLUDE}]`],
+            customFocusableCheck: (el, result) => {
+              // Handle elements that are hidden because they are not in the viewpoint of a scrollbar
+              if (
+                result === 'stop' &&
+                hasNoClientRects(el) &&
+                isInteractiveElement(el) &&
+                isTabbable(el) &&
+                el.closest(`[${DATA_ATTRIBUTES.SCROLL_PARENT}]`)
+              ) {
+                return 'focusable';
+              }
+              return result;
+            }
           }),
         );
         const result = this.focusNextInFocusableAria(focusableElements, direction);
@@ -482,6 +503,7 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
   private focusNextInFocusableAria(elements: HTMLElement[], direction: Direction): HTMLElement | undefined {
     let currentActiveElement = this.getActiveElement();
     const currentDomActiveElement = getDomActiveElement() as HTMLElement | null;
+    let focusableElements = elements
 
     // Sync current active element if necessary
     // It can be out of sync when:
@@ -489,13 +511,13 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
     // - focus fallback to body or other non-focusable element
     if (
       !currentActiveElement ||
-      !elements.includes(currentActiveElement) ||
+      !focusableElements.includes(currentActiveElement) ||
       currentActiveElement !== currentDomActiveElement
     ) {
-      if (currentDomActiveElement && elements.includes(currentDomActiveElement)) {
+      if (currentDomActiveElement && focusableElements.includes(currentDomActiveElement)) {
         currentActiveElement = currentDomActiveElement;
       } else {
-        [currentActiveElement] = elements;
+        [currentActiveElement] = focusableElements;
       }
       this.setActiveElement(currentActiveElement);
     }
@@ -513,8 +535,14 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
       if (elementWithDataset && nextElementSelector) {
         const root = (elementWithDataset.getRootNode() as Document | ShadowRoot)
         const nextElement = root?.getElementById(nextElementSelector) ?? root?.querySelector(nextElementSelector);
-        if (nextElement) {
-          return nextElement;
+        
+        if (nextElement){
+          if (focusableElements.includes(nextElement)) {
+            // Use nextElement if it focusable
+            return nextElement;
+          } 
+          // Search focusable inside nextElements sub-tree
+          focusableElements = focusableElements.filter(el => nextElement.contains(el));
         }
       }
     }
@@ -530,7 +558,7 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
     }
 
     // Find the closest element in the given direction
-    const results = orderElementsByDistance(currentActiveElement, elements, direction, this.distanceCalculationWeights);
+    const results = orderElementsByDistance(currentActiveElement, focusableElements, direction, this.distanceCalculationWeights);
     return results[0]?.candidate;
   }
 
@@ -550,7 +578,7 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
   /**
    * Set the active element.
    *
-   * Also, setup MutationObserver to track the element removal from the DOM.
+   * Also, set up MutationObserver to track the element removal from the DOM.
    *
    * @param element - New active element
    * @internal
@@ -606,8 +634,8 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
     }
 
     // Handle over sized elements inside scrollable area
-    if (target.parentElement && !target.hasAttribute('data-spatial-noscroll')) {
-      const parent = target.closest('[data-spatial-scroll-parent]') ?? target.parentElement;
+    if (target.parentElement && !target.hasAttribute(DATA_ATTRIBUTES.NO_SCROLL)) {
+      const parent = target.closest(`[${DATA_ATTRIBUTES.SCROLL_PARENT}}]`) ?? target.parentElement;
 
       const targetScrollAxis = getScrollableAxis(parent);
       if (targetScrollAxis) {
@@ -620,7 +648,11 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
             parent.scrollTo({ top: parent.scrollTop - parentBB.height / 2, behavior: 'auto' });
             eventHandled = true;
           }
-          if (action === 'down' && targetBB.bottom > parentBB.bottom && (parent.scrollTop + parentBB.height) < parent.scrollHeight) {
+          if (
+            action === 'down' &&
+            targetBB.bottom > parentBB.bottom &&
+            parent.scrollTop + parentBB.height < parent.scrollHeight
+          ) {
             parent.scrollTo({ top: parent.scrollTop + parentBB.height / 2, behavior: 'auto' });
             eventHandled = true;
           }
@@ -628,12 +660,16 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
 
         // horizontal scrolling
         if (targetScrollAxis === 'horizontal' || targetScrollAxis === 'both') {
-          if (action === 'right' && targetBB.left < parentBB.left &&parent.scrollLeft > 0) {
+          if (action === 'right' && targetBB.left < parentBB.left && parent.scrollLeft > 0) {
             parent.scrollTo({ left: parent.scrollLeft - parentBB.width / 2, behavior: 'auto' });
             eventHandled = true;
           }
 
-          if (action === 'left' && targetBB.right > parentBB.right && (parent.scrollLeft + parentBB.width) < parent.scrollWidth) {
+          if (
+            action === 'left' &&
+            targetBB.right > parentBB.right &&
+            parent.scrollLeft + parentBB.width < parent.scrollWidth
+          ) {
             parent.scrollTo({ left: parent.scrollLeft + parentBB.width / 2, behavior: 'auto' });
             eventHandled = true;
           }
@@ -753,13 +789,12 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
   /**
    * Handle back action
    *
-   * Either trigger click on goBack element if any
-   * otherwise call default go back handler
+   * Either trigger click on the goBack element if any otherwise call the default go back handler
    *
    * @returns true when go back handled, false otherwise
    */
   public goBack(): boolean {
-    const goBackElement = findFocusable(this.root).find(el => el.hasAttribute('data-spatial-go-back'));
+    const goBackElement = findFocusable(this.root).find(el => el.hasAttribute(DATA_ATTRIBUTES.GO_BACK));
     const isDefaultPrevented = this.emitGoBackEvent(goBackElement);
 
     if (goBackElement && !isDefaultPrevented) {

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.constants.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.constants.ts
@@ -6,6 +6,18 @@ export const TAG_NAME = utils.constructTagName('spatialnavigationprovider');
 
 export const SPATIAL_NAVIGATION_DIRECTION_KEYS = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
 
+export const DATA_ATTRIBUTES = {
+  DIRECTION_LEFT: 'data-spatial-left',
+  DIRECTION_RIGHT: 'data-spatial-right',
+  DIRECTION_UP: 'data-spatial-up',
+  DIRECTION_DOWN: 'data-spatial-down',
+  GO_BACK: 'data-spatial-go-back',
+  FOCUSABLE: 'data-spatial-focusable',
+  EXCLUDE: 'data-spatial-exclude',
+  NO_SCROLL: 'data-spatial-noscroll',
+  SCROLL_PARENT: 'data-spatial-scroll-parent',
+};
+
 export const DEFAULTS = {
   SPATIAL_NAVIGATION_KEY_MAPPING: {
     left: 'ArrowLeft',

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.e2e-test.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.e2e-test.ts
@@ -15,25 +15,37 @@ const setup = async (args: SetupOptions) => {
 
   await componentsPage.mount({
     html: ` 
-      <div>
+      <div style="height: 100%">
         <style>
-          .button-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            grid-template-rows: repeat(3, 1fr);
+          .button-grid, .group {
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+            height: 100%;
+            align-items: center;
+            justify-content: space-around;
+          }
+          .group {
+            flex-direction: row;
           }
         </style>
         <mdc-spatialnavigationprovider id="snp-provider">
           <div class="button-grid">
-            <mdc-button id="btn-1">button 1</mdc-button>
-            <mdc-button id="btn-2">button 2</mdc-button>
-            <mdc-button id="btn-3">button 3</mdc-button>
-            <mdc-button id="btn-4">button 4</mdc-button>
-            <mdc-button id="btn-5">button 5</mdc-button>
-            <mdc-button id="btn-6">button 6</mdc-button>
-            <mdc-button id="btn-7">button 7</mdc-button>
-            <mdc-button id="btn-8">button 8</mdc-button>
-            <mdc-button id="btn-9">button 9</mdc-button>
+            <div class="group" id="group-1">
+              <mdc-button id="btn-1">button 1</mdc-button>
+              <mdc-button id="btn-2">button 2</mdc-button>
+              <mdc-button id="btn-3">button 3</mdc-button>
+            </div>
+            <div class="group" id="group-2">
+              <mdc-button id="btn-4">button 4</mdc-button>
+              <mdc-button id="btn-5">button 5</mdc-button>
+              <mdc-button id="btn-6">button 6</mdc-button>
+            </div>
+            <div class="group" id="group-3">
+              <mdc-button id="btn-7">button 7</mdc-button>
+              <mdc-button id="btn-8">button 8</mdc-button>
+              <mdc-button id="btn-9">button 9</mdc-button>
+            </div>
           </div>
         </mdc-spatialnavigationprovider
       </div>
@@ -410,7 +422,6 @@ test('mdc-spatialnavigationprovider', async ({ componentsPage }) => {
       await expect(locators.btn7).toBeFocused();
     });
 
-
     await test.step('data-spatial-{direction}', async () => {
       await test.step('it does nothing when it has no value', async () => {
         // AI-Assisted
@@ -475,6 +486,28 @@ test('mdc-spatialnavigationprovider', async ({ componentsPage }) => {
         await expect(locators.btn8).toBeFocused();
         // End AI-Assisted
       });
-    })
+
+      await test.step('when a group targeted an item in the group will be focused', async () => {
+        // AI-Assisted
+        const locators = await setup({ componentsPage });
+        const { keyboard } = componentsPage.page;
+
+        // Set data-spatial-right to a group container (group-3) on btn1
+        await componentsPage.setAttributes(locators.btn1, {
+          'data-spatial-right': 'group-3',
+        });
+        await componentsPage.page.pause()
+
+        // Move to btn1 first
+        await keyboard.press('ArrowDown');
+        await expect(locators.btn1).toBeFocused();
+
+        // Focus should land on the second item of group 3 because
+        // we target group-3 and btn8 is to the right from btn-1
+        await keyboard.press('ArrowRight');
+        await expect(locators.btn8).toBeFocused();
+        // End AI-Assisted
+      });
+    });
   });
 });

--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.utils.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.utils.ts
@@ -5,6 +5,7 @@ import type {
   ElementDistance,
   ShortestDistanceWeights,
 } from './spatialnavigationprovider.types';
+import { DATA_ATTRIBUTES } from './spatialnavigationprovider.constants';
 
 /**
  * Calculate the center point of the element
@@ -113,7 +114,14 @@ export const orderElementsByDistance = (
       // Skip the active element
       if (candidate === activeElement) return acc;
 
-      const cr = getElementRectWithMidPoint(candidate);
+      const scrollParent = candidate.closest(`[${DATA_ATTRIBUTES.SCROLL_PARENT}]`) as HTMLElement | null;
+
+      // Focusable inside scrollable container can be out of viewport and/or too small to pick up autofocus,
+      // so we measure the scroll parent instead.
+      const measuredElement = scrollParent && !scrollParent.contains(activeElement) ? scrollParent : candidate;
+
+      const cr = getElementRectWithMidPoint(measuredElement);
+
       // Filter out elements that are not in the navigation direction
       if (direction === 'left' && cr.right > reference.xMid) return acc;
       if (direction === 'right' && cr.left < reference.xMid) return acc;

--- a/packages/components/src/utils/dom.ts
+++ b/packages/components/src/utils/dom.ts
@@ -8,8 +8,6 @@ type FindFocusableCommands = 'focusable' | 'continue' | 'stop';
  * Options for finding focusable elements.
  */
 type FindFocusableOptions = {
-  /** Elements to include (and its subtree) in the search. */
-  includeElements?: HTMLElement[];
   /** Elements to exclude (and its subtree) from the search. */
   excludedElements?: HTMLElement[];
   /** Selectors to include in the search. */
@@ -240,7 +238,7 @@ export const findFocusable = (
   const includeSelectors = options?.includeSelectors ?? [];
   const excludeSelectors = options?.excludeSelectors ?? [];
   const stopAtNonTabbable = options?.stopAtNonTabbable ?? false;
-  const matches = new Set<HTMLElement>(options.includeElements ?? []);
+  const matches = new Set<HTMLElement>([]);
 
   const internalFocusableCheck = (element: HTMLElement) => {
     // Excluded

--- a/packages/components/src/utils/dom.ts
+++ b/packages/components/src/utils/dom.ts
@@ -2,6 +2,8 @@
 
 import type { OverflowMixinInterface } from './mixins/OverflowMixin';
 
+type FindFocusableCommands = 'focusable' | 'continue' | 'stop';
+
 /**
  * Options for finding focusable elements.
  */
@@ -20,6 +22,14 @@ type FindFocusableOptions = {
    * inactive items and their children should not be reachable via Tab navigation.
    */
   stopAtNonTabbable?: boolean;
+  /**
+   * When it is provided, it is executed after the default checked run.
+   * I get the result from the default checked run and can modify it.
+   *
+   * @param element - The element to check.
+   * @param result - The result of the default checked run.
+   */
+  customFocusableCheck?: (element: HTMLElement, result: FindFocusableCommands) => FindFocusableCommands;
 };
 
 /**
@@ -84,7 +94,7 @@ export const getScrollableAxis = (element: Element | null): null | 'horizontal' 
   const computedStyle = getComputedStyle(element);
   const { overflowX, overflowY } = computedStyle;
 
-  const horizontal = overflowX === 'auto' || overflowX === 'scroll'
+  const horizontal = overflowX === 'auto' || overflowX === 'scroll';
   const vertical = overflowY === 'auto' || overflowY === 'scroll';
 
   if (horizontal && vertical) return 'both';
@@ -232,13 +242,13 @@ export const findFocusable = (
   const stopAtNonTabbable = options?.stopAtNonTabbable ?? false;
   const matches = new Set<HTMLElement>(options.includeElements ?? []);
 
-  const focusableCheck = (element: HTMLElement) => {
-    if (
-      !(element instanceof HTMLSlotElement) &&
-      (isHidden(element) || isDisabled(element) || isMatchAny(element, excludeSelectors))
-    ) {
-      return 'stop';
-    }
+  const internalFocusableCheck = (element: HTMLElement) => {
+    // Excluded
+    if (excludesSet.has(root as HTMLElement) || isMatchAny(element, excludeSelectors)) return 'stop';
+
+    // Unreachable
+    if (isHidden(element) || isDisabled(element)) return 'stop';
+
     if (stopAtNonTabbable && !(element instanceof HTMLSlotElement) && element.getAttribute('tabindex') === '-1') {
       // AI-Assisted
       // Do not stop traversal for elements inside a shadow root with delegatesFocus: true.
@@ -250,56 +260,40 @@ export const findFocusable = (
       }
       // End AI-Assisted
     }
+
     return isMatchAny(element, includeSelectors) || (isTabbable(element) && isInteractiveElement(element))
       ? 'focusable'
       : 'continue';
   };
 
-  const finder = (root: ShadowRoot | HTMLElement) => {
-    if (excludesSet.has(root as HTMLElement) || (root instanceof HTMLElement && isMatchAny(root, excludeSelectors))) {
-      return;
-    }
-    if (root instanceof HTMLElement && focusableCheck(root) === 'focusable') {
-      matches.add(root);
-    }
+  const focusableCheck = options.customFocusableCheck
+    ? (el: HTMLElement) => options.customFocusableCheck!(el, internalFocusableCheck(el))
+    : internalFocusableCheck;
 
-    let children: HTMLElement[] = [];
-    if (root instanceof HTMLElement && root.shadowRoot) {
-      children = Array.from(root.shadowRoot.children) as HTMLElement[];
-    } else if (root.children.length) {
-      children = Array.from(root.children) as HTMLElement[];
-    }
-
-    children.forEach((child: Node) => {
-      const element = child as HTMLElement;
-      const isFocusableResult = focusableCheck(element);
+  const finder = (root: ShadowRoot | Element) => {
+    if (root instanceof HTMLElement) {
+      const isFocusableResult = focusableCheck(root);
 
       if (isFocusableResult === 'focusable') {
-        matches.add(element);
+        matches.add(root);
       }
 
       if (isFocusableResult === 'stop') {
         return;
       }
+    }
 
-      if (element.shadowRoot) {
-        finder(element.shadowRoot);
-      } else if (element.tagName === 'SLOT') {
-        const assignedNodes = (element as HTMLSlotElement).assignedElements({ flatten: true });
-        assignedNodes.forEach(node => {
-          if (node instanceof HTMLElement) {
-            // When stopAtNonTabbable is enabled, skip non-tabbable slotted elements and their
-            // subtrees to support composite widget patterns (e.g., roving tabindex in lists)
-            if (stopAtNonTabbable && !(node instanceof HTMLSlotElement) && node.getAttribute('tabindex') === '-1') {
-              return;
-            }
-            finder(node);
-          }
-        });
-      } else {
-        finder(element);
-      }
-    });
+    let children: Element[] = [];
+
+    if (root instanceof HTMLSlotElement) {
+      children = root.assignedElements({ flatten: true });
+    } else if (root instanceof HTMLElement && root.shadowRoot) {
+      children = Array.from(root.shadowRoot.children);
+    } else if (root.children.length) {
+      children = Array.from(root.children);
+    }
+
+    children.forEach(finder);
   };
 
   finder(root);


### PR DESCRIPTION
### Description

- when in focusable item scrolled out of view, SNP uses the scroll area 
  as reference for the distance calculation
- data-spatial-{direction} can point to container elements to narrow the
  search for the next focusable element 

Breaking change: none