### PR TITLE
docs: update chip knowledge-base topics from design guidelines

### DIFF
--- a/knowledge-base/index.components.json
+++ b/knowledge-base/index.components.json
@@ -36,7 +36,7 @@
       "tier": 3,
       "path": "packages/components/src/components/alertchip/knowledge-base/alertchip.component.md",
       "title": "Alert Chip",
-      "summary": "Usage, guidelines, and accessibility for the mdc-alertchip component — an interactive chip used to represent an alert with a leading icon and label.",
+      "summary": "Usage, guidelines, and accessibility for mdc-alertchip — an interactive chip that calls attention to status or crucial information using reserved alert colors and a leading icon.",
       "canonical": null,
       "component": "alertchip"
     },
@@ -216,7 +216,7 @@
       "tier": 3,
       "path": "packages/components/src/components/chip/knowledge-base/chip.component.md",
       "title": "Chip",
-      "summary": "Usage, guidelines, and accessibility for the mdc-chip component — a small interactive button-shaped element representing compact info, an attribute, or a quick action with optional icon and label.",
+      "summary": "Usage, guidelines, and accessibility for mdc-chip — an interactive label chip for compact attributes, categories, or quick actions, with optional tooltip support.",
       "canonical": null,
       "component": "chip"
     },
@@ -279,7 +279,7 @@
       "tier": 3,
       "path": "packages/components/src/components/filterchip/knowledge-base/filterchip.component.md",
       "title": "Filterchip",
-      "summary": "Usage, guidelines, and accessibility for the mdc-filterchip component — a togglable chip used to apply or remove a single filter, with a built-in checkmark indicator when selected.",
+      "summary": "Usage, guidelines, and accessibility for mdc-filterchip — a togglable chip for applying or removing a single filter, with a checkmark indicator when selected.",
       "canonical": null,
       "component": "filterchip"
     },
@@ -351,7 +351,7 @@
       "tier": 3,
       "path": "packages/components/src/components/inputchip/knowledge-base/inputchip.component.md",
       "title": "Inputchip",
-      "summary": "Usage, guidelines, and accessibility for the mdc-inputchip component — an interactive chip representing a tokenised input value with a leading prefix, a label, and a close button.",
+      "summary": "Usage, guidelines, and accessibility for mdc-inputchip — a chip representing a tokenized user input value with an optional prefix, label, and removable close button.",
       "canonical": null,
       "component": "inputchip"
     },
@@ -684,7 +684,7 @@
       "tier": 3,
       "path": "packages/components/src/components/staticchip/knowledge-base/staticchip.component.md",
       "title": "Static Chip",
-      "summary": "Usage, guidelines, and accessibility for the mdc-staticchip component — a non-interactive chip with a label and optional leading icon, used to display short metadata or status.",
+      "summary": "Usage, guidelines, and accessibility for mdc-staticchip — a non-interactive label chip for displaying short categories, metadata, or attributes.",
       "canonical": null,
       "component": "staticchip"
     },

--- a/packages/components/src/components/alertchip/knowledge-base/alertchip.component.md
+++ b/packages/components/src/components/alertchip/knowledge-base/alertchip.component.md
@@ -1,22 +1,25 @@
 ---
 title: Alert Chip
-summary: Usage, guidelines, and accessibility for the mdc-alertchip component — an interactive chip used to represent an alert with a leading icon and label.
+summary: Usage, guidelines, and accessibility for mdc-alertchip — an interactive chip that calls attention to status or crucial information using reserved alert colors and a leading icon.
 tier: 3
 component: alertchip
 ---
 
 ## Overview
 
-The alert chip is an interactive chip whose color and leading icon indicate one of five visual states — `error`, `informational`, `neutral`, `success`, and `warning`. The variant only changes the visual styling; it does not announce or read out any alert content to assistive technologies on its own.
+Alert chips call attention to a status or crucial piece of information inline within content. `mdc-alertchip` pairs a short label with a leading icon and one of five alert color treatments — `error`, `informational`, `neutral`, `success`, and `warning` — reserved for conveying status across Momentum products.
 
 ### When to use
 
