### PR TITLE
fix: update figma mcp transport

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,8 +1,8 @@
 {
-    "servers": {
-        "Figma Dev Mode MCP": {
-            "type": "sse",
-            "url": "http://127.0.0.1:3845/sse"
-        }
+  "servers": {
+    "figmaDesktop": {
+      "type": "http",
+      "url": "http://127.0.0.1:3845/mcp"
     }
+  }
 }


### PR DESCRIPTION
The workspace Figma MCP config still used the legacy MCP HTTP+SSE transport (`type: "sse"` + `/sse`). The MCP spec now defines Streamable HTTP as the standard HTTP transport and marks the 2024-11-05 HTTP+SSE transport as deprecated. SSE itself is still supported inside Streamable HTTP for streaming responses, so this change moves the config to the Figma-documented `/mcp` endpoint.

MCP transport spec:
https://modelcontextprotocol.io/specification/2025-11-25/basic/transports

Figma desktop MCP setup:
https://developers.figma.com/docs/figma-mcp-server/local-server-installation/

VS Code MCP configuration reference:
https://code.visualstudio.com/docs/agents/reference/mcp-configuration
