### PR TITLE
fix(spatialnavigation): data-spatial-{dir} move focus into an sub-tree

### DIFF
--- a/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
+++ b/packages/components/src/components/spatialnavigationprovider/spatialnavigationprovider.component.ts
@@ -516,10 +516,14 @@ class SpatialNavigationProvider extends Provider<SpatialNavigationContextValue> 
         const nextElement = root?.getElementById(nextElementSelector) ?? root?.querySelector(nextElementSelector);
 
         if (nextElement) {
-          const isNextElementInFocusables = focusableElements.includes(nextElement);
+          const focusableAroundNextElement = findFocusable(nextElement.parentElement, {
+            includeSelectors: [`[${DATA_ATTRIBUTES.FOCUSABLE}]`],
+            excludeSelectors: [`[${DATA_ATTRIBUTES.EXCLUDE}]`],
+          })
+          const isNextElementInFocusables = focusableAroundNextElement.includes(nextElement);
 
-          focusableElements = focusableElements.filter(el => nextElement.contains(el) && el);
-          if (isNextElementInFocusables || focusableElements.length <= 1) {
+          focusableElements = focusableAroundNextElement.filter(el => nextElement.contains(el) && el !== nextElement);
+          if (isNextElementInFocusables || focusableElements.length <= 0) {
             // Use nextElement if it focusable
             return nextElement;
           }


### PR DESCRIPTION
### Description

When data-spatial-{left|right|up|down}
- points to a focusable, it focuses to it
- points to a non-focusable element, but it contains focusables, it reduces the navigation scope to the defined element's subtree and applies the distance-based algorithm to find the next focusable.
- otherwhise prevent navigation

Breaking change: none