-- Use `mdc-alertchip` to surface a short, interactive status (error, success, warning, informational, neutral) inline within content.
+- To surface a short, interactive status inline — such as errors, warnings, successes, or informational callouts.
+- When alert-specific colors and icons should communicate status at a glance alongside a concise label.
 
 ### When not to use
 
-- Use a non-interactive status indicator (e.g. `mdc-badge` or `mdc-staticchip`) when the chip should not be clickable or focusable.
-- Use `mdc-toast` or `mdc-banner` when the message needs more length, dedicated actions, or system-level prominence.
+- When the chip is purely decorative or read-only with no associated action. Consider `mdc-staticchip` for non-interactive display.
+- When the message needs more length, dedicated actions, or system-level prominence. Use `mdc-toast` or `mdc-banner` instead.
+- When the chip should toggle a content filter. Use `mdc-filterchip` instead.
+- When categorizing content with general-purpose label colors. Use `mdc-chip` or `mdc-staticchip` instead — alert colors are reserved for status and validation.
 
 ## Guidelines
 
@@ -33,17 +36,26 @@ import { AlertChip } from '@momentum-design/components/dist/react';
 Minimal markup example:
 
 ```html
-<mdc-alertchip variant="warning" label="Connection unstable"></mdc-alertchip>
+<mdc-alertchip variant="warning" label="Unstable"></mdc-alertchip>
 ```
 
 ### Content guidance
 
-- Limit the label text to a **maximum of 20 characters**, including empty spaces to split words.
+- Keep the `label` short — limit to a maximum of **20 characters** including spaces.
+- Include the status in the label when assistive technology users must hear it (e.g. `label="Error: offline"`), because the variant color and icon are not announced on their own.
+- Use sentence case for the label.
 
 ### Property/Attribute details
 
-- `variant` selects the visual tone and drives the default leading icon. Supported values: `neutral` (default), `error`, `success`, `warning`, `informational`.
-- `icon-name` overrides the default per-variant icon when a custom icon is required.
+- **`variant`**: Selects the visual tone and default leading icon. Supported values: `neutral` (default), `error`, `success`, `warning`, `informational`. These colors should not be used outside of alerts or validation. The variant is visual only and is not announced as a separate status by assistive technologies.
+- **`icon-name`**: Overrides the default per-variant icon when a custom icon is required.
+
+An alert chip may have an `mdc-tooltip` associated with it when supplementary detail is needed.
+
+### Limitations
+
+- Fixed at 24px height; width grows with the label. Only one size is available.
+- Long labels are visually truncated with ellipsis.
 
 ## Accessibility
 
@@ -54,14 +66,14 @@ The alert chip behaves as a button.
 #### Internal ARIA managed by the component
 
 - The host element exposes `role="button"` and participates in tab order like any other button.
-- Standard button keyboard interaction (Enter/Space activation) is provided.
+- Standard button keyboard interaction (`Enter`/`Space` activation) is provided.
 
 ### Implementation requirements
 
 #### General
 
 - Treat the alert chip as a button when integrating it: ensure the surrounding context makes the action it triggers clear.
-- The variant color/icon is visual only and is not announced. If the alert state must be conveyed to assistive technologies, include the state in the `label` text (e.g. `label="Error: connection lost"`) or in surrounding context.
+- The variant color and icon are visual only and are not announced. If the alert state must be conveyed to assistive technologies, include the state in the `label` text or in surrounding context.
 
 #### Labelling
 

--- a/packages/components/src/components/chip/knowledge-base/chip.component.md
+++ b/packages/components/src/components/chip/knowledge-base/chip.component.md
@@ -1,27 +1,26 @@
 ---
 title: Chip
