### PR TITLE
docs: update decorator knowledge-base topics from design guidelines

### DIFF
--- a/knowledge-base/index.components.json
+++ b/knowledge-base/index.components.json
@@ -117,7 +117,7 @@
       "tier": 3,
       "path": "packages/components/src/components/bullet/knowledge-base/bullet.component.md",
       "title": "Bullet",
-      "summary": "Usage, guidelines, and accessibility for the mdc-bullet component — a small circular visual indicator used to mark or separate list-style content.",
+      "summary": "Usage, guidelines, and accessibility for mdc-bullet — a styled dot marker for unordered list items and inline content separation.",
       "canonical": null,
       "component": "bullet"
     },
@@ -270,7 +270,7 @@
       "tier": 3,
       "path": "packages/components/src/components/divider/knowledge-base/divider.component.md",
       "title": "Divider",
-      "summary": "Usage, guidelines, and accessibility for the mdc-divider component — a thin horizontal or vertical separator that can optionally host a centered text label or an interactive grabber button.",
+      "summary": "Usage, guidelines, and accessibility for mdc-divider — a thin horizontal or vertical separator with optional centered label or grabber button.",
       "canonical": null,
       "component": "divider"
     },
@@ -423,7 +423,7 @@
       "tier": 3,
       "path": "packages/components/src/components/marker/knowledge-base/marker.component.md",
       "title": "Marker",
-      "summary": "Usage, guidelines, and accessibility for the mdc-marker component — a thin vertical visual indicator (solid or striped) used alongside list items, cards, or content blocks to convey status.",
+      "summary": "Usage, guidelines, and accessibility for mdc-marker — a thin vertical visual indicator used to call out rows, calendar items, or content blocks.",
       "canonical": null,
       "component": "marker"
     },

--- a/packages/components/src/components/bullet/knowledge-base/bullet.component.md
+++ b/packages/components/src/components/bullet/knowledge-base/bullet.component.md
@@ -1,25 +1,26 @@
 ---
 title: Bullet
-summary: Usage, guidelines, and accessibility for the mdc-bullet component — a small circular visual indicator used to mark or separate list-style content.
+summary: Usage, guidelines, and accessibility for mdc-bullet — a styled dot marker for unordered list items and inline content separation.
 tier: 3
 component: bullet
 ---
 
 ## Overview
 
-The bullet is a small, non-interactive circular indicator used to mark or separate items in a list-style layout. It provides a consistent visual mark in three sizes (small, medium, large) so consumers can match the bullet to the surrounding content density.
+Bullets are visual markers used to organize and present items in a list format, making content easier to scan and understand. `mdc-bullet` renders a styled circular dot in three sizes so consumers can match list density and visual emphasis in custom unordered lists, navigation indicators, or inline separators.
 
 ### When to use
 
-- Use `mdc-bullet` as a visual marker in custom unordered lists, navigation indicators, or as a separator dot between inline text fragments.
-- Pick the size based on layout density and visual emphasis: `small` for compact rows, `medium` for typical body content, `large` when the marker should stand out.
+- When building custom unordered lists where styled dots improve readability and structure beyond native list styling.
+- When a compact visual marker is needed between inline text fragments or in navigation indicators.
+- When list item order is not essential but each item needs distinct separation — pick `small` for compact rows, `medium` for typical body content, and `large` when the marker should stand out.
 
 ### When not to use
 
-- Use a native `<ul>`/`<li>` list when the platform's default bullet styling is sufficient — it carries list semantics for free.
-- Use `mdc-badge` (`dot` type) when the indicator should communicate a notification or status rather than mark a list item.
-- Use `mdc-presence` when the dot conveys a user's availability state (active, away, busy, dnd).
-- Use `mdc-divider` when you need a visible separator between sections rather than a marker for an individual item.
+- When a native `<ul>`/`<li>` list is sufficient — it carries list semantics for free.
+- When the dot should communicate notification or status. Use `mdc-badge` (`dot` type) instead.
+- When the dot conveys a user's availability state (active, away, busy, dnd). Use `mdc-presence` instead.
+- When a visible separator between sections is needed rather than a marker for an individual item. Use `mdc-divider` instead.
 
 ## Guidelines
 
