### PR TITLE
fix(timepicker): flakey e2e test

### DIFF
--- a/packages/components/src/components/timepicker/timepicker.e2e-test.ts
+++ b/packages/components/src/components/timepicker/timepicker.e2e-test.ts
@@ -303,23 +303,7 @@ test.describe('mdc-timepicker', () => {
 
       const selectedOption = timepicker.locator('mdc-option[selected]');
       await expect(selectedOption).toBeFocused();
-      await expect
-        .poll(() =>
-          selectedOption.evaluate(option => {
-            const popover = option.closest('mdc-popover');
-            const popoverContent = popover?.shadowRoot?.querySelector('[part="popover-content"]');
-            if (!popoverContent) return false;
-
-            const optionRect = option.getBoundingClientRect();
-            const contentRect = popoverContent.getBoundingClientRect();
-            const scrollMargin = parseFloat(getComputedStyle(option).scrollMarginBlockStart) || 0;
-            return (
-              optionRect.top >= contentRect.top + scrollMargin - 0.5 &&
-              optionRect.bottom <= contentRect.bottom - scrollMargin + 0.5
-            );
-          }),
-        )
-        .toBe(true);
+      await expect(selectedOption).toBeInViewport({ ratio: 1 });
     });
 
     test('should show 15-minute intervals when configured', async ({ componentsPage }) => {


### PR DESCRIPTION
### Description

The previous assertion used getBoundingClientRect via shadow DOM queries inside expect.poll, which was unreliable due to Floating UI setting overflow-y async, shadow DOM timing, and mid-scroll rect values.

Replace with `expect(selectedOption).toBeInViewport({ ratio: 1 })` which uses IntersectionObserver, handles overflow clipping correctly, and retries automatically without fragile DOM traversal.

Breaking change: none