-summary: Usage, guidelines, and accessibility for the mdc-chip component — a small interactive button-shaped element representing compact info, an attribute, or a quick action with optional icon and label.
+summary: Usage, guidelines, and accessibility for mdc-chip — an interactive label chip for compact attributes, categories, or quick actions, with optional tooltip support.
 tier: 3
 component: chip
 ---
 
 ## Overview
 
-The chip is a compact interactive surface that renders an optional leading icon and a short label. It behaves like a button (single tap or `Enter`/`Space` activation, focus, hover, and disabled states) and is commonly used to represent a tag, attribute, filter trigger, or quick action.
-
-Keep the label short — we recommend a maximum of **20 characters** (including spaces). Chips can be connected to an `mdc-tooltip` (via the tooltip's `triggerid` pointing at the chip's `id`) to surface additional context when the label is truncated or needs explanation.
+Chips are small, interactive elements that represent a status, attribute, or action in a concise format. `mdc-chip` is the interactive label chip: a 24px-tall button-shaped surface with an optional leading icon and short label, commonly used when the chip needs to respond to pointer or keyboard input — for example to reveal supportive detail through an `mdc-tooltip`.
 
 ### When to use
 
-- Use `mdc-chip` to represent an attribute, tag, or quick action that fits in a single, short word or phrase.
-- Use it inside a horizontal row or wrap of chips when several short actions or attributes share the same visual weight.
+- When a short label or attribute should be interactive — such as surfacing extra context on hover or focus via an `mdc-tooltip`.
+- When several compact actions or attributes share the same visual weight in a horizontal row or wrap of chips.
 
 ### When not to use
 
-- Use `mdc-button` when the action needs more visual weight, more text, or icon-only treatment beyond a compact tag.
-- Use `mdc-filterchip` when the chip should reflect an applied filter that can be toggled and removed.
-- Use `mdc-alertchip` when the chip should communicate a status (information, warning, error) rather than trigger an action.
-- Use `mdc-staticchip` when the chip is purely decorative and should not be interactive (e.g. inside a list item that owns the click target).
+- When the chip is purely informational and does not need interaction. Use `mdc-staticchip` instead.
+- When the chip should toggle an applied filter on or off. Use `mdc-filterchip` instead.
+- When the chip should communicate alert or validation status. Use `mdc-alertchip` instead.
+- When the chip represents a removable user-entered value alongside an input pattern. Use `mdc-inputchip` instead.
+- When the action needs more visual weight or longer text. Use `mdc-button` instead.
 
 ## Guidelines
 
@@ -45,17 +44,19 @@ Listen for the `click` event (or `keydown`/`keyup` for keyboard activation) to r
 
 ### Content guidance
 
-- Keep the `label` short — we recommend up to 20 characters including spaces.
-- Use `icon-name` only when the icon clarifies the chip; an icon-only chip is not supported (a label is required for an accessible name).
-- Pick a `color` token that matches the chip's semantic meaning in your surface; do not rely on color alone to convey meaning.
+- Keep the `label` short — limit to a maximum of **20 characters** including spaces. Labels should not need to be over-explained; use surrounding UI context and tooltips where needed.
+- Use `icon-name` only when the icon clarifies the chip; a label is required for an accessible name.
+- Use sentence case for the label.
 
 ### Property/Attribute details
 
