### PR TITLE
docs: update avatar knowledge-base topics from design guidelines

### DIFF
--- a/knowledge-base/index.components.json
+++ b/knowledge-base/index.components.json
@@ -81,7 +81,7 @@
       "tier": 3,
       "path": "packages/components/src/components/avatarbutton/knowledge-base/avatarbutton.component.md",
       "title": "Avatar Button",
-      "summary": "Usage, guidelines, and accessibility for the mdc-avatarbutton component — an interactive, focusable avatar wrapped in a button.",
+      "summary": "Usage, guidelines, and accessibility for mdc-avatarbutton — an interactive, focusable avatar wrapped in a button for profile menus, account switchers, and popover triggers.",
       "canonical": null,
       "component": "avatarbutton"
     },
@@ -531,7 +531,7 @@
       "tier": 3,
       "path": "packages/components/src/components/presence/knowledge-base/presence.component.md",
       "title": "Presence",
-      "summary": "Usage, guidelines, and accessibility for the mdc-presence component — a small status badge that visually represents the availability or activity state of a user or entity.",
+      "summary": "Usage, guidelines, and accessibility for mdc-presence — a small status badge that overlays an avatar to show a user's real-time availability or activity state.",
       "canonical": null,
       "component": "presence"
     },

--- a/packages/components/src/components/avatar/knowledge-base/avatar.component.md
+++ b/packages/components/src/components/avatar/knowledge-base/avatar.component.md
@@ -7,15 +7,16 @@ component: avatar
 
 ## Overview
 
-The avatar represents a person or a group. It can be rendered as a photo, initials, icon, or counter, and is non-interactive and non-focusable by default. An optional presence indicator and a typing loading state are also supported.
+An avatar visually represents a user, profile, or identity. `mdc-avatar` is the non-interactive variant: it renders as a photo, initials, icon, or counter and is omitted from tab order. An optional presence indicator and typing state can overlay the artwork when the representing user status or in-progress message composition.
 
 ### When to use
 
-- Use `mdc-avatar` to visually represent a person or group inline within content (e.g. lists, cards, message rows).
+- When a person or group needs a visual identity inline within content — for example in lists, cards, message rows, or participant strips.
 
 ### When not to use
 
-- Use `mdc-avatarbutton` when the avatar must be clickable or focusable (profile menu, account switcher, etc.).
+- When the avatar must be clickable or focusable (profile menu, account switcher, etc.). Use `mdc-avatarbutton` instead.
+- When a standalone status badge is needed without avatar artwork. Use `mdc-presence` instead.
 
 ## Guidelines
 
@@ -44,12 +45,18 @@ Minimal markup example:
 
 When multiple display attributes are provided, the avatar picks what to render in this priority order:
 
-1. **Photo** (`src`) — highest priority. While loading, `initials` show as an instant placeholder when provided, otherwise the icon is shown (after the icon library loads). On load error, the placeholder remains visible.
-2. **Icon** (`icon-name`) — used when `src` is not provided. If both `icon-name` and `initials` are provided (without `src`), the icon wins and `initials` are ignored, which means users may briefly see nothing while the icon library loads even though initials would have rendered instantly. Defaults to `user-regular` when nothing else is available.
-3. **Initials** (`initials`) — shown when neither `src` nor `icon-name` is provided. Renders instantly.
-4. **Counter** (`counter`) — shown only when none of the above are provided.
+1. **`src`** (photo) — highest priority. While loading, `initials` show as an instant placeholder when provided; otherwise the default icon is shown. On load error, the placeholder remains visible.
+2. **`icon-name`** — used when `src` is not provided. If both `icon-name` and `initials` are provided (without `src`), the icon wins and `initials` are ignored, which means users may briefly see nothing while the icon library loads even though initials would have rendered instantly.
+3. **`initials`** — shown when neither `src` nor `icon-name` is provided. Renders instantly.
+4. **`counter`** — shown only when none of the above are provided.
 
