### PR TITLE
fix(CI): replace cache actions with upload/download artifact actions

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -72,11 +72,12 @@ jobs:
       - name: Build Automation
         run: yarn telemetry build && yarn automation build:cli
 
-      - name: Cache Automation
-        uses: actions/cache@v5
+      - name: Upload Automation
+        uses: actions/upload-artifact@v4
         with:
+          name: automation-dist-${{ env.rid }}
           path: '**/automation/dist'
-          key: automation-dist-${{ env.rid }}
+          retention-days: 1
 
   generate-package-matrix:
     name: Generate Package Matrix with Dist Changes
@@ -102,22 +103,23 @@ jobs:
             packages/**/node_modules
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Uncache Automation
-        id: uncache-automation
-        uses: actions/cache@v5
+      - name: Download Automation
+        id: download-automation
+        uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
-          path: '**/automation/dist'
-          key: automation-dist-${{ env.rid }}
+          name: automation-dist-${{ env.rid }}
+          path: .
 
-      - name: Build Automation (cache miss fallback)
-        if: steps.uncache-automation.outputs.cache-hit != 'true'
+      - name: Build Automation (artifact miss fallback)
+        if: steps.download-automation.outcome == 'failure'
         run: yarn telemetry build && yarn automation build:cli
 
-      - name: Uncache Dist
-        uses: actions/cache@v5
+      - name: Download Dist
+        uses: actions/download-artifact@v4
         with:
-          path: '**/dist'
-          key: dist-${{ env.rid }}
+          name: dist-${{ env.rid }}
+          path: .
 
       - name: Synchronize Packages
         run: yarn
@@ -200,11 +202,12 @@ jobs:
       - name: Build
         run: yarn build
 
-      - name: Cache Dist
-        uses: actions/cache@v5
+      - name: Upload Dist
+        uses: actions/upload-artifact@v4
         with:
+          name: dist-${{ env.rid }}
           path: '**/dist'
-          key: dist-${{ env.rid }}
+          retention-days: 1
 
   deploy-npmjs:
     name: ( ${{ matrix.package }} ) Deploy - NPMJS
@@ -232,11 +235,11 @@ jobs:
             packages/**/node_modules
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Uncache Dist
-        uses: actions/cache@v5
+      - name: Download Dist
+        uses: actions/download-artifact@v4
         with:
-          path: '**/dist'
-          key: dist-${{ env.rid }}
+          name: dist-${{ env.rid }}
+          path: .
 
       - name: Synchronize Packages
         run: yarn
@@ -280,11 +283,11 @@ jobs:
             packages/**/node_modules
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Uncache Dist
-        uses: actions/cache@v5
+      - name: Download Dist
+        uses: actions/download-artifact@v4
         with:
-          path: '**/dist'
-          key: dist-${{ env.rid }}
+          name: dist-${{ env.rid }}
+          path: .
 
       - name: Synchronize Packages
         run: yarn
@@ -323,11 +326,11 @@ jobs:
             packages/**/node_modules
            key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
-       - name: Uncache Dist
-         uses: actions/cache@v5
+       - name: Download Dist
+         uses: actions/download-artifact@v4
          with:
-           path: '**/dist'
-           key: dist-${{ env.rid }}
+           name: dist-${{ env.rid }}
+           path: .
 
        - name: Synchronize Packages
          run: yarn

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -106,14 +106,9 @@ jobs:
       - name: Download Automation
         id: download-automation
         uses: actions/download-artifact@v4
-        continue-on-error: true
         with:
           name: automation-dist-${{ env.rid }}
           path: .
-
-      - name: Build Automation (artifact miss fallback)
-        if: steps.download-automation.outcome == 'failure'
-        run: yarn telemetry build && yarn automation build:cli
 
       - name: Download Dist
         uses: actions/download-artifact@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,11 +71,12 @@ jobs:
         run: PUBLIC_ALGOLIA_APP_ID=${{ env.PUBLIC_ALGOLIA_APP_ID }} PUBLIC_ALGOLIA_INDEX_NAME=${{ env.PUBLIC_ALGOLIA_INDEX_NAME }} PUBLIC_ALGOLIA_DOC_SEARCH=${{ env.PUBLIC_ALGOLIA_DOC_SEARCH }} yarn build
         working-directory: ${{ env.BUILD_PATH }}
         