-- `label` — visible label text rendered through `mdc-text`. Used as the accessible name. Recommended max length 20 characters.
-- `icon-name` — optional leading icon, rendered through `mdc-icon`. When omitted, no icon is rendered.
-- `color` — visual treatment. One of `default` (default), `cobalt`, `gold`, `lime`, `mint`, `orange`, `pink`, `purple`, `slate`, `violet`.
-- `disabled` — when `true`, the chip is non-interactive and removed from the tab order.
-- `autoFocusOnMount` — when `true`, focuses the chip on first render.
+- **`label`**: Visible label text rendered through `mdc-text`. Used as the accessible name. Recommended max length 20 characters.
+- **`icon-name`**: Optional leading icon, rendered through `mdc-icon`. When omitted, no icon is rendered.
+- **`color`**: Visual treatment for categorization or emphasis — one of `default` (default), `cobalt`, `gold`, `lime`, `mint`, `orange`, `pink`, `purple`, `slate`, `violet`. Do not use these colors to convey alert or validation status; reserve status colors for `mdc-alertchip`.
+- **`disabled`**: When `true`, the chip is non-interactive and removed from the tab order.
+- **`autoFocusOnMount`**: When `true`, focuses the chip on first render.
+
+Connect an `mdc-tooltip` (via the tooltip's `triggerid` pointing at the chip's `id`) when the label is truncated or needs supplementary explanation on hover or keyboard focus.
 
 ### Limitations
 
@@ -68,8 +69,8 @@ Listen for the `click` event (or `keydown`/`keyup` for keyboard activation) to r
 
 The host renders with `role="button"` and a single tab stop. The component owns keyboard activation:
 
-- `Enter` activates the chip on `keydown` (matches native button behaviour).
-- `Space` activates the chip on `keyup` (matches native button behaviour; `keydown` is suppressed so the page does not scroll).
+- `Enter` activates the chip on `keydown` (matches native button behavior).
+- `Space` activates the chip on `keyup` (matches native button behavior; `keydown` is suppressed so the page does not scroll).
 - Click activates the chip.
 
 When `disabled` is `true`, click and keyboard activation are suppressed and the host is removed from the tab order.
@@ -78,10 +79,10 @@ The `label` provides the accessible name. The leading icon is decorative and is 
 
 #### Internal ARIA managed by the component
 
-| Element | Attribute   | Value                                  |
-| ------- | ----------- | -------------------------------------- |
-| Host    | `role`      | `button`                               |
-| Host    | `tabindex`  | `0` when enabled; `-1` when `disabled` |
+| Element | Attribute  | Value                                  |
+| ------- | ---------- | -------------------------------------- |
+| Host    | `role`     | `button`                               |
+| Host    | `tabindex` | `0` when enabled; `-1` when `disabled` |
 
 ### Implementation requirements
 

--- a/packages/components/src/components/filterchip/knowledge-base/filterchip.component.md
+++ b/packages/components/src/components/filterchip/knowledge-base/filterchip.component.md
@@ -1,27 +1,27 @@
 ---
 title: Filterchip
-summary: Usage, guidelines, and accessibility for the mdc-filterchip component — a togglable chip used to apply or remove a single filter, with a built-in checkmark indicator when selected.
+summary: Usage, guidelines, and accessibility for mdc-filterchip — a togglable chip for applying or removing a single filter, with a checkmark indicator when selected.
 tier: 3
 component: filterchip
 ---
 
 ## Overview
 
-The filterchip is a compact, togglable chip used to represent a single filter in a list, table, or search context. Activating the chip flips its `selected` state and the component swaps its leading icon to a checkmark to indicate the active filter.
-
-Filterchips are typically rendered in a horizontal row next to a result set; users toggle them on and off to narrow the set.
+Filter chips let users refine content based on specific criteria — commonly beside lists, tables, or search results in e-commerce, dashboards, and data interfaces. `mdc-filterchip` is a compact, togglable chip: activating it flips the `selected` state, swaps the leading icon to a checkmark, and applies an active background with a 2px border.
 
 ### When to use
 
-- Use `mdc-filterchip` when each chip toggles a single filter that can be applied or removed independently.
-- Use it inside a row of filters where the selected state should be visually obvious at a glance.
+- When each chip toggles a single filter that can be applied or removed independently.
+- In a **group** of filter chips placed close to the result set they affect — filter chips are always used in a group, not as a single isolated chip.
+- On e-commerce, dashboard, or search surfaces where users narrow a list or table with quick filters.
 
 ### When not to use
 