-Other behaviour worth knowing:
+Other supported attributes:
+
+- **`size`**: Avatar diameter in px — `24` (2X-Small), `32` (X-Small, default), `48` (Small), `64` (Midsize), `72` (Large), `88` (X-Large), `124` (2X-Large). Invalid values fall back to `32`. Match size to surrounding content density — smaller sizes for compact rows, larger sizes when the avatar is a focal identity marker.
+- **`presence`**: Activity status passed through to the nested `mdc-presence` badge. Accepts `active`, `away`, `away-calling`, `busy`, `dnd`, `meeting`, `on-call`, `on-device`, `on-mobile`, `pause`, `pto`, `presenting`, `quiet`, `scheduled`. Hidden when a counter is rendered or while typing.
+- **`is-typing`**: When `true`, overlays a three-dot typing loading indicator on top of the current content. Hidden when the avatar is in counter mode.
+
+### Limitations
 
 - When `is-typing` is `true`, a typing loading indicator overlays the existing content.
 - The presence indicator is hidden when the avatar is rendering a counter, or when it is in the typing state.
@@ -62,10 +69,10 @@ The avatar is treated as decorative by default — it is hidden from assistive t
 
 #### Internal ARIA managed by the component
 
-| Element        | Attribute     | Value                                                                              |
-| -------------- | ------------- | ---------------------------------------------------------------------------------- |
-| Host           | `aria-hidden` | `true` by default; consumers may set `aria-hidden="false"` when the avatar conveys meaning |
-| Photo (`img`)  | `aria-hidden` | `true` (the host carries the accessible exposure)                                   |
+| Element       | Attribute     | Value                                                                                        |
+| ------------- | ------------- | -------------------------------------------------------------------------------------------- |
+| Host          | `aria-hidden` | `true` by default; consumers may set `aria-hidden="false"` when the avatar conveys meaning   |
+| Photo (`img`) | `aria-hidden` | `true` (the host carries the accessible exposure when overridden)                            |
 
 ### Implementation requirements
 

--- a/packages/components/src/components/avatarbutton/knowledge-base/avatarbutton.component.md
+++ b/packages/components/src/components/avatarbutton/knowledge-base/avatarbutton.component.md
@@ -1,21 +1,23 @@
 ---
 title: Avatar Button
-summary: Usage, guidelines, and accessibility for the mdc-avatarbutton component — an interactive, focusable avatar wrapped in a button.
+summary: Usage, guidelines, and accessibility for mdc-avatarbutton — an interactive, focusable avatar wrapped in a button for profile menus, account switchers, and popover triggers.
 tier: 3
 component: avatarbutton
 ---
 
 ## Overview
 
-The avatar button is an interactive, clickable version of the avatar. It wraps the avatar in a button so it becomes focusable and actionable, while still supporting all avatar display modes (photo, initials, icon, counter) and the presence indicator. Use CSS parts to customise the avatar appearance inside the button.
+An avatar button is the interactive variant of the avatar — a clickable, keyboard-focusable control that supports every avatar display mode (photo, initials, icon, counter) plus an optional presence indicator. Use it when activating the avatar should open a profile popover, menu, or other contextual surface. Use CSS parts to customize the avatar appearance inside the button.
 
 ### When to use
 
-- Use `mdc-avatarbutton` when the avatar must be clickable or keyboard-focusable — for example a profile menu trigger, account switcher, or a member chip that opens a details panel.
+- When the avatar must be clickable or keyboard-focusable — for example a profile menu trigger, account switcher, or member chip that opens a details panel or popover.
+- When all avatar display modes and presence indicators are needed alongside button interaction semantics.
 
 ### When not to use
 
-- Use `mdc-avatar` when the avatar is purely decorative or informational and should not be interactive.
+- When the avatar is purely decorative or informational and should not be interactive. Use `mdc-avatar` instead.
+- When a generic button with text or an icon is sufficient and no avatar artwork is required. Use `mdc-button` instead.
 
 ## Guidelines
 
