### PR TITLE
feat(component): add focus trap

### DIFF
--- a/knowledge-base/index.components.json
+++ b/knowledge-base/index.components.json
@@ -284,6 +284,15 @@
       "component": "filterchip"
     },
     {
+      "id": "tier3/packages/components/src/components/focustrap/knowledge-base/focustrap.component",
+      "tier": 3,
+      "path": "packages/components/src/components/focustrap/knowledge-base/focustrap.component.md",
+      "title": "FocusTrap",
+      "summary": "Traps keyboard focus within a container, preventing users from tabbing outside its bounds and ensuring focus is restored when the trap is deactivated.",
+      "canonical": null,
+      "component": "focustrap"
+    },
+    {
       "id": "tier3/packages/components/src/components/formfieldgroup/knowledge-base/formfieldgroup.component",
       "tier": 3,
       "path": "packages/components/src/components/formfieldgroup/knowledge-base/formfieldgroup.component.md",

--- a/packages/components/config/playwright/playwright.config.ts
+++ b/packages/components/config/playwright/playwright.config.ts
@@ -55,9 +55,11 @@ const config: PlaywrightTestConfig = {
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: url,
-    /* On CI: Collect trace when retrying the failed test /
-    Locally: always collect trace. See https://playwright.dev/docs/trace-viewer */
-    trace: process.env.CI ? 'retain-on-failure' : 'on',
+    /* Collect trace only for failed tests, both on CI and locally.
+    `trace: 'on'` (always record) was found to make trace export pathologically slow in
+    resource-constrained environments, causing tests to spuriously exceed the test timeout
+    with no clear underlying failure. See https://playwright.dev/docs/trace-viewer */
+    trace: 'retain-on-failure',
   },
 
   snapshotPathTemplate: '{testDir}/{testFileDir}/__screenshots__/{projectName}/{arg}{ext}',

--- a/packages/components/src/components/focustrap/focustrap.component.ts
+++ b/packages/components/src/components/focustrap/focustrap.component.ts
@@ -23,28 +23,28 @@ class FocusTrap extends FocusTrapMixin(Component) {
    *
    * @default false
    */
-  @property({ type: Boolean, reflect: true })
-  disabled: boolean = DEFAULTS.DISABLED;
+  @property({ type: Boolean, reflect: true, attribute: 'trap-disabled' })
+  trapDisabled: boolean = DEFAULTS.TRAP_DISABLED;
 
   /**
    * Implements the abstract `focusTrap` required by `FocusTrapMixin`.
-   * Kept in sync with the public `disabled` property (inverted).
+   * Kept in sync with the public `trapDisabled` property (inverted).
    * @internal
    */
   protected focusTrap: boolean = true;
 
   /**
    * When `true`, disables restoring focus to the previously focused element
-   * when `disable` is set to `true` or the component is disconnected from the DOM.
+   * when `trapDisabled` is set to `true` or the component is disconnected from the DOM.
    * When `false` (default), focus will be restored.
    * @default false
    */
-  @property({ type: Boolean, reflect: true, attribute: 'disable-restore-focus' })
-  disableRestoreFocus: boolean = DEFAULTS.DISABLE_RESTORE_FOCUS;
+  @property({ type: Boolean, reflect: true, attribute: 'restore-focus-disabled' })
+  restoreFocusDisabled: boolean = DEFAULTS.RESTORE_FOCUS_DISABLED;
 
   /**
    * When `true`, the first focusable element inside the container receives focus
-   * automatically when focus trapping is enabled (when `disabled` is `false`).
+   * automatically when focus trapping is enabled (when `trapDisabled` is `false`).
    *
    * @default false
    */
@@ -55,7 +55,7 @@ class FocusTrap extends FocusTrapMixin(Component) {
   private previouslyFocusedElement: HTMLElement | null = null;
 
   override disconnectedCallback() {
-    const shouldRestoreFocus = !this.disabled;
+    const shouldRestoreFocus = !this.trapDisabled;
 
     this.deactivateFocusTrap();
 
@@ -69,11 +69,11 @@ class FocusTrap extends FocusTrapMixin(Component) {
   protected override updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
 
-    if (changedProperties.has('disabled')) {
-      // Keep focusTrap in sync with disabled (inverted)
-      this.focusTrap = !this.disabled;
+    if (changedProperties.has('trapDisabled')) {
+      // Keep focusTrap in sync with trapDisabled (inverted)
+      this.focusTrap = !this.trapDisabled;
 
-      if (!this.disabled) {
+      if (!this.trapDisabled) {
         this.previouslyFocusedElement = (document.activeElement as HTMLElement) ?? null;
         this.activateFocusTrap();
 
@@ -82,7 +82,7 @@ class FocusTrap extends FocusTrapMixin(Component) {
           // at this point, so findFocusable() would find nothing. Defer to the next animation
           // frame, by which time all pending Lit updates have flushed.
           requestAnimationFrame(() => {
-            if (this.autoFocus && !this.disabled) {
+            if (this.autoFocus && !this.trapDisabled) {
               this.setInitialFocus();
             }
           });
@@ -99,10 +99,10 @@ class FocusTrap extends FocusTrapMixin(Component) {
 
   /**
    * Restores focus to the element that was focused before the trap was activated,
-   * if `disableRestoreFocus` is false.
+   * if `restoreFocusDisabled` is false.
    */
   private restorePreviousFocus() {
-    if (!this.disableRestoreFocus && this.previouslyFocusedElement) {
+    if (!this.restoreFocusDisabled && this.previouslyFocusedElement) {
       this.previouslyFocusedElement.focus({ preventScroll: true });
     }
     this.previouslyFocusedElement = null;

--- a/packages/components/src/components/focustrap/focustrap.component.ts
+++ b/packages/components/src/components/focustrap/focustrap.component.ts
@@ -24,11 +24,11 @@ class FocusTrap extends FocusTrapMixin(Component) {
    * @default false
    */
   @property({ type: Boolean, reflect: true })
-  disable: boolean = DEFAULTS.DISABLE;
+  disabled: boolean = DEFAULTS.DISABLED;
 
   /**
    * Implements the abstract `focusTrap` required by `FocusTrapMixin`.
-   * Kept in sync with the public `disable` property (inverted).
+   * Kept in sync with the public `disabled` property (inverted).
    * @internal
    */
   protected focusTrap: boolean = true;
@@ -44,7 +44,7 @@ class FocusTrap extends FocusTrapMixin(Component) {
 
   /**
    * When `true`, the first focusable element inside the container receives focus
-   * automatically when focus trapping is enabled (when `disable` is `false`).
+   * automatically when focus trapping is enabled (when `disabled` is `false`).
    *
    * @default false
    */
@@ -55,7 +55,7 @@ class FocusTrap extends FocusTrapMixin(Component) {
   private previouslyFocusedElement: HTMLElement | null = null;
 
   override disconnectedCallback() {
-    const shouldRestoreFocus = !this.disable;
+    const shouldRestoreFocus = !this.disabled;
 
     this.deactivateFocusTrap();
 
@@ -69,11 +69,11 @@ class FocusTrap extends FocusTrapMixin(Component) {
   protected override updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
 
-    if (changedProperties.has('disable')) {
-      // Keep focusTrap in sync with disable (inverted)
-      this.focusTrap = !this.disable;
+    if (changedProperties.has('disabled')) {
+      // Keep focusTrap in sync with disabled (inverted)
+      this.focusTrap = !this.disabled;
 
-      if (!this.disable) {
+      if (!this.disabled) {
         this.previouslyFocusedElement = (document.activeElement as HTMLElement) ?? null;
         this.activateFocusTrap();
 
@@ -82,7 +82,7 @@ class FocusTrap extends FocusTrapMixin(Component) {
           // at this point, so findFocusable() would find nothing. Defer to the next animation
           // frame, by which time all pending Lit updates have flushed.
           requestAnimationFrame(() => {
-            if (this.autoFocus && !this.disable) {
+            if (this.autoFocus && !this.disabled) {
               this.setInitialFocus();
             }
           });

--- a/packages/components/src/components/focustrap/focustrap.component.ts
+++ b/packages/components/src/components/focustrap/focustrap.component.ts
@@ -1,0 +1,119 @@
+// AI-Assisted
+import { CSSResult, html, PropertyValues } from 'lit';
+import { property } from 'lit/decorators.js';
+
+import { Component } from '../../models';
+import { FocusTrapMixin } from '../../utils/mixins/focus/FocusTrapMixin';
+
+import { DEFAULTS } from './focustrap.constants';
+import styles from './focustrap.styles';
+
+/**
+ * @tagname mdc-focustrap
+ *
+ * @event focus-trap-activated - (React: onFocusTrapActivated) Fired when the focus trap is activated.
+ * @event focus-trap-deactivated - (React: onFocusTrapDeactivated) Fired when the focus trap is deactivated.
+ *
+ * @slot default - Default slot – place any focusable content here.
+ */
+class FocusTrap extends FocusTrapMixin(Component) {
+  /**
+   * When `true`, disables keyboard focus trapping inside this component.
+   * When `false` (default), focus will be trapped.
+   *
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true })
+  disable: boolean = DEFAULTS.DISABLE;
+
+  /**
+   * Implements the abstract `focusTrap` required by `FocusTrapMixin`.
+   * Kept in sync with the public `disable` property (inverted).
+   * @internal
+   */
+  protected focusTrap: boolean = true;
+
+  /**
+   * When `true`, disables restoring focus to the previously focused element
+   * when `disable` is set to `true` or the component is disconnected from the DOM.
+   * When `false` (default), focus will be restored.
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'disable-restore-focus' })
+  disableRestoreFocus: boolean = DEFAULTS.DISABLE_RESTORE_FOCUS;
+
+  /**
+   * When `true`, the first focusable element inside the container receives focus
+   * automatically when focus trapping is enabled (when `disable` is `false`).
+   *
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'auto-focus' })
+  autoFocus: boolean = DEFAULTS.AUTO_FOCUS;
+
+  /** @internal – the element that had focus before the trap was activated */
+  private previouslyFocusedElement: HTMLElement | null = null;
+
+  override disconnectedCallback() {
+    const shouldRestoreFocus = !this.disable;
+
+    this.deactivateFocusTrap();
+
+    if (shouldRestoreFocus) {
+      this.restorePreviousFocus();
+    }
+
+    super.disconnectedCallback();
+  }
+
+  protected override updated(changedProperties: PropertyValues) {
+    super.updated(changedProperties);
+
+    if (changedProperties.has('disable')) {
+      // Keep focusTrap in sync with disable (inverted)
+      this.focusTrap = !this.disable;
+
+      if (!this.disable) {
+        this.previouslyFocusedElement = (document.activeElement as HTMLElement) ?? null;
+        this.activateFocusTrap();
+
+        if (this.autoFocus) {
+          // Slotted children (e.g. mdc-input) may not have completed their own first render yet
+          // at this point, so findFocusable() would find nothing. Defer to the next animation
+          // frame, by which time all pending Lit updates have flushed.
+          requestAnimationFrame(() => {
+            if (this.autoFocus && !this.disable) {
+              this.setInitialFocus();
+            }
+          });
+        }
+
+        this.dispatchEvent(new CustomEvent('focus-trap-activated', { bubbles: true, composed: true }));
+      } else {
+        this.deactivateFocusTrap();
+        this.restorePreviousFocus();
+        this.dispatchEvent(new CustomEvent('focus-trap-deactivated', { bubbles: true, composed: true }));
+      }
+    }
+  }
+
+  /**
+   * Restores focus to the element that was focused before the trap was activated,
+   * if `disableRestoreFocus` is false.
+   */
+  private restorePreviousFocus() {
+    if (!this.disableRestoreFocus && this.previouslyFocusedElement) {
+      this.previouslyFocusedElement.focus({ preventScroll: true });
+    }
+    this.previouslyFocusedElement = null;
+  }
+
+  public override render() {
+    return html`<slot></slot>`;
+  }
+
+  public static override styles: Array<CSSResult> = [...Component.styles, ...styles];
+}
+
+export default FocusTrap;
+// End AI-Assisted

--- a/packages/components/src/components/focustrap/focustrap.constants.ts
+++ b/packages/components/src/components/focustrap/focustrap.constants.ts
@@ -1,0 +1,13 @@
+// AI-Assisted
+import utils from '../../utils/tag-name';
+
+const TAG_NAME = utils.constructTagName('focustrap');
+
+const DEFAULTS = {
+  DISABLE: false,
+  DISABLE_RESTORE_FOCUS: false,
+  AUTO_FOCUS: false,
+};
+
+export { TAG_NAME, DEFAULTS };
+// End AI-Assisted

--- a/packages/components/src/components/focustrap/focustrap.constants.ts
+++ b/packages/components/src/components/focustrap/focustrap.constants.ts
@@ -4,8 +4,8 @@ import utils from '../../utils/tag-name';
 const TAG_NAME = utils.constructTagName('focustrap');
 
 const DEFAULTS = {
-  DISABLED: false,
-  DISABLE_RESTORE_FOCUS: false,
+  TRAP_DISABLED: false,
+  RESTORE_FOCUS_DISABLED: false,
   AUTO_FOCUS: false,
 };
 

--- a/packages/components/src/components/focustrap/focustrap.constants.ts
+++ b/packages/components/src/components/focustrap/focustrap.constants.ts
@@ -4,7 +4,7 @@ import utils from '../../utils/tag-name';
 const TAG_NAME = utils.constructTagName('focustrap');
 
 const DEFAULTS = {
-  DISABLE: false,
+  DISABLED: false,
   DISABLE_RESTORE_FOCUS: false,
   AUTO_FOCUS: false,
 };

--- a/packages/components/src/components/focustrap/focustrap.e2e-test.ts
+++ b/packages/components/src/components/focustrap/focustrap.e2e-test.ts
@@ -4,8 +4,8 @@ import { KEYS } from '../../utils/keys';
 
 type SetupOptions = {
   componentsPage: ComponentsPage;
-  disabled?: boolean;
-  disableRestoreFocus?: boolean;
+  trapDisabled?: boolean;
+  restoreFocusDisabled?: boolean;
   autoFocus?: boolean;
   shouldFocusTrapWrap?: boolean;
 };
@@ -19,8 +19,8 @@ const setup = async (args: SetupOptions) => {
         <button id="before-2">Before 2</button>
         <mdc-focustrap
           id="focustrap"
-          ${restArgs.disabled ? 'disabled' : ''}
-          ${restArgs.disableRestoreFocus ? 'disable-restore-focus' : ''}
+          ${restArgs.trapDisabled ? 'trap-disabled' : ''}
+          ${restArgs.restoreFocusDisabled ? 'restore-focus-disabled' : ''}
           ${restArgs.autoFocus ? 'auto-focus' : ''}
         >
           <button id="inside-1">Inside 1</button>
@@ -65,14 +65,14 @@ test('mdc-focustrap', async ({ componentsPage }) => {
   await test.step('attributes', async () => {
     await test.step('default properties', async () => {
       const { focustrap } = await setup({ componentsPage });
-      await expect(focustrap).not.toHaveAttribute('disabled');
-      await expect(focustrap).not.toHaveAttribute('disable-restore-focus');
+      await expect(focustrap).not.toHaveAttribute('trap-disabled');
+      await expect(focustrap).not.toHaveAttribute('restore-focus-disabled');
       await expect(focustrap).not.toHaveAttribute('auto-focus');
     });
 
-    await test.step('disabled attribute reflects', async () => {
-      const { focustrap } = await setup({ componentsPage, disabled: true });
-      await expect(focustrap).toHaveAttribute('disabled', '');
+    await test.step('trapDisabled attribute reflects', async () => {
+      const { focustrap } = await setup({ componentsPage, trapDisabled: true });
+      await expect(focustrap).toHaveAttribute('trap-disabled', '');
     });
   });
 
@@ -126,8 +126,8 @@ test('mdc-focustrap', async ({ componentsPage }) => {
       await expect(inside1).toBeFocused();
     });
 
-    await test.step('focus is not trapped when disabled is true', async () => {
-      const { before2, inside1, after } = await setup({ componentsPage, disabled: true });
+    await test.step('focus is not trapped when trapDisabled is true', async () => {
+      const { before2, inside1, after } = await setup({ componentsPage, trapDisabled: true });
 
       await before2.focus();
       await componentsPage.page.keyboard.press('Tab');
@@ -156,14 +156,14 @@ test('mdc-focustrap', async ({ componentsPage }) => {
 
   await test.step('restore focus', async () => {
     await test.step('focus is restored to the previously focused element when the trap is deactivated', async () => {
-      const { focustrap, before1, after } = await setup({ componentsPage, disabled: true });
+      const { focustrap, before1, after } = await setup({ componentsPage, trapDisabled: true });
 
       await before1.focus();
       await expect(before1).toBeFocused();
 
       // activating the trap captures `before1` as the previously focused element
       await focustrap.evaluate(el => {
-        el.removeAttribute('disabled');
+        el.removeAttribute('trap-disabled');
       });
 
       // simulate focus moving elsewhere while the trap is active
@@ -172,27 +172,31 @@ test('mdc-focustrap', async ({ componentsPage }) => {
 
       // deactivating the trap should restore focus back to `before1`
       await focustrap.evaluate(el => {
-        el.setAttribute('disabled', '');
+        el.setAttribute('trap-disabled', '');
       });
 
       await expect(before1).toBeFocused();
     });
 
-    await test.step('focus is not restored when disableRestoreFocus is true', async () => {
-      const { focustrap, before1, after } = await setup({ componentsPage, disabled: true, disableRestoreFocus: true });
+    await test.step('focus is not restored when restoreFocusDisabled is true', async () => {
+      const { focustrap, before1, after } = await setup({
+        componentsPage,
+        trapDisabled: true,
+        restoreFocusDisabled: true,
+      });
 
       await before1.focus();
       await expect(before1).toBeFocused();
 
       await focustrap.evaluate(el => {
-        el.removeAttribute('disabled');
+        el.removeAttribute('trap-disabled');
       });
 
       await after.focus();
       await expect(after).toBeFocused();
 
       await focustrap.evaluate(el => {
-        el.setAttribute('disabled', '');
+        el.setAttribute('trap-disabled', '');
       });
 
       await expect(after).toBeFocused();
@@ -200,25 +204,25 @@ test('mdc-focustrap', async ({ componentsPage }) => {
   });
 
   await test.step('events', async () => {
-    await test.step('focus-trap-activated is fired when disable becomes false', async () => {
-      const { focustrap } = await setup({ componentsPage, disabled: true });
+    await test.step('focus-trap-activated is fired when trapDisabled becomes false', async () => {
+      const { focustrap } = await setup({ componentsPage, trapDisabled: true });
 
       const waitForActivated = await componentsPage.waitForEvent(focustrap, 'focus-trap-activated');
 
       await focustrap.evaluate(el => {
-        el.removeAttribute('disabled');
+        el.removeAttribute('trap-disabled');
       });
 
       await expect(waitForActivated).toEventEmitted();
     });
 
-    await test.step('focus-trap-deactivated is fired when disabled becomes true', async () => {
+    await test.step('focus-trap-deactivated is fired when trapDisabled becomes true', async () => {
       const { focustrap } = await setup({ componentsPage });
 
       const waitForDeactivated = await componentsPage.waitForEvent(focustrap, 'focus-trap-deactivated');
 
       await focustrap.evaluate(el => {
-        el.setAttribute('disabled', '');
+        el.setAttribute('trap-disabled', '');
       });
 
       await expect(waitForDeactivated).toEventEmitted();
@@ -227,14 +231,14 @@ test('mdc-focustrap', async ({ componentsPage }) => {
 
   await test.step('disconnect', async () => {
     await test.step('focus is restored when the component is removed from the DOM', async () => {
-      const { focustrap, before1 } = await setup({ componentsPage, disabled: true });
+      const { focustrap, before1 } = await setup({ componentsPage, trapDisabled: true });
 
       await before1.focus();
       await expect(before1).toBeFocused();
 
       // activating the trap captures `before1` as the previously focused element
       await focustrap.evaluate(el => {
-        el.removeAttribute('disabled');
+        el.removeAttribute('trap-disabled');
       });
 
       await componentsPage.page.evaluate(() => {
@@ -253,11 +257,11 @@ test('mdc-focustrap', async ({ componentsPage }) => {
       // otherwise deactivate an already-active trap without reactivating it.
       const { focustrap, before1, before2, inside1, inside2, inside3 } = await setup({
         componentsPage,
-        disabled: true,
+        trapDisabled: true,
       });
       await componentsPage.wrapElement({ wrapperTagName: 'mdc-spatialnavigationprovider' });
       await focustrap.evaluate(el => {
-        el.removeAttribute('disabled');
+        el.removeAttribute('trap-disabled');
       });
       const { keyboard } = componentsPage.page;
 
@@ -297,7 +301,7 @@ test('mdc-focustrap', async ({ componentsPage }) => {
     await test.step('arrow key navigation is not confined when the trap is disabled', async () => {
       const { before1, before2, inside1, inside2, inside3, after } = await setup({
         componentsPage,
-        disabled: true,
+        trapDisabled: true,
       });
       await componentsPage.wrapElement({ wrapperTagName: 'mdc-spatialnavigationprovider' });
       const { keyboard } = componentsPage.page;

--- a/packages/components/src/components/focustrap/focustrap.e2e-test.ts
+++ b/packages/components/src/components/focustrap/focustrap.e2e-test.ts
@@ -1,0 +1,322 @@
+// AI-Assisted
+import { ComponentsPage, test, expect } from '../../../config/playwright/setup';
+import { KEYS } from '../../utils/keys';
+
+type SetupOptions = {
+  componentsPage: ComponentsPage;
+  disable?: boolean;
+  disableRestoreFocus?: boolean;
+  autoFocus?: boolean;
+  shouldFocusTrapWrap?: boolean;
+};
+
+const setup = async (args: SetupOptions) => {
+  const { componentsPage, ...restArgs } = args;
+  await componentsPage.mount({
+    html: `
+      <div id="wrapper" style="display: flex; flex-direction: column; gap: 8px;">
+        <button id="before-1">Before 1</button>
+        <button id="before-2">Before 2</button>
+        <mdc-focustrap
+          id="focustrap"
+          ${restArgs.disable ? 'disable' : ''}
+          ${restArgs.disableRestoreFocus ? 'disable-restore-focus' : ''}
+          ${restArgs.autoFocus ? 'auto-focus' : ''}
+        >
+          <button id="inside-1">Inside 1</button>
+          <button id="inside-2">Inside 2</button>
+          <button id="inside-3">Inside 3</button>
+        </mdc-focustrap>
+        <button id="after">After</button>
+      </div>
+    `,
+    clearDocument: true,
+  });
+
+  await componentsPage.page.locator('div#wrapper').waitFor();
+
+  // `shouldFocusTrapWrap` defaults to `true`, so setting it to `false` cannot be expressed
+  // via a bare boolean attribute in markup (any attribute presence, incl. "false", parses to
+  // true) - it must be set directly via the JS property instead.
+  if (restArgs.shouldFocusTrapWrap === false) {
+    await componentsPage.page.evaluate(() => {
+      const el = document.querySelector('#focustrap') as HTMLElement & { shouldFocusTrapWrap: boolean };
+      el.shouldFocusTrapWrap = false;
+    });
+  }
+
+  return {
+    focustrap: componentsPage.page.locator('#focustrap'),
+    before1: componentsPage.page.locator('#before-1'),
+    before2: componentsPage.page.locator('#before-2'),
+    inside1: componentsPage.page.locator('#inside-1'),
+    inside2: componentsPage.page.locator('#inside-2'),
+    inside3: componentsPage.page.locator('#inside-3'),
+    after: componentsPage.page.locator('#after'),
+  };
+};
+
+test('mdc-focustrap', async ({ componentsPage }) => {
+  await test.step('accessibility', async () => {
+    await setup({ componentsPage });
+    await componentsPage.accessibility.checkForA11yViolations('focustrap-default');
+  });
+
+  await test.step('attributes', async () => {
+    await test.step('default properties', async () => {
+      const { focustrap } = await setup({ componentsPage });
+      await expect(focustrap).not.toHaveAttribute('disable');
+      await expect(focustrap).not.toHaveAttribute('disable-restore-focus');
+      await expect(focustrap).not.toHaveAttribute('auto-focus');
+    });
+
+    await test.step('disable attribute reflects', async () => {
+      const { focustrap } = await setup({ componentsPage, disable: true });
+      await expect(focustrap).toHaveAttribute('disable', '');
+    });
+  });
+
+  await test.step('focus trapping', async () => {
+    await test.step('tab cycles only through elements inside the trap and wraps around', async () => {
+      const { before2, inside1, inside2, inside3 } = await setup({ componentsPage });
+
+      await before2.focus();
+      await componentsPage.page.keyboard.press('Tab');
+      await expect(inside1).toBeFocused();
+
+      await componentsPage.page.keyboard.press('Tab');
+      await expect(inside2).toBeFocused();
+
+      await componentsPage.page.keyboard.press('Tab');
+      await expect(inside3).toBeFocused();
+
+      // wraps back to the first focusable element inside the trap
+      await componentsPage.page.keyboard.press('Tab');
+      await expect(inside1).toBeFocused();
+
+      // shift+tab wraps back to the last focusable element inside the trap
+      await componentsPage.page.keyboard.press('Shift+Tab');
+      await expect(inside3).toBeFocused();
+    });
+
+    await test.step('tab does not wrap when shouldFocusTrapWrap is false', async () => {
+      const { before2, inside1, inside2, inside3 } = await setup({ componentsPage, shouldFocusTrapWrap: false });
+
+      await before2.focus();
+      await componentsPage.page.keyboard.press('Tab');
+      await expect(inside1).toBeFocused();
+
+      await componentsPage.page.keyboard.press('Tab');
+      await expect(inside2).toBeFocused();
+
+      await componentsPage.page.keyboard.press('Tab');
+      await expect(inside3).toBeFocused();
+
+      // stays on the last element instead of wrapping to the first
+      await componentsPage.page.keyboard.press('Tab');
+      await expect(inside3).toBeFocused();
+
+      await componentsPage.page.keyboard.press('Shift+Tab');
+      await expect(inside2).toBeFocused();
+      await componentsPage.page.keyboard.press('Shift+Tab');
+      await expect(inside1).toBeFocused();
+
+      // stays on the first element instead of wrapping to the last
+      await componentsPage.page.keyboard.press('Shift+Tab');
+      await expect(inside1).toBeFocused();
+    });
+
+    await test.step('focus is not trapped when disable is true', async () => {
+      const { before2, inside1, after } = await setup({ componentsPage, disable: true });
+
+      await before2.focus();
+      await componentsPage.page.keyboard.press('Tab');
+      await expect(inside1).toBeFocused();
+
+      await componentsPage.page.keyboard.press('Tab');
+      await componentsPage.page.keyboard.press('Tab');
+      await componentsPage.page.keyboard.press('Tab');
+      await expect(after).toBeFocused();
+    });
+  });
+
+  await test.step('auto focus', async () => {
+    await test.step('first focusable element receives focus automatically when autoFocus is true', async () => {
+      const { inside1 } = await setup({ componentsPage, autoFocus: true });
+      await expect(inside1).toBeFocused();
+    });
+
+    await test.step('focus is not moved automatically when autoFocus is false (default)', async () => {
+      const { before1, inside1 } = await setup({ componentsPage, autoFocus: false });
+      await before1.focus();
+      await expect(before1).toBeFocused();
+      await expect(inside1).not.toBeFocused();
+    });
+  });
+
+  await test.step('restore focus', async () => {
+    await test.step('focus is restored to the previously focused element when the trap is deactivated', async () => {
+      const { focustrap, before1, after } = await setup({ componentsPage, disable: true });
+
+      await before1.focus();
+      await expect(before1).toBeFocused();
+
+      // activating the trap captures `before1` as the previously focused element
+      await focustrap.evaluate(el => {
+        el.removeAttribute('disable');
+      });
+
+      // simulate focus moving elsewhere while the trap is active
+      await after.focus();
+      await expect(after).toBeFocused();
+
+      // deactivating the trap should restore focus back to `before1`
+      await focustrap.evaluate(el => {
+        el.setAttribute('disable', '');
+      });
+
+      await expect(before1).toBeFocused();
+    });
+
+    await test.step('focus is not restored when disableRestoreFocus is true', async () => {
+      const { focustrap, before1, after } = await setup({ componentsPage, disable: true, disableRestoreFocus: true });
+
+      await before1.focus();
+      await expect(before1).toBeFocused();
+
+      await focustrap.evaluate(el => {
+        el.removeAttribute('disable');
+      });
+
+      await after.focus();
+      await expect(after).toBeFocused();
+
+      await focustrap.evaluate(el => {
+        el.setAttribute('disable', '');
+      });
+
+      await expect(after).toBeFocused();
+    });
+  });
+
+  await test.step('events', async () => {
+    await test.step('focus-trap-activated is fired when disable becomes false', async () => {
+      const { focustrap } = await setup({ componentsPage, disable: true });
+
+      const waitForActivated = await componentsPage.waitForEvent(focustrap, 'focus-trap-activated');
+
+      await focustrap.evaluate(el => {
+        el.removeAttribute('disable');
+      });
+
+      await expect(waitForActivated).toEventEmitted();
+    });
+
+    await test.step('focus-trap-deactivated is fired when disable becomes true', async () => {
+      const { focustrap } = await setup({ componentsPage });
+
+      const waitForDeactivated = await componentsPage.waitForEvent(focustrap, 'focus-trap-deactivated');
+
+      await focustrap.evaluate(el => {
+        el.setAttribute('disable', '');
+      });
+
+      await expect(waitForDeactivated).toEventEmitted();
+    });
+  });
+
+  await test.step('disconnect', async () => {
+    await test.step('focus is restored when the component is removed from the DOM', async () => {
+      const { focustrap, before1 } = await setup({ componentsPage, disable: true });
+
+      await before1.focus();
+      await expect(before1).toBeFocused();
+
+      // activating the trap captures `before1` as the previously focused element
+      await focustrap.evaluate(el => {
+        el.removeAttribute('disable');
+      });
+
+      await componentsPage.page.evaluate(() => {
+        document.querySelector('#focustrap')?.remove();
+      });
+
+      await expect(before1).toBeFocused();
+    });
+  });
+
+  await test.step('spatial navigation', async () => {
+    await test.step('arrow key navigation is confined within an active focus trap', async () => {
+      // Mount with the trap initially disabled and activate it only after `wrapElement` has
+      // re-parented the DOM under `mdc-spatialnavigationprovider`. Re-parenting an already
+      // connected custom element triggers disconnectedCallback/connectedCallback, which would
+      // otherwise deactivate an already-active trap without reactivating it.
+      const { focustrap, before1, before2, inside1, inside2, inside3 } = await setup({
+        componentsPage,
+        disable: true,
+      });
+      await componentsPage.wrapElement({ wrapperTagName: 'mdc-spatialnavigationprovider' });
+      await focustrap.evaluate(el => {
+        el.removeAttribute('disable');
+      });
+      const { keyboard } = componentsPage.page;
+
+      // navigate down from outside the trap, into it
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(before1).toBeFocused();
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(before2).toBeFocused();
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(inside1).toBeFocused();
+
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(inside2).toBeFocused();
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(inside3).toBeFocused();
+
+      // reaching the last focusable element inside the trap should not escape to elements
+      // outside of it (e.g. the "after" button)
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(inside3).toBeFocused();
+
+      await keyboard.press(KEYS.ARROW_UP);
+      await expect(inside2).toBeFocused();
+      await keyboard.press(KEYS.ARROW_UP);
+      await expect(inside1).toBeFocused();
+
+      // reaching the first focusable element inside the trap should not escape to elements
+      // outside of it (e.g. the "before-2" button)
+      await keyboard.press(KEYS.ARROW_UP);
+      await expect(inside1).toBeFocused();
+
+      const waitForClick = await componentsPage.waitForEvent(inside1, 'click');
+      await keyboard.press(KEYS.ENTER);
+      await expect(waitForClick).toEventEmitted();
+    });
+
+    await test.step('arrow key navigation is not confined when the trap is disabled', async () => {
+      const { before1, before2, inside1, inside2, inside3, after } = await setup({
+        componentsPage,
+        disable: true,
+      });
+      await componentsPage.wrapElement({ wrapperTagName: 'mdc-spatialnavigationprovider' });
+      const { keyboard } = componentsPage.page;
+
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(before1).toBeFocused();
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(before2).toBeFocused();
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(inside1).toBeFocused();
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(inside2).toBeFocused();
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(inside3).toBeFocused();
+
+      // navigation freely escapes past the (disabled) trap boundary
+      await keyboard.press(KEYS.ARROW_DOWN);
+      await expect(after).toBeFocused();
+    });
+  });
+});
+// End AI-Assisted

--- a/packages/components/src/components/focustrap/focustrap.e2e-test.ts
+++ b/packages/components/src/components/focustrap/focustrap.e2e-test.ts
@@ -4,7 +4,7 @@ import { KEYS } from '../../utils/keys';
 
 type SetupOptions = {
   componentsPage: ComponentsPage;
-  disable?: boolean;
+  disabled?: boolean;
   disableRestoreFocus?: boolean;
   autoFocus?: boolean;
   shouldFocusTrapWrap?: boolean;
@@ -19,7 +19,7 @@ const setup = async (args: SetupOptions) => {
         <button id="before-2">Before 2</button>
         <mdc-focustrap
           id="focustrap"
-          ${restArgs.disable ? 'disable' : ''}
+          ${restArgs.disabled ? 'disabled' : ''}
           ${restArgs.disableRestoreFocus ? 'disable-restore-focus' : ''}
           ${restArgs.autoFocus ? 'auto-focus' : ''}
         >
@@ -65,14 +65,14 @@ test('mdc-focustrap', async ({ componentsPage }) => {
   await test.step('attributes', async () => {
     await test.step('default properties', async () => {
       const { focustrap } = await setup({ componentsPage });
-      await expect(focustrap).not.toHaveAttribute('disable');
+      await expect(focustrap).not.toHaveAttribute('disabled');
       await expect(focustrap).not.toHaveAttribute('disable-restore-focus');
       await expect(focustrap).not.toHaveAttribute('auto-focus');
     });
 
-    await test.step('disable attribute reflects', async () => {
-      const { focustrap } = await setup({ componentsPage, disable: true });
-      await expect(focustrap).toHaveAttribute('disable', '');
+    await test.step('disabled attribute reflects', async () => {
+      const { focustrap } = await setup({ componentsPage, disabled: true });
+      await expect(focustrap).toHaveAttribute('disabled', '');
     });
   });
 
@@ -126,8 +126,8 @@ test('mdc-focustrap', async ({ componentsPage }) => {
       await expect(inside1).toBeFocused();
     });
 
-    await test.step('focus is not trapped when disable is true', async () => {
-      const { before2, inside1, after } = await setup({ componentsPage, disable: true });
+    await test.step('focus is not trapped when disabled is true', async () => {
+      const { before2, inside1, after } = await setup({ componentsPage, disabled: true });
 
       await before2.focus();
       await componentsPage.page.keyboard.press('Tab');
@@ -156,14 +156,14 @@ test('mdc-focustrap', async ({ componentsPage }) => {
 
   await test.step('restore focus', async () => {
     await test.step('focus is restored to the previously focused element when the trap is deactivated', async () => {
-      const { focustrap, before1, after } = await setup({ componentsPage, disable: true });
+      const { focustrap, before1, after } = await setup({ componentsPage, disabled: true });
 
       await before1.focus();
       await expect(before1).toBeFocused();
 
       // activating the trap captures `before1` as the previously focused element
       await focustrap.evaluate(el => {
-        el.removeAttribute('disable');
+        el.removeAttribute('disabled');
       });
 
       // simulate focus moving elsewhere while the trap is active
@@ -172,27 +172,27 @@ test('mdc-focustrap', async ({ componentsPage }) => {
 
       // deactivating the trap should restore focus back to `before1`
       await focustrap.evaluate(el => {
-        el.setAttribute('disable', '');
+        el.setAttribute('disabled', '');
       });
 
       await expect(before1).toBeFocused();
     });
 
     await test.step('focus is not restored when disableRestoreFocus is true', async () => {
-      const { focustrap, before1, after } = await setup({ componentsPage, disable: true, disableRestoreFocus: true });
+      const { focustrap, before1, after } = await setup({ componentsPage, disabled: true, disableRestoreFocus: true });
 
       await before1.focus();
       await expect(before1).toBeFocused();
 
       await focustrap.evaluate(el => {
-        el.removeAttribute('disable');
+        el.removeAttribute('disabled');
       });
 
       await after.focus();
       await expect(after).toBeFocused();
 
       await focustrap.evaluate(el => {
-        el.setAttribute('disable', '');
+        el.setAttribute('disabled', '');
       });
 
       await expect(after).toBeFocused();
@@ -201,24 +201,24 @@ test('mdc-focustrap', async ({ componentsPage }) => {
 
   await test.step('events', async () => {
     await test.step('focus-trap-activated is fired when disable becomes false', async () => {
-      const { focustrap } = await setup({ componentsPage, disable: true });
+      const { focustrap } = await setup({ componentsPage, disabled: true });
 
       const waitForActivated = await componentsPage.waitForEvent(focustrap, 'focus-trap-activated');
 
       await focustrap.evaluate(el => {
-        el.removeAttribute('disable');
+        el.removeAttribute('disabled');
       });
 
       await expect(waitForActivated).toEventEmitted();
     });
 
-    await test.step('focus-trap-deactivated is fired when disable becomes true', async () => {
+    await test.step('focus-trap-deactivated is fired when disabled becomes true', async () => {
       const { focustrap } = await setup({ componentsPage });
 
       const waitForDeactivated = await componentsPage.waitForEvent(focustrap, 'focus-trap-deactivated');
 
       await focustrap.evaluate(el => {
-        el.setAttribute('disable', '');
+        el.setAttribute('disabled', '');
       });
 
       await expect(waitForDeactivated).toEventEmitted();
@@ -227,14 +227,14 @@ test('mdc-focustrap', async ({ componentsPage }) => {
 
   await test.step('disconnect', async () => {
     await test.step('focus is restored when the component is removed from the DOM', async () => {
-      const { focustrap, before1 } = await setup({ componentsPage, disable: true });
+      const { focustrap, before1 } = await setup({ componentsPage, disabled: true });
 
       await before1.focus();
       await expect(before1).toBeFocused();
 
       // activating the trap captures `before1` as the previously focused element
       await focustrap.evaluate(el => {
-        el.removeAttribute('disable');
+        el.removeAttribute('disabled');
       });
 
       await componentsPage.page.evaluate(() => {
@@ -253,11 +253,11 @@ test('mdc-focustrap', async ({ componentsPage }) => {
       // otherwise deactivate an already-active trap without reactivating it.
       const { focustrap, before1, before2, inside1, inside2, inside3 } = await setup({
         componentsPage,
-        disable: true,
+        disabled: true,
       });
       await componentsPage.wrapElement({ wrapperTagName: 'mdc-spatialnavigationprovider' });
       await focustrap.evaluate(el => {
-        el.removeAttribute('disable');
+        el.removeAttribute('disabled');
       });
       const { keyboard } = componentsPage.page;
 
@@ -297,7 +297,7 @@ test('mdc-focustrap', async ({ componentsPage }) => {
     await test.step('arrow key navigation is not confined when the trap is disabled', async () => {
       const { before1, before2, inside1, inside2, inside3, after } = await setup({
         componentsPage,
-        disable: true,
+        disabled: true,
       });
       await componentsPage.wrapElement({ wrapperTagName: 'mdc-spatialnavigationprovider' });
       const { keyboard } = componentsPage.page;

--- a/packages/components/src/components/focustrap/focustrap.stories.ts
+++ b/packages/components/src/components/focustrap/focustrap.stories.ts
@@ -1,0 +1,93 @@
+// AI-Assisted
+import type { Meta, StoryObj, Args } from '@storybook/web-components';
+import '.';
+import { html } from 'lit';
+
+import { classArgType, styleArgType } from '../../../config/storybook/commonArgTypes';
+
+const render = (args: Args) => html`
+  <div>
+    <mdc-button>Before 1</mdc-button>
+    <mdc-button>Before 2</mdc-button>
+    <mdc-focustrap
+      ?disable="${args.disable}"
+      ?disable-restore-focus="${args.disableRestoreFocus}"
+      ?auto-focus="${args.autoFocus}"
+      .shouldFocusTrapWrap="${args.shouldFocusTrapWrap}"
+      class="${args.class}"
+      style="
+        margin: 1rem;
+        padding: 1rem;
+        border: 1px solid var(--mds-color-theme-outline-primary-normal);
+        display: flex;
+        flex-direction: column;
+        gap: 1rem"
+    >
+      <p>Focus trap</p>
+      <mdc-input placeholder="First input"></mdc-input>
+      <mdc-input placeholder="Second input"></mdc-input>
+      <mdc-button appearance="primary">Button</mdc-button>
+      <mdc-linkbutton>Link</mdc-linkbutton>
+    </mdc-focustrap>
+    <mdc-button>After</mdc-button>
+  </div>
+`;
+
+const meta: Meta = {
+  title: 'Components/focustrap',
+  tags: ['autodocs'],
+  component: 'mdc-focustrap',
+  render,
+  argTypes: {
+    disable: {
+      control: 'boolean',
+      description: 'When true, focus trapping is disabled. When false (default), keyboard focus is trapped.',
+    },
+    disableRestoreFocus: {
+      control: 'boolean',
+      description:
+        'When true, focus is NOT restored to the previously focused element when the trap is deactivated. When false (default), focus is restored.',
+    },
+    autoFocus: {
+      control: 'boolean',
+      description: 'When true, the first focusable element receives focus automatically when the trap is activated.',
+    },
+    shouldFocusTrapWrap: {
+      control: 'boolean',
+      description: 'When true (default), Tab wraps from the last focusable element back to the first and vice versa.',
+    },
+    ...classArgType,
+    ...styleArgType,
+  },
+};
+
+export default meta;
+
+export const Example: StoryObj = {
+  args: {
+    disable: false,
+    disableRestoreFocus: false,
+    autoFocus: false,
+    shouldFocusTrapWrap: true,
+  },
+};
+
+export const WithAutoFocus: StoryObj = {
+  args: {
+    disable: false,
+    disableRestoreFocus: false,
+    autoFocus: true,
+    shouldFocusTrapWrap: true,
+  },
+};
+
+export const WithoutWrap: StoryObj = {
+  args: {
+    disable: false,
+    disableRestoreFocus: false,
+    autoFocus: false,
+    shouldFocusTrapWrap: false,
+  },
+};
+
+// End AI-Assisted

--- a/packages/components/src/components/focustrap/focustrap.stories.ts
+++ b/packages/components/src/components/focustrap/focustrap.stories.ts
@@ -10,7 +10,7 @@ const render = (args: Args) => html`
     <mdc-button>Before 1</mdc-button>
     <mdc-button>Before 2</mdc-button>
     <mdc-focustrap
-      ?disable="${args.disable}"
+      ?disabled="${args.disabled}"
       ?disable-restore-focus="${args.disableRestoreFocus}"
       ?auto-focus="${args.autoFocus}"
       .shouldFocusTrapWrap="${args.shouldFocusTrapWrap}"
@@ -39,7 +39,7 @@ const meta: Meta = {
   component: 'mdc-focustrap',
   render,
   argTypes: {
-    disable: {
+    disabled: {
       control: 'boolean',
       description: 'When true, focus trapping is disabled. When false (default), keyboard focus is trapped.',
     },
@@ -65,7 +65,7 @@ export default meta;
 
 export const Example: StoryObj = {
   args: {
-    disable: false,
+    disabled: false,
     disableRestoreFocus: false,
     autoFocus: false,
     shouldFocusTrapWrap: true,
@@ -74,7 +74,7 @@ export const Example: StoryObj = {
 
 export const WithAutoFocus: StoryObj = {
   args: {
-    disable: false,
+    disabled: false,
     disableRestoreFocus: false,
     autoFocus: true,
     shouldFocusTrapWrap: true,
@@ -83,7 +83,7 @@ export const WithAutoFocus: StoryObj = {
 
 export const WithoutWrap: StoryObj = {
   args: {
-    disable: false,
+    disabled: false,
     disableRestoreFocus: false,
     autoFocus: false,
     shouldFocusTrapWrap: false,

--- a/packages/components/src/components/focustrap/focustrap.stories.ts
+++ b/packages/components/src/components/focustrap/focustrap.stories.ts
@@ -10,8 +10,8 @@ const render = (args: Args) => html`
     <mdc-button>Before 1</mdc-button>
     <mdc-button>Before 2</mdc-button>
     <mdc-focustrap
-      ?disabled="${args.disabled}"
-      ?disable-restore-focus="${args.disableRestoreFocus}"
+      ?trap-disabled="${args.trapDisabled}"
+      ?restore-focus-disabled="${args.restoreFocusDisabled}"
       ?auto-focus="${args.autoFocus}"
       .shouldFocusTrapWrap="${args.shouldFocusTrapWrap}"
       class="${args.class}"
@@ -39,11 +39,11 @@ const meta: Meta = {
   component: 'mdc-focustrap',
   render,
   argTypes: {
-    disabled: {
+    trapDisabled: {
       control: 'boolean',
       description: 'When true, focus trapping is disabled. When false (default), keyboard focus is trapped.',
     },
-    disableRestoreFocus: {
+    restoreFocusDisabled: {
       control: 'boolean',
       description:
         'When true, focus is NOT restored to the previously focused element when the trap is deactivated. When false (default), focus is restored.',
@@ -65,8 +65,8 @@ export default meta;
 
 export const Example: StoryObj = {
   args: {
-    disabled: false,
-    disableRestoreFocus: false,
+    trapDisabled: false,
+    restoreFocusDisabled: false,
     autoFocus: false,
     shouldFocusTrapWrap: true,
   },
@@ -74,8 +74,8 @@ export const Example: StoryObj = {
 
 export const WithAutoFocus: StoryObj = {
   args: {
-    disabled: false,
-    disableRestoreFocus: false,
+    trapDisabled: false,
+    restoreFocusDisabled: false,
     autoFocus: true,
     shouldFocusTrapWrap: true,
   },
@@ -83,8 +83,8 @@ export const WithAutoFocus: StoryObj = {
 
 export const WithoutWrap: StoryObj = {
   args: {
-    disabled: false,
-    disableRestoreFocus: false,
+    trapDisabled: false,
+    restoreFocusDisabled: false,
     autoFocus: false,
     shouldFocusTrapWrap: false,
   },

--- a/packages/components/src/components/focustrap/focustrap.styles.ts
+++ b/packages/components/src/components/focustrap/focustrap.styles.ts
@@ -1,0 +1,11 @@
+// AI-Assisted
+import { css } from 'lit';
+
+const styles = css`
+  :host {
+    display: contents;
+  }
+`;
+
+export default [styles];
+// End AI-Assisted

--- a/packages/components/src/components/focustrap/focustrap.types.ts
+++ b/packages/components/src/components/focustrap/focustrap.types.ts
@@ -1,0 +1,17 @@
+// AI-Assisted
+interface Events {
+  /** Fired when the focus trap is activated (React: onFocusTrapActivated) */
+  onFocusTrapActivated: Event;
+  /** Fired when the focus trap is deactivated (React: onFocusTrapDeactivated) */
+  onFocusTrapDeactivated: Event;
+}
+
+declare global {
+  interface GlobalEventHandlersEventMap {
+    focustrapactivated: Event;
+    focustrapdeactivated: Event;
+  }
+}
+
+export type { Events };
+// End AI-Assisted

--- a/packages/components/src/components/focustrap/focustrap.types.ts
+++ b/packages/components/src/components/focustrap/focustrap.types.ts
@@ -1,9 +1,9 @@
 // AI-Assisted
 interface Events {
   /** Fired when the focus trap is activated (React: onFocusTrapActivated) */
-  onFocusTrapActivated: Event;
+  onFocusTrapActivatedEvent: Event;
   /** Fired when the focus trap is deactivated (React: onFocusTrapDeactivated) */
-  onFocusTrapDeactivated: Event;
+  onFocusTrapDeactivatedEvent: Event;
 }
 
 declare global {

--- a/packages/components/src/components/focustrap/index.ts
+++ b/packages/components/src/components/focustrap/index.ts
@@ -1,0 +1,12 @@
+import FocusTrap from './focustrap.component';
+import { TAG_NAME } from './focustrap.constants';
+
+FocusTrap.register(TAG_NAME);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    ['mdc-focustrap']: FocusTrap;
+  }
+}
+
+export default FocusTrap;

--- a/packages/components/src/components/focustrap/knowledge-base/focustrap.component.md
+++ b/packages/components/src/components/focustrap/knowledge-base/focustrap.component.md
@@ -30,7 +30,7 @@ FocusTrap is a container component that manages keyboard focus within a specifie
 Import and use the `<mdc-focustrap>` web component to wrap any focusable content:
 
 ```html
-<mdc-focustrap disable="false" auto-focus="false">
+<mdc-focustrap disabled="false" auto-focus="false">
   <input type="text" placeholder="First input" />
   <input type="text" placeholder="Second input" />
   <button>Submit</button>
@@ -48,7 +48,7 @@ export function MyModal() {
   return (
     isOpen && (
       <FocusTrap
-        disable={false}
+        disabled={false}
         disableRestoreFocus={false}
         autoFocus={true}
       >
@@ -66,7 +66,7 @@ export function MyModal() {
 
 ### Property/Attribute details
 
-- **`disable`** (boolean, default: `false`)  
+- **`disabled`** (boolean, default: `false`)  
   When `true`, focus trapping is disabled. When `false`, focus is trapped within the component. This is the inverse of the `contain` prop in `@react-aria/focus`.
 
 - **`disable-restore-focus` / `disableRestoreFocus`** (boolean, default: `false`)  
@@ -116,7 +116,7 @@ FocusTrap itself does not require a label. However, the container and its conten
 ```html
 <div role="dialog" aria-labelledby="dialog-title" aria-modal="true">
   <h2 id="dialog-title">Confirm Action</h2>
-  <mdc-focustrap disable="false" auto-focus="true">
+  <mdc-focustrap disabled="false" auto-focus="true">
     <p>Are you sure?</p>
     <button>Cancel</button>
     <button class="primary">Confirm</button>

--- a/packages/components/src/components/focustrap/knowledge-base/focustrap.component.md
+++ b/packages/components/src/components/focustrap/knowledge-base/focustrap.component.md
@@ -1,0 +1,135 @@
+---
+title: FocusTrap
+summary: Traps keyboard focus within a container, preventing users from tabbing outside its bounds and ensuring focus is restored when the trap is deactivated.
+tier: 3
+component: focustrap
+---
+
+## Overview
+
+FocusTrap is a container component that manages keyboard focus within a specified region. It prevents focus from moving outside the container via Tab/Shift+Tab and optionally restores focus to the previously focused element when the trap is deactivated. Commonly used in modals, dialogs, popovers, and other overlay patterns to improve accessibility and user experience.
+
+### When to use
+
+- **Custom Modals and dialogs** – Trap focus so users interact only with the dialog content.
+- **Custom Popovers and menus** – Keep focus within an overlay component.
+- **Custom Dropdown menus** – Ensure focus stays within menu options while open.
+- **Multi-step forms** – Control focus flow between steps or sub-sections.
+- **Accessible disclosure widgets** – Any collapsible or hidden content that should capture focus when revealed.
+
+### When not to use
+
+- **Full-page navigation** – Do not trap focus on the main page; only use on transient overlays.
+- **Optional or advisory overlays** – If users can dismiss the overlay and continue with the page, consider whether focus trapping is necessary.
+- **Nested focus traps** – Avoid nesting multiple FocusTrap instances; the innermost trap will dominate focus behavior. MDC Dialog, popover and menu components already implement FocusTrap internally, so wrapping them in another FocusTrap is unnecessary and may cause unexpected behavior.
+
+## Guidelines
+
+### Developer usage
+
+Import and use the `<mdc-focustrap>` web component to wrap any focusable content:
+
+```html
+<mdc-focustrap disable="false" auto-focus="false">
+  <input type="text" placeholder="First input" />
+  <input type="text" placeholder="Second input" />
+  <button>Submit</button>
+</mdc-focustrap>
+```
+
+**React / TypeScript integration:**
+
+```tsx
+import { FocusTrap } from '@momentum-design/components/react';
+
+export function MyModal() {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    isOpen && (
+      <FocusTrap
+        disable={false}
+        disableRestoreFocus={false}
+        autoFocus={true}
+      >
+        <h2>Modal Title</h2>
+        <input type="text" placeholder="Name" />
+        <button onClick={() => setIsOpen(false)}>Close</button>
+      </FocusTrap>
+    )
+  );
+}
+```
+
+**Package import:** `@momentum-design/components`  
+**Custom element tag:** `mdc-focustrap`
+
+### Property/Attribute details
+
+- **`disable`** (boolean, default: `false`)  
+  When `true`, focus trapping is disabled. When `false`, focus is trapped within the component. This is the inverse of the `contain` prop in `@react-aria/focus`.
+
+- **`disable-restore-focus` / `disableRestoreFocus`** (boolean, default: `false`)  
+  When `true`, focus is not restored to the previously focused element when the trap is deactivated or the component is removed from the DOM. When `false`, focus returns to the element that had focus before the trap was activated.
+
+- **`auto-focus` / `autoFocus`** (boolean, default: `false`)  
+  When `true`, the first focusable element inside the container automatically receives focus when focus trapping is enabled. When `false`, no automatic focus is set.
+
+- **`should-focus-trap-wrap` / `shouldFocusTrapWrap`** (boolean, default: `true`)  
+  When `true` (default), Tab from the last focusable element wraps to the first, and Shift+Tab from the first wraps to the last. When `false`, Tab/Shift+Tab does not wrap; focus exits the trap.
+
+### Limitations
+
+- **Single trap per overlay** – Multiple nested FocusTrap instances may produce unexpected behavior. Only the innermost trap will fully control focus.
+- **Required focusable content** – The FocusTrap requires at least one focusable element (button, input, link, etc.) inside it. An empty or content-only container has no effect.
+- **Focus management outside content** – The trap manages focus within its slot content only. External DOM elements or adjacent overlays are not affected.
+- **Slotted content only** – The FocusTrap does not trap focus on direct child elements added programmatically after render; slot-based content is required.
+
+### Notes
+
+FocusTrap is built on the `FocusTrapMixin` utility and is designed to complement accessible overlay patterns. For complex focus scenarios (such as multiple overlays or programmatic focus control), consider pairing with higher-level patterns or frameworks. Focus restoration respects the `disableRestoreFocus` flag and is automatically triggered on component disconnect.
+
+## Accessibility
+
+### Built-in features
+
+- **Focus containment** – Prevents keyboard navigation from leaving the trap boundaries, ensuring users remain focused on the intended content.
+- **Focus wrapping** – By default, Tab from the last focusable element returns to the first, and vice versa, creating a continuous focus cycle.
+- **Focus restoration** – Restores focus to the previously focused element when the trap is deactivated (unless `disableRestoreFocus` is `true`), maintaining context for screen-reader users and sighted users alike.
+
+#### Internal ARIA managed by the component
+
+The FocusTrap component does not apply ARIA roles or properties itself. It relies on semantic HTML and standard focus behavior. The consumer must ensure focusable elements inside the trap have appropriate roles and labels.
+
+### Implementation requirements
+
+#### Labelling
+
+FocusTrap itself does not require a label. However, the container and its content must follow standard labelling practices:
+
+- **Modal dialogs** – Use `role="dialog"` on a wrapper element and include `aria-labelledby` pointing to the dialog's title.
+- **Popover or menu** – Use `role="menu"` or similar, with `aria-label` or `aria-labelledby` as appropriate.
+- **Focusable children** – Ensure all interactive children (buttons, inputs, links) have visible or accessible labels via `<label>`, `aria-label`, or `aria-labelledby`.
+
+**Example with proper semantics:**
+
+```html
+<div role="dialog" aria-labelledby="dialog-title" aria-modal="true">
+  <h2 id="dialog-title">Confirm Action</h2>
+  <mdc-focustrap disable="false" auto-focus="true">
+    <p>Are you sure?</p>
+    <button>Cancel</button>
+    <button class="primary">Confirm</button>
+  </mdc-focustrap>
+</div>
+```
+
+#### General
+
+- Ensure the context in which FocusTrap is used (e.g., a modal overlay) is semantically marked with `role="dialog"`, `role="menu"`, or another appropriate role.
+- Provide a way for users to dismiss or deactivate the focus trap (e.g., a Close button or Escape key handler), and restore focus to the triggering element on dismissal.
+- Test focus behavior with keyboard navigation and screen readers to verify that focus enters, cycles, and exits the trap as expected.
+
+### Notes
+
+Focus trapping is a critical accessibility pattern for overlays and modals. Always test with actual assistive technology (NVDA, JAWS, VoiceOver) to ensure focus announcements and navigation feel natural. Pair FocusTrap with semantic markup and appropriate ARIA roles to provide the full accessibility contract.

--- a/packages/components/src/components/focustrap/knowledge-base/focustrap.component.md
+++ b/packages/components/src/components/focustrap/knowledge-base/focustrap.component.md
@@ -30,7 +30,7 @@ FocusTrap is a container component that manages keyboard focus within a specifie
 Import and use the `<mdc-focustrap>` web component to wrap any focusable content:
 
 ```html
-<mdc-focustrap disabled="false" auto-focus="false">
+<mdc-focustrap trap-disabled="false" auto-focus="false">
   <input type="text" placeholder="First input" />
   <input type="text" placeholder="Second input" />
   <button>Submit</button>
@@ -48,8 +48,8 @@ export function MyModal() {
   return (
     isOpen && (
       <FocusTrap
-        disabled={false}
-        disableRestoreFocus={false}
+        trapDisabled={false}
+        restoreFocusDisabled={false}
         autoFocus={true}
       >
         <h2>Modal Title</h2>
@@ -66,10 +66,10 @@ export function MyModal() {
 
 ### Property/Attribute details
 
-- **`disabled`** (boolean, default: `false`)  
+- **`trap-disabled` / `trapDisabled`** (boolean, default: `false`)  
   When `true`, focus trapping is disabled. When `false`, focus is trapped within the component. This is the inverse of the `contain` prop in `@react-aria/focus`.
 
-- **`disable-restore-focus` / `disableRestoreFocus`** (boolean, default: `false`)  
+- **`restore-focus-disabled` / `restoreFocusDisabled`** (boolean, default: `false`)  
   When `true`, focus is not restored to the previously focused element when the trap is deactivated or the component is removed from the DOM. When `false`, focus returns to the element that had focus before the trap was activated.
 
 - **`auto-focus` / `autoFocus`** (boolean, default: `false`)  
@@ -87,7 +87,7 @@ export function MyModal() {
 
 ### Notes
 
-FocusTrap is built on the `FocusTrapMixin` utility and is designed to complement accessible overlay patterns. For complex focus scenarios (such as multiple overlays or programmatic focus control), consider pairing with higher-level patterns or frameworks. Focus restoration respects the `disableRestoreFocus` flag and is automatically triggered on component disconnect.
+FocusTrap is built on the `FocusTrapMixin` utility and is designed to complement accessible overlay patterns. For complex focus scenarios (such as multiple overlays or programmatic focus control), consider pairing with higher-level patterns or frameworks. Focus restoration respects the `restoreFocusDisabled` flag and is automatically triggered on component disconnect.
 
 ## Accessibility
 
@@ -95,7 +95,7 @@ FocusTrap is built on the `FocusTrapMixin` utility and is designed to complement
 
 - **Focus containment** – Prevents keyboard navigation from leaving the trap boundaries, ensuring users remain focused on the intended content.
 - **Focus wrapping** – By default, Tab from the last focusable element returns to the first, and vice versa, creating a continuous focus cycle.
-- **Focus restoration** – Restores focus to the previously focused element when the trap is deactivated (unless `disableRestoreFocus` is `true`), maintaining context for screen-reader users and sighted users alike.
+- **Focus restoration** – Restores focus to the previously focused element when the trap is deactivated (unless `restoreFocusDisabled` is `true`), maintaining context for screen-reader users and sighted users alike.
 
 #### Internal ARIA managed by the component
 
@@ -116,7 +116,7 @@ FocusTrap itself does not require a label. However, the container and its conten
 ```html
 <div role="dialog" aria-labelledby="dialog-title" aria-modal="true">
   <h2 id="dialog-title">Confirm Action</h2>
-  <mdc-focustrap disabled="false" auto-focus="true">
+  <mdc-focustrap trap-disabled="false" auto-focus="true">
     <p>Are you sure?</p>
     <button>Cancel</button>
     <button class="primary">Confirm</button>

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -93,6 +93,7 @@ import Banner from './components/banner';
 import Buttonsimple from './components/buttonsimple';
 import Verticaltablist from './components/verticaltablist';
 import StatusMessage from './components/statusmessage';
+import FocusTrap from './components/focustrap';
 
 // Types Imports
 import type { AvatarSize } from './components/avatar/avatar.types';
@@ -240,6 +241,7 @@ export {
   Buttonsimple,
   Verticaltablist,
   StatusMessage,
+  FocusTrap,
 };
 
 // Types Exports

--- a/packages/components/src/utils/mixins/focus/FocusTrapMixin.ts
+++ b/packages/components/src/utils/mixins/focus/FocusTrapMixin.ts
@@ -178,6 +178,14 @@ export const FocusTrapMixin = <T extends Constructor<Component>>(superClass: T) 
       }
       const activeElement = this.getDeepActiveElement!() as HTMLElement;
       const activeIndex = this.findElement(activeElement);
+
+      // If focus currently sits outside this trap's focusable elements (e.g. on a sibling
+      // element in the document), do not hijack Tab navigation - let the browser's default
+      // behavior move focus naturally, including into the trap.
+      if (activeIndex === -1) {
+        return;
+      }
+
       const direction = event.shiftKey;
 
       if (direction) {

--- a/packages/components/src/utils/mixins/focus/FocusTrapStack.ts
+++ b/packages/components/src/utils/mixins/focus/FocusTrapStack.ts
@@ -29,6 +29,7 @@ export class FocusTrapStack {
   private static removeKeydownListener() {
     if (this.currentKeydownListener) {
       document.removeEventListener('keydown', this.currentKeydownListener);
+      this.currentKeydownListener = null;
     }
   }
 


### PR DESCRIPTION
### Description

Implement Focus trap component

FocusTrap is a container component that manages keyboard focus within a specified region. It prevents focus from moving outside the container via Tab/Shift+Tab and optionally restores focus to the previously focused element when the trap is deactivated. Commonly used in modals, dialogs, popovers, and other overlay patterns to improve accessibility and user experience. 
This component is in addition to the existing dialog, popover components, which have the focus trap already built in.

breaking change: none