-- Use `mdc-chip` when the chip triggers an action rather than a toggle.
-- Use `mdc-alertchip` when the chip communicates a status (information, warning, error) rather than a togglable filter.
-- Use `mdc-staticchip` when the chip is purely decorative and should not be interactive.
-- Use `mdc-checkbox` or `mdc-radio` when the control should appear inside a form field group rather than as a compact filter row.
+- When the chip triggers a one-off action rather than a toggle. Use `mdc-chip` instead.
+- When the chip communicates alert or validation status. Use `mdc-alertchip` instead.
+- When the chip is purely informational with no toggle behavior. Use `mdc-staticchip` instead.
+- When the control should appear inside a form field group. Use `mdc-checkbox` or `mdc-radio` instead.
+- When representing a removable user-entered value. Use `mdc-inputchip` instead.
 
 ## Guidelines
 
@@ -46,17 +46,22 @@ Listen for the `click` event (or `keydown`/`keyup` for keyboard activation) to r
 
 ### Content guidance
 
-- Keep the `label` short — we recommend up to 20 characters including spaces, matching the underlying chip.
-- Phrase the label as the filter that gets applied when the chip is selected ("In stock", not "Toggle in stock"); the checkmark indicates state.
+- Keep the `label` short — limit to a maximum of **20 characters** including spaces.
+- Phrase the label as the filter that gets applied when selected ("In stock", not "Toggle in stock"); the checkmark indicates state.
 - Group related filterchips together and place the row close to the result set they affect.
 
 ### Property/Attribute details
 
-- `selected` — when `true`, the chip is in the active state, displays the checkmark icon, and sets `aria-pressed="true"`. Default `false`.
-- `label` — visible label text rendered through `mdc-text`. Used as the accessible name. Recommended max length 20 characters.
-- `color` — fixed to the filterchip-specific colour token on connect; setting a different `color` has no effect after connect.
-- `disabled` — when `true`, the chip is non-interactive and removed from the tab order.
-- `autoFocusOnMount` — when `true`, focuses the chip on first render.
+- **`selected`**: When `true`, the chip is in the active state, displays the checkmark icon, shows the press/active background color with a 2px border, and sets `aria-pressed="true"`. Default `false`. Clicking a selected chip deselects it — the checkmark disappears and the chip returns to its normal neutral state.
+- **`label`**: Visible label text rendered through `mdc-text`. Used as the accessible name. Recommended max length 20 characters.
+- **`color`**: Fixed to the filterchip-specific neutral color token on connect; setting a different `color` has no effect after connect. Do not apply the multi-color palette used by label chips.
+- **`disabled`**: When `true`, the chip is non-interactive and removed from the tab order.
+- **`autoFocusOnMount`**: When `true`, focuses the chip on first render.
+
+### Limitations
+
+- Fixed at 24px height; width grows with the label. Only one size is available.
+- Intended for use in groups — avoid rendering a lone filter chip without surrounding filter context.
 
 ## Accessibility
 
@@ -64,8 +69,8 @@ Listen for the `click` event (or `keydown`/`keyup` for keyboard activation) to r
 
 The host renders with `role="button"` and a single tab stop. Activating the chip flips `selected` and updates `aria-pressed` accordingly, exposing the toggle state to assistive technology.
 
-- `Enter` activates the chip on `keydown` (matches native button behaviour).
-- `Space` activates the chip on `keyup` (matches native button behaviour; `keydown` is suppressed so the page does not scroll).
+- `Enter` activates the chip on `keydown` (matches native button behavior).
+- `Space` activates the chip on `keyup` (matches native button behavior; `keydown` is suppressed so the page does not scroll).
 - Click activates the chip.
 
 When `disabled` is `true`, click and keyboard activation are suppressed and the host is removed from the tab order.
@@ -74,11 +79,11 @@ The `label` provides the accessible name. When `selected` is `true`, the leading
 
 #### Internal ARIA managed by the component
 