-      - name: Cache Documentation
-        uses: actions/cache@v5
+      - name: Upload Documentation
+        uses: actions/upload-artifact@v4
         with:
+          name: docs-${{ env.rid }}
           path: ${{ env.BUILD_PATH }}/packages/documentation/dist/
-          key: docs-${{ env.rid }}
+          retention-days: 1
 
   deploy:
     name: Deploy
@@ -90,11 +91,11 @@ jobs:
         run: |
           rm -rf ${{ env.BUILD_PATH }}/docs
 
-      - name: Uncache Documentation
-        uses: actions/cache@v5
+      - name: Download Documentation
+        uses: actions/download-artifact@v4
         with:
+          name: docs-${{ env.rid }}
           path: ${{ env.BUILD_PATH }}/packages/documentation/dist/
-          key: docs-${{ env.rid }}
       
       - name: Process Cached Docs
         run: cp -avr ${{ env.BUILD_PATH }}/packages/documentation/dist docs/

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -220,11 +220,12 @@ jobs:
         env:
           MOMENTUM_METRICS_API_KEY: ${{ secrets.MOMENTUM_METRICS_API_KEY }}
 
-      - name: Cache Dist
-        uses: actions/cache@v5
+      - name: Upload Dist
+        uses: actions/upload-artifact@v4
         with:
+          name: dist-${{ env.rid }}
           path: '**/dist'
-          key: dist-${{ env.rid }}
+          retention-days: 1
 
   analyze-root:
     name: Analyze Root
@@ -283,11 +284,11 @@ jobs:
             packages/**/node_modules
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Uncache Dist
-        uses: actions/cache@v5
+      - name: Download Dist
+        uses: actions/download-artifact@v4
         with:
-          path: '**/dist'
-          key: dist-${{ env.rid }}
+          name: dist-${{ env.rid }}
+          path: .
 
       - name: Synchronize Packages
         run: yarn
@@ -323,11 +324,11 @@ jobs:
             packages/**/node_modules
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
       
-      - name: Uncache Dist
-        uses: actions/cache@v5
+      - name: Download Dist
+        uses: actions/download-artifact@v4
         with:
-          path: '**/dist'
-          key: dist-${{ env.rid }}
+          name: dist-${{ env.rid }}
+          path: .
 
       - name: Synchronize Packages
         run: yarn
@@ -363,11 +364,11 @@ jobs:
             packages/**/node_modules
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Uncache Dist
-        uses: actions/cache@v5
+      - name: Download Dist
+        uses: actions/download-artifact@v4
         with:
-          path: '**/dist'
-          key: dist-${{ env.rid }}
+          name: dist-${{ env.rid }}
+          path: .
 
       - name: Synchronize Packages
         run: yarn
@@ -403,11 +404,11 @@ jobs:
             packages/**/node_modules
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Uncache Dist
-        uses: actions/cache@v5
+      - name: Download Dist
+        uses: actions/download-artifact@v4
         with:
-          path: '**/dist'
-          key: dist-${{ env.rid }}
+          name: dist-${{ env.rid }}
+          path: .
 
       - name: Debug dist
         run: |

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -79,11 +79,12 @@ jobs:
         env:
           MOMENTUM_METRICS_API_KEY: ${{ secrets.MOMENTUM_METRICS_API_KEY }}
 
-      - name: Cache Dist
-        uses: actions/cache@v5
+      - name: Upload Dist
+        uses: actions/upload-artifact@v4
         with:
+          name: dist-${{ env.rid }}
           path: "**/dist"
-          key: dist-${{ env.rid }}
+          retention-days: 1
 
   update-snapshots:
     name: Update Snapshots
@@ -108,11 +109,11 @@ jobs:
             packages/**/node_modules
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Uncache Dist
-        uses: actions/cache@v5
+      - name: Download Dist
+        uses: actions/download-artifact@v4
         with:
-          path: "**/dist"
-          key: dist-${{ env.rid }}
+          name: dist-${{ env.rid }}
+          path: .
 
       - name: Synchronize Packages
         run: yarn


### PR DESCRIPTION
### Description

It is necessary because:
- upload/download is the right action to share artifacts between jobs
- GitHub made cache read-only in some cases which block our CI in PRs https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/

Breaking change: none