@@ -39,29 +40,39 @@ Minimal markup example:
 <mdc-bullet size="medium"></mdc-bullet>
 ```
 
+### Content guidance
+
+- In Momentum Design, bullets are styled dots only — do not substitute custom icons or shapes for the default dot treatment.
+- Keep the default `outline/secondary` color (`--mds-color-theme-outline-secondary-normal`). Do not override bullet color for categorization or status; use accompanying text or a semantic component when meaning must be conveyed.
+- Always pair the bullet with meaningful adjacent text — the dot itself is decorative and carries no semantic meaning.
+
 ### Property/Attribute details
 
-- `size` — controls the diameter of the bullet:
-  - `small` (default) — 0.25rem (4px), for compact lists.
-  - `medium` — 0.5rem (8px), for typical body content.
-  - `large` — 1rem (16px), for emphasised or hero layouts.
+- **`size`**: Controls the diameter of the bullet — `small` (default, 0.25rem / 4px) for compact lists, `medium` (0.5rem / 8px) for typical body content, `large` (1rem / 16px) for emphasized layouts.
+- **`--mdc-bullet-background-color`**: CSS custom property for the dot fill. Defaults to `outline/secondary`; overriding is discouraged except where design system guidance explicitly allows it.
+- **`--mdc-bullet-size`**: CSS custom property for dot height; prefer the `size` attribute over manual overrides.
+
+### Limitations
+
+- The bullet is purely decorative with no role, label, or interactive behavior — it must never be the sole carrier of information.
+- Color and size alone must not convey state or hierarchy; pair with text or an appropriate semantic component when meaning is required.
 
 ## Accessibility
 
 ### Built-in features
 
-The bullet is purely decorative. It renders as a generic element with no role, label, or interactive behaviour, so assistive technologies skip over it by default.
+The bullet is purely decorative. It renders as a generic element with no role, label, or interactive behavior, so assistive technologies skip over it by default.
 
 #### Internal ARIA managed by the component
 
-| Element | Attribute | Value                       |
-| ------- | --------- | --------------------------- |
-| Host    | `role`    | None set by the component   |
+| Element | Attribute | Value                     |
+| ------- | --------- | ------------------------- |
+| Host    | `role`    | None set by the component |
 
 ### Implementation requirements
 
 #### General
 
 - Always pair the bullet with meaningful adjacent text — never let the bullet itself carry information.
-- Do not rely on bullet size or colour alone to convey state or hierarchy; use accompanying text or an appropriate semantic component (e.g. `mdc-badge`, `mdc-presence`) when the dot must communicate meaning.
+- Do not rely on bullet size or color alone to convey state or hierarchy; use accompanying text or an appropriate semantic component (e.g. `mdc-badge`, `mdc-presence`) when the dot must communicate meaning.
 - If the bullet is rendered inside a list of items, prefer marking up the surrounding container with the appropriate list semantics (`<ul>`/`<li>` or `role="list"`/`role="listitem"`) so assistive technologies announce the list structure.

--- a/packages/components/src/components/divider/knowledge-base/divider.component.md
+++ b/packages/components/src/components/divider/knowledge-base/divider.component.md
@@ -1,32 +1,32 @@
 ---
 title: Divider
-summary: Usage, guidelines, and accessibility for the mdc-divider component — a thin horizontal or vertical separator that can optionally host a centered text label or an interactive grabber button.
+summary: Usage, guidelines, and accessibility for mdc-divider — a thin horizontal or vertical separator with optional centered label or grabber button.
 tier: 3
 component: divider
 ---
 
 ## Overview
 
-The divider draws a thin separator line between sections of a layout. It supports both horizontal and vertical orientations and two visual variants — `solid` (uniform colour) and `gradient` (fades on both ends).
+The divider draws a thin separator line between sections of a layout. It supports both horizontal and vertical orientations and two visual variants — `solid` (uniform color) and `gradient` (fades on both ends).
 
 The component infers its type from the slotted content:
 
 - **Primary** — no slotted content; renders just the line.
-- **Text** — a single `mdc-text` child; renders the line with a centred label.
-- **Grabber Button** — a single `mdc-button` child; renders the line with a centred interactive button (typically used to collapse/expand a resizable pane).
+- **Text** — a single `mdc-text` child; renders the line with a centered label.
+- **Grabber Button** — a single `mdc-button` child; renders the line with a centered interactive button (typically used to collapse/expand a resizable pane).
 
-If the slot contains multiple elements or unrecognised tag names, the divider falls back to the primary type.
+If the slot contains multiple elements or unrecognized tag names, the divider falls back to the primary type.
 
 ### When to use
 
-- Use `mdc-divider` to separate sections of content within a layout, list, or table.
-- Use a text divider to add a short caption between two visually similar sections.
-- Use a grabber-button divider to create a resizable boundary between two panes.
+- When separating sections of content within a layout, list, or table improves navigation and hierarchy.
+- When a short caption between two visually similar sections clarifies the boundary.
+- When a resizable or collapsible boundary between two panes needs a centered expand/collapse affordance.
 
 ### When not to use
 
-- Use whitespace, padding, or background-colour groupings when a visible line is not needed — a divider should add meaning, not decoration.
-- Use `mdc-list` separators rather than nesting dividers inside list items, since lists already render their own dividers.
+- When whitespace, padding, or background-color groupings provide sufficient separation — dividers should add meaning, not decoration. Use them sparingly to avoid visual clutter.
+- When `mdc-list` already renders separators between items — prefer list separators over nesting dividers inside list items.
 
 ## Guidelines
 
@@ -68,37 +68,42 @@ For a grabber-button divider the component automatically applies `variant="secon
 
 ### Content guidance
 