-| Element | Attribute      | Value                                                  |
-| ------- | -------------- | ------------------------------------------------------ |
-| Host    | `role`         | `button`                                               |
-| Host    | `aria-pressed` | `true` when `selected`, `false` otherwise              |
-| Host    | `tabindex`     | `0` when enabled; `-1` when `disabled`                 |
+| Element | Attribute      | Value                                  |
+| ------- | -------------- | -------------------------------------- |
+| Host    | `role`         | `button`                               |
+| Host    | `aria-pressed` | `true` when `selected`, `false` otherwise |
+| Host    | `tabindex`     | `0` when enabled; `-1` when `disabled` |
 
 ### Implementation requirements
 

--- a/packages/components/src/components/inputchip/knowledge-base/inputchip.component.md
+++ b/packages/components/src/components/inputchip/knowledge-base/inputchip.component.md
@@ -1,25 +1,26 @@
 ---
 title: Inputchip
-summary: Usage, guidelines, and accessibility for the mdc-inputchip component — an interactive chip representing a tokenised input value with a leading prefix, a label, and a close button.
+summary: Usage, guidelines, and accessibility for mdc-inputchip — a chip representing a tokenized user input value with an optional prefix, label, and removable close button.
 tier: 3
 component: inputchip
 ---
 
 ## Overview
 
-The inputchip represents a single tokenised value: a short label with an optional leading prefix (icon name or arbitrary slotted content such as an avatar) and a close button that fires a `remove` event when activated. It is used in patterns where multiple values are collected into a list of chips (recipients, filters, tags).
-
-The chip supports an `error` visual state for invalid values, a `disabled` state that also disables the close button, and a `prefix` slot that takes precedence over `icon-name` when both are provided.
+Input chips represent user-entered values — such as tags, email addresses, or other small tokens — inside a multi-value input pattern. `mdc-inputchip` shows a short label with an optional leading prefix (icon or slotted content such as an avatar) and a close button that fires a `remove` event when activated.
 
 ### When to use
 
-- Use `mdc-inputchip` to represent individual values inside a multi-value input pattern: token-style inputs for recipients, tags, filters, or any list of removable items.
-- Use it when the consumer needs full control over chip removal — the chip emits `remove` and the consumer decides what to do with that signal.
+- To represent individual values inside a multi-value input pattern: recipients, tags, filters, or any list of removable items the user has entered.
+- When input chips should be paired with a text field so users can add new values while existing ones appear as chips.
+- When the consumer needs full control over chip removal — the chip emits `remove` and the consumer decides how to update state.
 
 ### When not to use
 
-- Use `mdc-filterchip` for chips that toggle a selected/unselected state to filter a list, rather than representing a removable input value.
-- Use `mdc-chip` for static, non-removable display chips.
+- When the chip should toggle a selected/unselected filter state. Use `mdc-filterchip` instead.
+- When the chip is a static, non-removable label. Use `mdc-staticchip` or `mdc-chip` instead.
+- When the chip should communicate system alert status. Use `mdc-alertchip` instead.
+- As a standalone input without an accompanying text field when users still need to enter new values.
 
 ## Guidelines
 
@@ -55,21 +56,24 @@ Listen for the `remove` event to react to the close button being clicked.
 
 ### Content guidance
 
-- Keep the `label` short — we recommend a maximum length of 20 characters (including spaces). Longer values are visually truncated.
+- Keep the `label` short — limit to a maximum of **20 characters** including spaces. Longer values are visually truncated.
 - Use `icon-name` for simple iconographic prefixes; use the `prefix` slot for richer content such as avatars or presence indicators (slot content always wins over `icon-name`).
-- Set `error="true"` when the represented value fails validation; pair the chip with surrounding helper text that explains the failure.
+- Pair input chips with a text field when users need to enter values that become chips — for example adding tags to a post or recipients to an email field.
+- Set `error="true"` when the represented value fails validation — incorrect format, invalid data, duplication, or exceeding character limits. Pair the chip with surrounding helper text that explains the failure.
 
 ### Property/Attribute details
 
