### PR TITLE
fix(toast): update more/less button when the header-text is updated

### DIFF
--- a/packages/components/src/components/toast/toast.component.ts
+++ b/packages/components/src/components/toast/toast.component.ts
@@ -166,16 +166,18 @@ class Toast extends FooterMixin(Component) {
     super.firstUpdated(changedProperties);
     this.updateDetailedSlotPresence();
     this.updateDataExpanded();
-
-    await this.updateComplete;
-    if (hasOverflowMixin(this.headerTextElement)) {
-      this.hasOverflowingHeaderText = this.headerTextElement.isHeightOverflowing();
-    }
   }
 
-  protected override updated(changedProperties: PropertyValues): void {
+  protected override async updated(changedProperties: PropertyValues): Promise<void> {
     if (changedProperties.has('showMoreText') || changedProperties.has('showLessText')) {
       this.updateDataExpanded();
+    }
+
+    if (changedProperties.has('headerText')) {
+      await this.updateComplete;
+      if (hasOverflowMixin(this.headerTextElement)) {
+        this.hasOverflowingHeaderText = this.headerTextElement.isHeightOverflowing();
+      }
     }
   }
 

--- a/packages/components/src/components/toast/toast.e2e-test.ts
+++ b/packages/components/src/components/toast/toast.e2e-test.ts
@@ -506,11 +506,34 @@ test.describe('Toast Feature Scenarios', () => {
       }
     });
 
+    await test.step('Toast updates toggle button visibility when header-text attribute changes', async () => {
+      // Start with a long title — toggle button should be visible
+      const toast = await setup({
+        componentsPage,
+        headerText: LONG_HEADER_TEXT,
+        headerTagName: 'span',
+        closeButtonAriaLabel: 'Close toast',
+        showMoreText: SHOW_MORE_TEXT,
+        showLessText: SHOW_LESS_TEXT,
+      });
+
+      const toggleBtn = toast.locator('mdc-button[part="footer-button-toggle"]');
+      await expect(toggleBtn).toBeVisible();
+
+      // Update to a short title — toggle button should be hidden
+      await toast.evaluate(el => el.setAttribute('header-text', 'Short title'));
+      await expect(toggleBtn).not.toBeVisible();
+
+      // Update back to a long title — toggle button should be visible again
+      await toast.evaluate((el, text) => el.setAttribute('header-text', text), LONG_HEADER_TEXT);
+      await expect(toggleBtn).toBeVisible();
+    });
+
     for (const [headerTextDescription, headerText] of [
       ['long', LONG_HEADER_TEXT],
       ['very-long', VERY_LONG_HEADER_TEXT],
     ]) {
-      await test.step('User expands/collapses toast title with keyboard', async () => {
+      await test.step(`User expands/collapses toast title with keyboard (${headerTextDescription})`, async () => {
         const toast = await setup({
           componentsPage,
           headerText,

--- a/packages/components/src/components/toast/toast.stories.ts
+++ b/packages/components/src/components/toast/toast.stories.ts
@@ -8,11 +8,15 @@ import '../avatar';
 import '../spinner';
 import '../button';
 
+import { createRef, ref } from 'lit/directives/ref.js';
+
 import { classArgType, styleArgType } from '../../../config/storybook/commonArgTypes';
 import { disableControls, hideAllControls, hideControls } from '../../../config/storybook/utils';
 import { VALID_TEXT_TAGS } from '../text/text.constants';
 
 import { TOAST_VARIANT } from './toast.constants';
+
+import type Toast from '.';
 
 const render = (args: Args) => html`
   <mdc-toast
@@ -137,6 +141,42 @@ export const LongTitleWithoutToggle: StoryObj = {
     'header-text':
       'This is a very long toast title of more than 6 lines that should overflow without the show more/less functionality. Once 6 lines is reached, this will truncate regardless of the length of the content to prevent the toast from taking up too much space.',
     'close-button-aria-label': 'Close toast',
+  },
+};
+
+export const DynamicShortLongTitle: StoryObj = {
+  name: 'Dynamic Short/Long Title',
+  render: () => {
+    const longTitle =
+      'This is a very long toast title of more than 3 lines that should overflow and trigger the show more/less functionality. Once 6 lines is reached, this will truncate regardless of the length of the content to prevent the toast from taking up too much space.';
+    const shortTitle = 'Short Title';
+
+    const toastRef = createRef<Toast>();
+
+    return html`
+      <mdc-toast
+        ${ref(toastRef)}
+        variant="success"
+        header-tag-name="span"
+        header-text=${longTitle}
+        show-more-text="Show more"
+        show-less-text="Show less"
+        close-button-aria-label="Close toast"
+      >
+      </mdc-toast>
+      <mdc-button
+        @click=${() => {
+          toastRef.value?.setAttribute('header-text', shortTitle);
+        }}
+        >Short Title</mdc-button
+      >
+      <mdc-button
+        @click=${() => {
+          toastRef.value?.setAttribute('header-text', longTitle);
+        }}
+        >Long Title</mdc-button
+      >
+    `;
   },
 };
 

--- a/packages/components/src/components/toast/toast.stories.ts
+++ b/packages/components/src/components/toast/toast.stories.ts
@@ -1,14 +1,13 @@
 import type { Meta, StoryObj, Args } from '@storybook/web-components';
 import { html } from 'lit';
-import { ifDefined } from 'lit/directives/if-defined.js';
 import { action } from 'storybook/actions';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { createRef, ref } from 'lit/directives/ref.js';
 
 import '.';
 import '../avatar';
 import '../spinner';
 import '../button';
-
-import { createRef, ref } from 'lit/directives/ref.js';
 
 import { classArgType, styleArgType } from '../../../config/storybook/commonArgTypes';
 import { disableControls, hideAllControls, hideControls } from '../../../config/storybook/utils';


### PR DESCRIPTION
### Description

- toast: when header-text is updated, recheck whether the show more/less button needs to be displayed

### Breaking Change

None