-- Keep text labels short — a single word ("OR") or a brief phrase fits the centred layout best.
-- Use the grabber-button divider only when the divider itself is the resize/expand affordance; otherwise prefer a primary divider next to a separate control.
-- Pick `variant="gradient"` when the divider sits over a coloured surface and a hard solid line would feel heavy; otherwise prefer `solid`.
+- Keep text labels short and concise — a single word ("OR") or brief phrase fits the centered layout best. Short labels also prevent responsive and localization issues when text length increases under zoom or translation; the flanking lines shrink to accommodate longer label text.
+- Reserve `variant="gradient"` for Webex App products and documentation — solid dividers are appropriate for any application. Gradient dividers soften separation between navigation and content areas.
+- Text dividers use the solid variant only — do not combine a label with a gradient line.
+- Use grabber-button dividers only when the divider is the collapse/expand affordance; otherwise prefer a primary divider next to a separate control.
 
 ### Property/Attribute details
 
-- `orientation` — `horizontal` (default) or `vertical`. Vertical text dividers are not currently supported.
-- `variant` — `solid` (default) or `gradient`. Drives the line's fill.
-- `arrow-direction` — direction of the arrow icon on the grabber button. `positive` (up for horizontal, right for vertical) or `negative` (down for horizontal, left for vertical). Default `negative`. Only relevant for the grabber-button divider.
-- `button-position` — position of the grabber button along the divider. `positive` (right for horizontal, top for vertical) or `negative` (left for horizontal, bottom for vertical). Default `negative`. Only relevant for the grabber-button divider.
+- **`orientation`**: `horizontal` (default) or `vertical`. Vertical text dividers are not supported.
+- **`variant`**: `solid` (default) or `gradient`. Drives the line fill. Solid is universal; gradient is reserved for Webex App surfaces.
+- **`arrow-direction`**: Direction of the arrow icon on the grabber button — `positive` (up for horizontal, right for vertical) or `negative` (down for horizontal, left for vertical). Default `negative`. Only relevant for grabber-button dividers. Icons used: `arrow-up-regular`, `arrow-down-regular`, `arrow-left-regular`, `arrow-right-regular`.
+- **`button-position`**: Position of the grabber button along the divider — `positive` (right for horizontal, top for vertical) or `negative` (left for horizontal, bottom for vertical). Default `negative`. Only relevant for grabber-button dividers.
+- **`--mdc-divider-background-color`**: Line color for solid dividers. Defaults to `outline/secondary`; may be overridden only in specific cases such as notification patterns (e.g. Webex App "New messages").
 
 ### Limitations
 