-- `label` — the visible text. Default `''`. Aim for ≤20 characters.
-- `icon-name` — name of the icon rendered in the leading prefix when no `prefix` slot content is provided. Default unset.
-- `error` — when `true`, switches the chip to its error visual treatment. Default `false`.
-- `disabled` — when `true`, dims the chip and disables the close button so the value cannot be removed by user interaction.
-- `clear-aria-label` — accessible name for the close button. Required (the close button has no visible text).
+- **`label`**: The visible text. Default `''`. Aim for ≤20 characters.
+- **`icon-name`**: Name of the icon rendered in the leading prefix when no `prefix` slot content is provided. Default unset.
+- **`error`**: When `true`, switches the chip to its error visual treatment (background red). Default `false`. Input chips use default gray for the normal state and red only for invalid or error states.
+- **`disabled`**: When `true`, dims the chip and disables the close button so the value cannot be removed by user interaction.
+- **`clear-aria-label`**: Accessible name for the close button. Required (the close button has no visible text).
 
 ### Limitations
 
-- The chip is not form-associated — it does not submit a value of its own. The owning input pattern is responsible for tracking which values are currently represented as chips and serialising them when the form submits.
+- The chip is not form-associated — it does not submit a value of its own. The owning input pattern is responsible for tracking which values are currently represented as chips and serializing them when the form submits.
+- Labels cannot be edited inline; users must remove the incorrect chip and add a new one to correct a value.
+- Fixed at 24px height; width grows with the label. Only one size is available.
 
 ## Accessibility
 
@@ -81,12 +85,16 @@ The label and prefix icon are presentational — the consumer chooses how to exp
 
 #### Internal ARIA managed by the component
 
-| Element        | Attribute     | Value                              |
-| -------------- | ------------- | ---------------------------------- |
-| Close button   | `aria-label`  | mirrors `clear-aria-label`         |
-| Close button   | `disabled`    | reflects `disabled`                |
+| Element      | Attribute    | Value                      |
+| ------------ | ------------ | -------------------------- |
+| Close button | `aria-label` | mirrors `clear-aria-label` |
+| Close button | `disabled`   | reflects `disabled`        |
 
 ### Implementation requirements
+
+#### General
+
+- Pair input chips with helper text or field-level error messaging when `error` is `true`, so users understand why a value failed validation.
 
 #### Labelling
 

--- a/packages/components/src/components/staticchip/knowledge-base/staticchip.component.md
+++ b/packages/components/src/components/staticchip/knowledge-base/staticchip.component.md
@@ -1,25 +1,26 @@
 ---
 title: Static Chip
-summary: Usage, guidelines, and accessibility for the mdc-staticchip component — a non-interactive chip with a label and optional leading icon, used to display short metadata or status.
+summary: Usage, guidelines, and accessibility for mdc-staticchip — a non-interactive label chip for displaying short categories, metadata, or attributes.
 tier: 3
 component: staticchip
 ---
 
 ## Overview
 
-The static chip is a small, non-interactive element used to display a short label with an optional leading icon. It is intended for displaying metadata, tags, or status, and supports a fixed set of colour variants.
+Label chips show static information — such as categories or read-only attributes — in a compact 24px-tall format. `mdc-staticchip` is the non-interactive variant: a short label with an optional leading icon, used when the chip itself should not receive focus or respond to activation.
 
 ### When to use
 
-- Use `mdc-staticchip` to display a short label or status that the user cannot interact with (e.g. a tag, category, or read-only attribute).
-- Use it inside lists, cards, or summary rows where the chip is purely informational.
+- To display a short label, category, or read-only attribute that the user cannot interact with directly.
+- Inside lists, cards, summary rows, or other layouts where the surrounding element owns the click target.
 
 ### When not to use
 
