### PR TITLE
docs: reference content guidelines in KB contributing skill

### DIFF
--- a/.github/skills/momentum-contributing-to-knowledge-base/SKILL.md
+++ b/.github/skills/momentum-contributing-to-knowledge-base/SKILL.md
@@ -9,14 +9,16 @@ This skill is the step-by-step workflow for **adding new** or **updating existin
 topic files in the Momentum Design knowledge base.
 
 It does **not** restate structural rules, tiers, frontmatter fields,
-allowed topic names, or body heading conventions. Those are defined once in
-the [Knowledge Base Schema](../../../config/knowledge-base/SCHEMA.md) and
+allowed topic names, body heading conventions, or user-facing copy standards.
+Those are defined once in the [Knowledge Base Schema](../../../config/knowledge-base/SCHEMA.md),
 the config files it references
 ([`frontmatter.config.json`](../../../config/knowledge-base/content/frontmatter.config.json),
 [`body.config.json`](../../../config/knowledge-base/content/body.config.json),
-[`topic-constraints.config.json`](../../../config/knowledge-base/topic-constraints.config.json)).
-Always consult the schema and its sibling config files before and during the
-steps below.
+[`topic-constraints.config.json`](../../../config/knowledge-base/topic-constraints.config.json)),
+and [`knowledge-base/content-guidelines.md`](../../../knowledge-base/content-guidelines.md)
+for Webex voice, tone, and in-product copy.
+Always consult the schema, its sibling config files, and the content guidelines
+before and during the steps below.
 
 ## When to use this skill
 
@@ -63,6 +65,10 @@ skill is not the place to change rules.
 
 4. **Create or update `knowledge-base/<topic>.md`** at the chosen level.
 
+   - Before drafting user-facing prose, read
+     [`knowledge-base/content-guidelines.md`](../../../knowledge-base/content-guidelines.md)
+     and apply its voice, tone, vocabulary, and content-pattern rules (see
+     [Content and copy standards](#content-and-copy-standards)).
    - For Tier 3 (component) topics, the file name **must** appear in
      [`topic-constraints.config.json`](../../../config/knowledge-base/topic-constraints.config.json).
      Do not invent new Tier 3 topic names; if a new one is genuinely
@@ -86,6 +92,11 @@ skill is not the place to change rules.
    [`body.config.json`](../../../config/knowledge-base/content/body.config.json).
    Read that file directly before drafting or editing content.
    Do not invent new section or sub-section headings without first adding them to `body.config.json` and calling that out to the user.
+
+   - In the **Content guidance** sub-section, keep copy component-specific.
+     Follow [`knowledge-base/content-guidelines.md`](../../../knowledge-base/content-guidelines.md)
+     for general standards; link to that topic instead of duplicating voice,
+     tone, or pattern rules (Rule 3).
 
 7. **Validate the knowledge-base.** Run:
 
@@ -112,6 +123,19 @@ skill is not the place to change rules.
    (see [Rule 5 of the schema](../../../config/knowledge-base/SCHEMA.md#rules)).
    Surface the diff explicitly so the reviewer can verify both content
    accuracy and tier placement.
+
+## Content and copy standards
+
+When drafting or editing user-facing prose in any topic file, read
+[`knowledge-base/content-guidelines.md`](../../../knowledge-base/content-guidelines.md)
+first. It is the canonical Tier 1 source for Webex UI/UX writing standards.
+
+- Apply its rules to labels, helper text, error messages, empty states,
+  button copy, and other in-product text you author in topic files.
+- Keep topic files scoped to their tier and subject; link to the content
+  guidelines for general voice, tone, and pattern rules rather than copying
+  them (Rule 3).
+- Do not restate the full content guidelines in this skill or in topic files.
 
 ## Updating an existing topic
 


### PR DESCRIPTION
## Summary

- Updates the `momentum-contributing-to-knowledge-base` skill to reference `knowledge-base/content-guidelines.md` when drafting user-facing copy in knowledge-base topics.
- Adds a **Content and copy standards** section and workflow pointers in steps 4 and 6 (link, do not duplicate — Rule 3).

## Dependency

This skill links to `knowledge-base/content-guidelines.md`. Merge after (or together with) the content guidelines topic PR if that file is not yet on `main`.

## Test plan

- [ ] Confirm skill links resolve once content guidelines topic is on `main`
- [ ] Review that guidance does not duplicate content from the canonical topic
- [ ] Verify agents are directed to read content guidelines before drafting pros