@@ -35,21 +37,48 @@ Minimal markup example:
 <mdc-avatarbutton initials="AB" aria-label="Open profile menu"></mdc-avatarbutton>
 ```
 
+Photo avatar button with presence:
+
+```html
+<mdc-avatarbutton
+  src="/profile.jpg"
+  initials="AB"
+  presence="active"
+  aria-label="Open Jane Doe's profile"
+></mdc-avatarbutton>
+```
+
+Wire a popover by placing `mdc-avatarbutton` as the trigger and connecting it to the popover component per the popover integration pattern in your product surface.
+
+Listen for `click`, `keydown`, `keyup`, and `focus` events to react to user interaction.
+
+### Content guidance
+
+- **Always** provide an `aria-label` that describes what activating the button does — not just the person's name (for example `aria-label="Open profile menu"`, not `aria-label="Jane Doe"`).
+- All avatar display guidance from `mdc-avatar` applies: initials are uppercased and truncated to two characters; counter values clamp at `99+`; the default icon is `user-regular` when no display input is provided.
+- Counter avatars do not show presence or typing indicators — the same restrictions as `mdc-avatar` apply.
+
 ### Property/Attribute details
 
-When multiple display attributes are provided, the avatar button picks what to render in this priority order:
+When multiple display attributes are provided, the avatar button picks what to render in this priority order (delegated to the inner `mdc-avatar`):
 
-1. **Photo** (`src`) — highest priority. While loading, `initials` show as an instant placeholder when provided, otherwise the icon is shown (after the icon library loads). On load error, the placeholder remains visible.
-2. **Icon** (`icon-name`) — used when `src` is not provided. If both `icon-name` and `initials` are provided (without `src`), the icon wins and `initials` are ignored. Defaults to `user-regular` when nothing else is available.
-3. **Initials** (`initials`) — shown when neither `src` nor `icon-name` is provided. Uppercased and truncated to the first two characters.
-4. **Counter** (`counter`) — shown only when none of the above are provided. Negatives display as `0`, values above 99 display as `99+`.
+1. **`src`** (photo) — highest priority. While loading, `initials` show as an instant placeholder when provided; otherwise the default icon is shown. On load error, the placeholder remains visible.
+2. **`icon-name`** — used when `src` is not provided. If both `icon-name` and `initials` are provided (without `src`), the icon wins and `initials` are ignored.
+3. **`initials`** — shown when neither `src` nor `icon-name` is provided.
+4. **`counter`** — shown only when none of the above are provided. Negatives display as `0`, values above 99 display as `99+`.
 
 Other supported attributes:
 
-- `size` — avatar size in px: `24`, `32` (default), `48`, `64`, `72`, `88`, `124`. Invalid values fall back to the default.
-- `presence` — activity status (`active`, `away`, `away-calling`, `busy`, `dnd`, `meeting`, `on-call`, `on-device`, `on-mobile`, `pause`, `pto`, `presenting`, `quiet`, `scheduled`). Hidden when a counter is rendered or while typing.
-- `is-typing` — when `true`, overlays a typing loading indicator on top of the current content.
-- `aria-label` — required accessible name for the button (see Accessibility).
+- **`size`**: Avatar diameter in px — `24`, `32` (default), `48`, `64`, `72`, `88`, `124`. Invalid values fall back to `32`.
+- **`presence`**: Activity status — `active`, `away`, `away-calling`, `busy`, `dnd`, `meeting`, `on-call`, `on-device`, `on-mobile`, `pause`, `pto`, `presenting`, `quiet`, `scheduled`. Hidden when a counter is rendered or while typing.
+- **`is-typing`**: When `true`, overlays a typing loading indicator on top of the current content.
+- **`aria-label`**: Required accessible name for the button (see Accessibility).
+
+### Limitations
+
+- The inner `mdc-avatar` is always `aria-hidden="true"` — the button host carries the accessible name; do not expect initials or photo alt text to be announced.
+- Counter avatars suppress presence and typing indicators, matching `mdc-avatar` behavior.
+- `disabled`, `active`, and `soft-disabled` are reset on connect and should not be relied on — the avatar button does not expose a disabled variant through these properties.
 
 ## Accessibility
 
@@ -57,17 +86,27 @@ Other supported attributes:
 
 The component behaves as a button: it is keyboard-focusable, activates on Enter/Space, and exposes button semantics to assistive technologies.
 
+- `Enter` activates the button on `keydown` (matches native button behavior).
+- `Space` activates the button on `keyup` (matches native button behavior; `keydown` is suppressed so the page does not scroll).
+- Click activates the button.
+
 #### Internal ARIA managed by the component
 
-| Element            | Attribute     | Value                                                          |
-| ------------------ | ------------- | -------------------------------------------------------------- |
-| Host               | `role`        | `button`                                                       |
-| Host               | `aria-label`  | Reflected from the `aria-label` attribute set by the consumer  |
-| Overlay (`div`)    | `aria-hidden` | `true` (decorative styling layer)                              |
-| Inner `mdc-avatar` | `aria-hidden` | `true` (the host carries the accessible name and button role)  |
+| Element            | Attribute     | Value                                                         |
+| ------------------ | ------------- | ------------------------------------------------------------- |
+| Host               | `role`        | `button`                                                      |
+| Host               | `aria-label`  | Reflected from the `aria-label` attribute set by the consumer |
+| Overlay (`div`)    | `aria-hidden` | `true` (decorative styling layer)                             |
+| Inner `mdc-avatar` | `aria-hidden` | `true` (the host carries the accessible name and button role) |
 
 ### Implementation requirements
 
+#### General
+
+- The clickable state to open popovers is available for all avatar display variations and must remain keyboard-accessible through the button host.
+- When pairing with a popover, ensure the popover's open/close state is reflected in `aria-expanded` on the avatar button if your integration pattern requires it.
+
 #### Labelling
 
-- **Always** provide an `aria-label` describing the button's purpose (e.g. `aria-label="Open profile menu"`). Without it the button has no accessible name, since the inner avatar is hidden from assistive technologies.
+- **Always** provide an `aria-label` describing the button's purpose (for example `aria-label="Open profile menu"`). Without it the button has no accessible name, since the inner avatar is hidden from assistive technologies.
+- Do not use the person's name alone as the label unless activating the button navigates to or focuses that person — describe the action the button performs.

--- a/packages/components/src/components/presence/knowledge-base/presence.component.md
+++ b/packages/components/src/components/presence/knowledge-base/presence.component.md
@@ -1,24 +1,25 @@
 ---
 title: Presence
-summary: Usage, guidelines, and accessibility for the mdc-presence component — a small status badge that visually represents the availability or activity state of a user or entity.
+summary: Usage, guidelines, and accessibility for mdc-presence — a small status badge that overlays an avatar to show a user's real-time availability or activity state.
 tier: 3
 component: presence
 ---
 
 ## Overview
 
-The presence is a small status badge that visually represents the availability or activity state of a user or entity (for example: active, away, busy, do-not-disturb, on a call, presenting). It is sized to be paired with an avatar so the status renders as a corner indicator on top of the avatar artwork.
+A presence indicator is a small colored icon overlaid on or beside an avatar to communicate a user's real-time status or availability — for example active, away, in a meeting, on a call, or do-not-disturb. `mdc-presence` is sized to pair with `mdc-avatar` and `mdc-avatarbutton`; the avatar component renders it automatically when the `presence` attribute is set.
 
 ### When to use
 
-- Use `mdc-presence` next to or on top of an `mdc-avatar` to indicate the represented user/entity's current availability or activity.
-- Use it whenever the application has a meaningful status signal to communicate alongside an avatar (online, in a meeting, away, etc.).
+- When an `mdc-avatar` or `mdc-avatarbutton` needs to show the represented user's current availability or activity alongside their identity artwork.
+- When the application has a meaningful, up-to-date status signal sourced from user settings or system state (online, in a meeting, presenting, on PTO, etc.).
 
 ### When not to use
 
-- Do not use it as a standalone status indicator divorced from an avatar — pair it with `mdc-avatar` so the icon size matches the avatar size.
-- Use `mdc-badge` for counts, dots, or non-status decorations.
-- Use `mdc-icon` if you need an arbitrary icon at custom sizes outside the supported avatar size set.
+- Do not use to display status separate from an avatar
+- When the avatar is in counter mode (representing multiple users).
+- When the avatar is showing a typing indicator.
+- When a count, notification dot, or non-status decoration is needed. Use `mdc-badge` instead.
 
 ## Guidelines
 
@@ -40,8 +41,35 @@ Minimal markup example:
 
 ### Property/Attribute details
 
-- `type` — the presence state: `active`, `away`, `away-calling`, `busy`, `dnd`, `meeting`, `on-call`, `on-device`, `on-mobile`, `pause`, `pto`, `presenting`, `quiet`, `scheduled`. If an unknown value is supplied the component falls back to `active`. Default `active`.
-- `size` — overall size of the presence badge in pixels: `24`, `32`, `48`, `64`, `72`, `88`, `124`. Default `32`. Presence icons have a minimum rendered size of 14px, so sizes `24`, `32`, and `48` all render the icon at 14px.
+- **`type`**: The presence state — `active`, `away`, `away-calling`, `busy`, `dnd`, `meeting`, `on-call`, `on-device`, `on-mobile`, `pause`, `pto`, `presenting`, `quiet`, `scheduled`. Default `active`. Unknown values fall back to `active`. When multiple signals apply, resolve to a single type in application logic using the precedence order below (highest first) before passing it to the component.
+
+| Precedence | `type` value     | Color token           | Set by   | Description                            |
+| ---------- | ---------------- | --------------------- | -------- | -------------------------------------- |
+| 1          | `pto`            | indicator/locked      | Manual   | Out of office / PTO                    |
+| 2          | `dnd`            | indicator/attention   | Manual   | Do not disturb                         |
+| 3          | `busy`           | indicator/unstable    | Manual   | Busy                                   |
+| 4          | `quiet`          | indicator/locked      | Manual   | Quiet hours / away from desk           |
+| 5          | `presenting`     | indicator/attention   | System   | Presenting or sharing screen           |
+| 6          | `meeting`        | indicator/unstable    | System   | In a meeting                           |
+| 7          | `on-call`        | indicator/unstable    | System   | On a phone call                        |
+| 8          | `pause`          | indicator/locked      | System   | On call but placed on hold             |
+| 9          | `away-calling`   | indicator/locked      | Manual   | Away (Calling service users)           |
+| 10         | `on-device`      | indicator/locked      | System   | Active on a device                     |
+| 11         | `on-mobile`      | indicator/locked      | System   | Active on a mobile device              |
+| 12         | `scheduled`      | indicator/unstable    | System   | Has a currently scheduled meeting      |
+| 13         | `active`         | indicator/stable      | System   | Online and available                   |
+| 14         | `away`           | indicator/locked      | System   | Idle / away                            |
+
+Presence icon colors are limited to the indicator tokens above for each type. Do not override badge colors to convey different meanings.
+
+- **`size`**: Overall badge size in px, matched to the parent avatar — `24`, `32` (default), `48`, `64`, `72`, `88`, `124`. Invalid values fall back to `32`.
+- Presence icons have a **minimum rendered size of 14px** to meet accessibility standards. For avatar sizes `24`, `32`, and `48`, the icon renders at 14px; larger avatar sizes scale the icon proportionally.
+
+### Limitations
+
+- The component displays one presence type at a time — precedence resolution is the consumer's responsibility.
+- The badge has no built-in accessible name; status must be communicated through surrounding context or parent labeling.
+- Counter avatars and typing states suppress the presence badge when rendered through `mdc-avatar` or `mdc-avatarbutton`.
 
 ## Accessibility
 


### PR DESCRIPTION
Align mdc-avatar, mdc-avatarbutton, and mdc-presence Tier 3 topics with avatar design guidelines and component APIs.

### Description

## Summary
- Align `mdc-avatar`, `mdc-avatarbutton`, and `mdc-presence` Tier 3 knowledge-base topics with avatar design guidelines and component APIs.
- Add display-type guidance, size scale, presence precedence table, limitations, and expanded accessibility requirements.
- Regenerate `knowledge-base/index.components.json` summary entries for the three components.