### PR TITLE
fix(ci): fail loudly on automation CLI error and add cache miss fallback

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -103,10 +103,15 @@ jobs:
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Uncache Automation
+        id: uncache-automation
         uses: actions/cache@v4
         with:
           path: '**/automation/dist'
           key: automation-dist-${{ env.rid }}
+
+      - name: Build Automation (cache miss fallback)
+        if: steps.uncache-automation.outputs.cache-hit != 'true'
+        run: yarn telemetry build && yarn automation build:cli
 
       - name: Uncache Dist
         uses: actions/cache@v4
@@ -122,7 +127,9 @@ jobs:
 
       - name: Get Changed Packages
         id: get-packages
-        run: echo "packages=$(yarn md-automation -- --command get-packages --changed --commit-index 1 --dependent)" >> $GITHUB_OUTPUT
+        run: |
+          PACKAGES=$(yarn md-automation -- --command get-packages --changed --commit-index 1 --dependent) || exit 1
+          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
 
       - name: Filter Packages with Dist Changes
         id: filter-packages


### PR DESCRIPTION
### Description

When `yarn md-automation` failed (e.g. missing dist/), the error was silently swallowed inside a $() subshell, producing packages=[] and causing deploy jobs to be skipped without any visible failure.

- Add `id` to Uncache Automation step and a conditional rebuild step so the automation CLI is always available even on cache miss.
- Split the inline echo into two lines with `|| exit 1` so a CLI failure causes the job to fail visibly instead of silently.

Breaking change: none