-- Use `mdc-chip` when the chip should respond to user interaction (click, selection).
-- Use `mdc-filterchip` for chips that toggle on/off as filters.
-- Use `mdc-inputchip` for editable, removable chips inside an input.
-- Use `mdc-badge` when you need a smaller, status-only indicator (especially for counts or notifications).
+- When the chip should be interactive — for example to show a tooltip on hover or focus. Use `mdc-chip` instead.
+- When the chip should toggle a filter on or off. Use `mdc-filterchip` instead.
+- When the chip should communicate alert or validation status. Use `mdc-alertchip` instead.
+- When the chip represents a removable user-entered value. Use `mdc-inputchip` instead.
+- When a smaller count or notification indicator is sufficient. Use `mdc-badge` instead.
 
 ## Guidelines
 
@@ -37,24 +38,27 @@ Minimal markup example:
 
 ```html
 <mdc-staticchip label="In progress" color="cobalt" icon-name="clock-bold"></mdc-staticchip>
-<mdc-staticchip label="Done" color="mint"></mdc-staticchip>
+<mdc-staticchip label="Design" color="purple"></mdc-staticchip>
 ```
 
 ### Content guidance
 
-- Keep the label short. Limit to a maximum of 20 characters, including spaces, so the chip stays compact.
+- Keep the `label` short — limit to a maximum of **20 characters** including spaces so the chip stays compact.
 - Use sentence case for the label.
+- Rely on surrounding UI context when the label alone does not fully explain the chip's meaning.
 
 ### Property/Attribute details
 
-- `label` — visible label text rendered inside the chip. Defaults to `undefined` (renders nothing if omitted).
-- `color` — colour variant. One of `default`, `cobalt`, `gold`, `lime`, `mint`, `orange`, `pink`, `purple`, `slate`, `violet`. Defaults to `default`.
-- `icon-name` — name of the icon rendered before the label. When omitted, no icon is shown.
+- **`label`**: Visible label text rendered inside the chip. Defaults to `undefined` (renders nothing if omitted).
+- **`color`**: Color variant for categorization or emphasis — one of `default`, `cobalt`, `gold`, `lime`, `mint`, `orange`, `pink`, `purple`, `slate`, `violet`. Defaults to `default`. Use these colors to call out context or categorize content; do not use them to convey alert or validation status.
+- **`icon-name`**: Name of the icon rendered before the label. When omitted, no icon is shown. Leading avatars or icons are optional.
 
 ### Limitations
 
 - Not interactive: cannot be focused, clicked, or activated.
 - Not form-associated: has no `name`/`value` and is not submitted with a form.
+- Fixed at 24px height; width grows with the label. Only one size is available.
+- Long labels are visually truncated with ellipsis.
 
 ## Accessibility
 
@@ -64,4 +68,4 @@ The component renders the label inside an `mdc-text` element and the optional ic
 
 ### Notes
 
-Because the component has no interactive role, ensure the surrounding context conveys what the chip represents (e.g. a label or heading describing the chip's purpose). When the chip carries semantic meaning that is not obvious from its label, include that meaning in the surrounding text.
+Because the component has no interactive role, ensure the surrounding context conveys what the chip represents (e.g. a label or heading describing the chip's purpose). When the chip carries semantic meaning that is not obvious from its label alone, include that meaning in the surrounding text.


### PR DESCRIPTION
Align chip, staticchip, alertchip, inputchip, and filterchip component docs with Momentum chip design guidelines, including cross-variant guidance and American English spelling.

### Description

## Summary
- Updates Tier 3 knowledge-base topics for `chip`, `staticchip`, `alertchip`, `inputchip`, and `filterchip` to align with Momentum chip design guidelines.
- Adds cross-variant guidance (when to use / when not to use), sizing and color rules, filter/input behavior, and accessibility notes.
- Regenerates `knowledge-base/index.components.json` with updated summaries.

### Breaking Change

See above
