### PR TITLE
fix(iconProvider): updating default sizing to rem instead of em

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ figma-webcomponent.config.json
 
 # copilot plan mode
 plan.md
+
+# Context Documentation
+.docs/*

--- a/packages/components/src/components/iconprovider/iconprovider.constants.ts
+++ b/packages/components/src/components/iconprovider/iconprovider.constants.ts
@@ -14,7 +14,7 @@ const LENGTH_UNIT_SIZE = {
 const DEFAULTS = {
   FILE_EXTENSION: 'svg',
   LENGTH_UNIT: 'rem',
-  SIZE: LENGTH_UNIT_SIZE.em,
+  SIZE: LENGTH_UNIT_SIZE.rem,
   ICON_SET: 'momentum-icons',
 } as const;
 

--- a/packages/components/src/components/iconprovider/iconprovider.constants.ts
+++ b/packages/components/src/components/iconprovider/iconprovider.constants.ts
@@ -13,7 +13,7 @@ const LENGTH_UNIT_SIZE = {
 
 const DEFAULTS = {
   FILE_EXTENSION: 'svg',
-  LENGTH_UNIT: 'em',
+  LENGTH_UNIT: 'rem',
   SIZE: LENGTH_UNIT_SIZE.em,
   ICON_SET: 'momentum-icons',
 } as const;

--- a/packages/components/src/components/iconprovider/iconprovider.stories.ts
+++ b/packages/components/src/components/iconprovider/iconprovider.stories.ts
@@ -62,7 +62,7 @@ export const Example: StoryObj = {
     'icon-set': 'momentum-icons',
     url: './icons/svg',
     'file-extension': 'svg',
-    'length-unit': 'em',
+    'length-unit': 'rem',
     'cache-strategy': undefined,
     'cache-name': 'my-icon-cache',
     size: 1,

--- a/packages/components/src/components/iconprovider/knowledge-base/iconprovider.component.md
+++ b/packages/components/src/components/iconprovider/knowledge-base/iconprovider.component.md
@@ -67,7 +67,7 @@ Custom icons (fetched over HTTP from a URL the consumer hosts):
 | `icon-set` | `momentum-icons` (default, dynamic import from the package) or `custom-icons` (fetched from `url`). Pick `custom-icons` when icons live in your own asset bundle. |
 | `url` | Base URL icons are fetched from. Required when `icon-set="custom-icons"`. |
 | `file-extension` | Extension appended to the icon `name` when fetching. Default `svg`; allow-listed, invalid values fall back to the default. |
-| `length-unit` | CSS length unit (`em`, `rem`, `px`, `%`) applied with `size` on every nested icon. Default `em`; allow-listed. |
+| `length-unit` | CSS length unit (`em`, `rem`, `px`, `%`) applied with `size` on every nested icon. Default `rem`; allow-listed. |
 | `size` | Default numeric size for nested icons that do not set their own. Default `1`. |
 | `cache-strategy` | `in-memory-cache` or `web-cache-api` (HTTPS only). Applies only to `custom-icons`. Default off. |
 | `cache-name` | Cache name used by `cache-strategy`; required when it is set and must be unique across the app's caches. |

--- a/packages/components/src/components/iconprovider/knowledge-base/iconprovider.component.md
+++ b/packages/components/src/components/iconprovider/knowledge-base/iconprovider.component.md
@@ -69,7 +69,7 @@ The iconprovider does not render any visible UI of its own — it only acts as a
 - `icon-set` — `momentum-icons` (default) for dynamic import from the `@momentum-design/icons` package, or `custom-icons` for fetch from `url`.
 - `url` — base URL from which icons are fetched. Required when `icon-set="custom-icons"`.
 - `file-extension` — extension appended to the icon `name` when fetching. Default `svg`. Restricted to an allow-list; invalid values fall back to the default.
-- `length-unit` — CSS length unit (`em`, `rem`, `px`, etc.) used together with `size` on every nested `mdc-icon`. Default `em`. Restricted to an allow-list; invalid values fall back to the default.
+- `length-unit` — CSS length unit (`em`, `rem`, `px`, etc.) used together with `size` on every nested `mdc-icon`. Default `rem`. Restricted to an allow-list; invalid values fall back to the default.
 - `size` — numeric default size for every nested `mdc-icon` when the icon does not set its own `size`. Default `1`.
 - `cache-strategy` — `in-memory-cache` (JS in-memory) or `web-cache-api` (browser Cache API; HTTPS only). Only applies when `icon-set="custom-icons"`. Default unset (no caching).
 - `cache-name` — name of the cache used by `cache-strategy`. Required when `cache-strategy` is set; must be unique across the app's caches.

--- a/packages/components/src/components/progressspinner/progressspinner.constants.ts
+++ b/packages/components/src/components/progressspinner/progressspinner.constants.ts
@@ -10,7 +10,7 @@ const DEFAULTS = {
   GAP_SIZE: 7.5, // Gap size between the spinner and the track
   ERROR_ICON_SIZE: 2,
   SUCCESS_ICON_SIZE: 3,
-  ICON_LENGTH_UNIT: 'em',
+  ICON_LENGTH_UNIT: 'rem',
 } as const;
 
 const ICON_NAME = {

--- a/packages/components/src/tsconfig.json
+++ b/packages/components/src/tsconfig.json
@@ -5,7 +5,7 @@
     "tsBuildInfoFile": null,
     "target": "es2019",
     "module": "ES2020",
-    "lib": ["es2020", "DOM", "DOM.Iterable", "ES2021.WeakRef"],
+    "lib": ["es2020", "ES2022.Array", "DOM", "DOM.Iterable", "ES2021.WeakRef"],
     "declaration": true,
     "declarationMap": false,
     "declarationDir": "../dist",


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

Investigating an icon rendering issue in a product consuming Momentum. Found that the default sizing of the icon provider is set to "em". This breaks our sizing conventions and architecture in Momentum, everything is based on "rem".

### Breaking Change

This is a breaking change. 