-- Vertical text dividers are not supported — combine `orientation="vertical"` with a text child and the layout will not render the label centred. Use the horizontal variant for text dividers.
-- The divider type is inferred from a single slotted child. If the slot contains more than one element or unrecognised tag names, the divider falls back to the primary type and any extra content is ignored visually.
+- Vertical text dividers are not supported — combining `orientation="vertical"` with a text child will not render a centered label. Use the horizontal variant for text dividers.
+- The divider type is inferred from a single slotted child. Multiple elements or unrecognized tag names fall back to the primary type and extra content is ignored visually.
+- Dividers and grabber lines can be stretched to fill their container; the line remains 1px thick.
+- Grabber-button dividers expose rest, hover, pressed, active, and focused states on the slotted `mdc-button` only — the line itself has no interactive states. The arrow icon indicates opened or closed section state; there are no disabled states for grabber buttons.
+- The grabber button is clickable only; there is no draggable resize state on the button itself. Wire `click` handlers in the consumer to toggle pane visibility or size.
 
 ## Accessibility
 
 ### Built-in features
 
-The divider is presentational and exposes no implicit ARIA role. When a grabber button is slotted, the button is fully focusable and keyboard-operable on its own (it is a standard `mdc-button`), and the consumer is responsible for wiring its accessibility (`aria-label`, `aria-expanded`, click handler) to the resize behaviour it controls.
+The divider is presentational and exposes no implicit ARIA role. When a grabber button is slotted, the button is fully focusable and keyboard-operable on its own (it is a standard `mdc-button`), and the consumer is responsible for wiring its accessibility (`aria-label`, `aria-expanded`, click handler) to the behavior it controls.
 
 When a text label is slotted, the label is rendered inline through `mdc-text` and is read by screen readers in document order.
 
 #### Internal ARIA managed by the component
 
-| Element     | Attribute   | Value                                                                                       |
-| ----------- | ----------- | ------------------------------------------------------------------------------------------- |
-| Host        | `data-type` | `mdc-primary-divider` (default), `mdc-text-divider`, or `mdc-grabber-divider` (inferred)    |
-| Slot button | `variant`   | `secondary` (auto-applied to a slotted `mdc-button`)                                        |
-| Slot button | `prefix-icon` | arrow icon derived from `orientation` and `arrow-direction`                               |
+| Element     | Attribute     | Value                                                                                     |
+| ----------- | ------------- | ----------------------------------------------------------------------------------------- |
+| Host        | `data-type`   | `mdc-primary-divider` (default), `mdc-text-divider`, or `mdc-grabber-divider` (inferred) |
+| Slot button | `variant`     | `secondary` (auto-applied to a slotted `mdc-button`)                                      |
+| Slot button | `prefix-icon` | Arrow icon derived from `orientation` and `arrow-direction`                               |
 
 ### Implementation requirements
 

--- a/packages/components/src/components/marker/knowledge-base/marker.component.md
+++ b/packages/components/src/components/marker/knowledge-base/marker.component.md
@@ -1,25 +1,23 @@
 ---
 title: Marker
-summary: Usage, guidelines, and accessibility for the mdc-marker component — a thin vertical visual indicator (solid or striped) used alongside list items, cards, or content blocks to convey status.
+summary: Usage, guidelines, and accessibility for mdc-marker — a thin vertical visual indicator used to call out rows, calendar items, or content blocks.
 tier: 3
 component: marker
 ---
 
 ## Overview
 
-The marker is a thin vertical line (0.25rem wide by default) used to draw the eye to a piece of content — typically rendered alongside a list item, card, or content block to indicate status, priority, or categorisation. Two visual variants are available: `solid` (a single coloured line) and `striped` (a line with diagonal stripes for a high-attention variant).
-
-The marker is purely presentational; its meaning must be conveyed elsewhere (label, status text, icon) because it has no accessible name.
+Markers draw attention to specific parts of content and provide visual emphasis alongside list items, cards, or content blocks. `mdc-marker` renders a thin vertical line (0.25rem / 4px wide by default) in `solid` or `striped` variants. Fill color can be customized to match context — for example validation status or calendar meeting categories — but meaning must always be conveyed elsewhere because the marker has no accessible name.
 
 ### When to use
 
