### PR TITLE
fix(ci): failing checkout actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -118,6 +118,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
@@ -157,6 +158,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
@@ -198,6 +200,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
@@ -236,6 +239,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
@@ -270,6 +274,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
@@ -310,6 +315,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
@@ -350,6 +356,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
@@ -394,6 +401,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'


### PR DESCRIPTION
### Description

Github changed pull_request_target checkout's security polocies

As a quick fix we can turn off the new policy, becase our pipiline is safeguarded with explicit labelling from the core team.

more deatils in the github announcmnet:
https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/

breaking change: none
