### PR TITLE
fix(presence): presence component update

### DIFF
--- a/packages/components/src/components/presence/presence.component.ts
+++ b/packages/components/src/components/presence/presence.component.ts
@@ -138,6 +138,7 @@ class Presence extends Component {
           part="mdc-presence-icon mdc-presence-icon__${this.currentIconType}"
           name="${this.icon}"
           size="${getPresenceIconSize(this.size)}"
+          length-unit="rem"
           @load="${this.handleOnLoad}"
           @error="${this.handleOnError}"
         ></mdc-icon>

--- a/packages/components/src/components/presence/presence.e2e-test.ts
+++ b/packages/components/src/components/presence/presence.e2e-test.ts
@@ -78,6 +78,19 @@ const testToRun = async (componentsPage: ComponentsPage) => {
       await expect(presence).toHaveAttribute('type', PRESENCE_TYPE.MEETING);
       await expect(presence).toHaveAttribute('size', PRESENCE_SIZE[124].toString());
     });
+
+    await test.step('should render inner icon with rem length unit and computed size', async () => {
+      const presenceWithIcon = await setup({
+        componentsPage,
+        type: PRESENCE_TYPE.DND,
+        size: PRESENCE_SIZE[32],
+      });
+      const icon = presenceWithIcon.locator('mdc-icon');
+      await icon.waitFor();
+
+      await expect(icon).toHaveAttribute('length-unit', 'rem');
+      await expect(icon).toHaveAttribute('style', '--computed-icon-size: 0.875rem;');
+    });
   });
 };
 


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

Locked sizing of avatar presence icon to rem to fix rendering issue in some products. 

I noticed that in a product consuming Momentum, the presence icon was being rendered incorrectly at certain sizes. I tracked the bug to be an alignment of the size of the icon to "em" instead of "rem". 

I locked the size at the component level to "rem" so it wouldn't inherit an "em" value from its parent accidentally.