-- Use `mdc-marker` to draw attention to important content, signal priority, or visually categorise items inside a layout.
-- Use it as a decorative companion to a list item, card, or content block — never as the sole signal for the information.
+- When visually calling out a row, calendar meeting item, or content block where a vertical accent helps users scan and categorize information.
+- When a decorative companion to text or icons reinforces priority or categorization — never as the sole signal.
 
 ### When not to use
 
-- Use a label, status text, or an icon when the meaning must be announced to screen readers — the marker alone is invisible to assistive technology.
-- Use `mdc-divider` for separating content sections rather than highlighting a single block.
+- When the meaning must be announced to screen readers — use a label, status text, or icon instead; the marker alone is invisible to assistive technology.
+- When separating content sections rather than highlighting a single block. Use `mdc-divider` instead.
 
 ## Guidelines
 
@@ -48,7 +46,7 @@ Striped marker for higher-attention treatment:
 <mdc-marker variant="striped"></mdc-marker>
 ```
 
-Customise the colour and width with CSS custom properties:
+Customize color and width with CSS custom properties:
 
 ```html
 <mdc-marker
@@ -59,27 +57,32 @@ Customise the colour and width with CSS custom properties:
 
 ### Content guidance
 
-- Always pair the marker with text or an icon that conveys the same meaning — the colour and pattern alone are not accessible.
+- Always pair the marker with text or an icon that conveys the same meaning — color and pattern alone are not accessible.
 - Reserve the `striped` variant for the highest-priority or most urgent treatment so it retains its visual weight.
-- Use the CSS custom properties (`--mdc-marker-solid-background-color`, `--mdc-marker-striped-color`, `--mdc-marker-striped-background-color`, `--mdc-marker-width`) to map the marker into a theme's colour tokens.
+- Override fill color with CSS custom properties to denote status types or categories (e.g. meeting types in a calendar). Default color is `outline/secondary`.
+- Markers can be stretched to fill the height of their container based on layout context.
 
 ### Property/Attribute details
 
-- `variant` — `solid` (default; single coloured line) or `striped` (line with diagonal stripes for higher-attention treatment).
+- **`variant`**: `solid` (default; single colored line) or `striped` (line with diagonal stripes for higher-attention treatment).
+- **`--mdc-marker-solid-background-color`**: Fill color for the solid variant. Defaults to `outline/secondary`; override to match contextual status or category colors.
+- **`--mdc-marker-striped-color`** / **`--mdc-marker-striped-background-color`**: Stripe and background colors for the striped variant.
+- **`--mdc-marker-width`**: Line thickness. Defaults to 0.25rem (4px); increase when a bolder accent is needed in the layout.
 
 ### Limitations
 
-- The marker is decorative and has no accessible name. It is invisible to screen readers and must always be accompanied by a text or icon affordance that carries the same meaning.
+- The marker is decorative and has no accessible name. It is invisible to screen readers and must always be accompanied by text or an icon that carries the same meaning.
+- Width and height follow the container — ensure the parent layout gives the marker sufficient height to remain visible.
 
 ## Accessibility
 
 ### Built-in features
 
-The marker has no role, no accessible name, and no keyboard or focus behaviour — it is a purely decorative bar. Screen readers skip it.
+The marker has no role, no accessible name, and no keyboard or focus behavior — it is a purely decorative bar. Screen readers skip it.
 
 ### Implementation requirements
 
 #### General
 
-- Always pair the marker with a text label, status string, or icon that conveys the same meaning. Do not rely on colour or pattern alone.
-- Ensure sufficient colour contrast between the marker and the surrounding background so sighted users with low vision can perceive it.
+- Always pair the marker with a text label, status string, or icon that conveys the same meaning. Do not rely on color or pattern alone.
+- Ensure sufficient color contrast between the marker and the surrounding background so sighted users with low vision can perceive it.


### PR DESCRIPTION
Align mdc-bullet, mdc-divider, and mdc-marker Tier 3 topics with decorator design guidelines and component APIs.

### Description

## Summary
- Align `mdc-bullet`, `mdc-divider`, and `mdc-marker` Tier 3 knowledge-base topics with decorator design guidelines.
- Add cross-component guidance, content rules, and property details consistent with accordion/chip KB updates.
- Regenerate `knowledge-base/index.components.json`.

### Breaking Change

See above