### PR TITLE
docs(assets): Tier 2 guidelines for illustrations, animations, and brand visuals

### DIFF
--- a/knowledge-base/index.packages.json
+++ b/knowledge-base/index.packages.json
@@ -25,7 +25,7 @@
       "tier": 2,
       "path": "packages/assets/illustrations/knowledge-base/illustrations.md",
       "title": "Illustrations",
-      "summary": "Guidance for Momentum's illustration library — SVG illustrations, when to use them, how to consume them via mdc-illustration and mdc-illustrationprovider, and accessibility.",
+      "summary": "Guidance for Momentum's illustration library — style principles, when to use, sizing and colour, consumption via mdc-illustration and mdc-illustrationprovider, and accessibility.",
       "canonical": null
     },
     {

--- a/knowledge-base/index.packages.json
+++ b/knowledge-base/index.packages.json
@@ -5,6 +5,30 @@
   "tier": 2,
   "topics": [
     {
+      "id": "tier2/packages/assets/animations/knowledge-base/animations",
+      "tier": 2,
+      "path": "packages/assets/animations/knowledge-base/animations.md",
+      "title": "Animations",
+      "summary": "Guidance for Momentum's animation assets — Lottie/SVG animations, what the library contains, how to consume them via mdc-animation, and how they differ from motion tokens.",
+      "canonical": null
+    },
+    {
+      "id": "tier2/packages/assets/brand-visuals/knowledge-base/brand-visuals",
+      "tier": 2,
+      "path": "packages/assets/brand-visuals/knowledge-base/brand-visuals.md",
+      "title": "Brand visuals",
+      "summary": "Guidance for Momentum's brand-visuals library — approved logos, wordmarks, and imagery, how to consume them via mdc-brandvisual, and the criteria for inclusion.",
+      "canonical": null
+    },
+    {
+      "id": "tier2/packages/assets/illustrations/knowledge-base/illustrations",
+      "tier": 2,
+      "path": "packages/assets/illustrations/knowledge-base/illustrations.md",
+      "title": "Illustrations",
+      "summary": "Guidance for Momentum's illustration library — SVG illustrations, when to use them, how to consume them via mdc-illustration and mdc-illustrationprovider, and accessibility.",
+      "canonical": null
+    },
+    {
       "id": "tier2/packages/components/knowledge-base/snowflake-components",
       "tier": 2,
       "path": "packages/components/knowledge-base/snowflake-components.md",

--- a/packages/assets/animations/knowledge-base/animations.md
+++ b/packages/assets/animations/knowledge-base/animations.md
@@ -1,0 +1,103 @@
+---
+title: Animations
+summary: Guidance for Momentum's animation assets — Lottie/SVG animations, what the library contains, how to consume them via mdc-animation, and how they differ from motion tokens.
+tier: 2
+---
+
+# Animations
+
+Guidance for **product designers and developers** working with the Momentum
+animation library (`@momentum-design/animations`). This article explains what the
+library contains, how animated assets are consumed, and how animation *assets*
+differ from motion *tokens*.
+
+## What the animations library is
+
+`@momentum-design/animations` ships pre-authored animated assets — **Lottie**
+JSON files and a small set of animated **SVG**s. Consumers load an asset by name
+(or URL) and render it; the package distributes the source files, it does not
+draw the animation itself.
+
+Lottie is the primary format: vector animations exported to JSON and played by a
+Lottie renderer. Use animated assets for short, self-contained motion — loading
+states, empty/success states, and small narrative moments — not for the timing of
+UI state changes (that is motion tokens; see below).
+
+## Animations versus motion tokens
+
+These are two different systems in two different packages — do not conflate them:
+
+| | Animation assets (`@momentum-design/animations`) | Motion tokens (`@momentum-design/tokens`) |
+| --- | --- | --- |
+| What it is | Pre-authored Lottie/SVG files | Duration, easing, delay, and stagger values |
+| Answers | *What* animated artwork plays | *How* a UI transition is timed and eased |
+| Consumed via | `mdc-animation` | CSS custom properties (`--mds-motion-*`) / animation recipes |
+| Example | A "calling" Lottie loop | A 200 ms hover fade with `standard` easing |
+
+Reach for a **motion token** to time a UI transition (hover, expand, enter/exit).
+Reach for an **animation asset** when you need a designed, moving graphic. See
+[Motion](../../tokens/knowledge-base/motion.md) for the token side.
+
+## Animations versus other Momentum assets
+
+| Asset type | Package | Use for |
+| --- | --- | --- |
+| **Animations** | `@momentum-design/animations` | Moving Lottie/SVG artwork — loading, empty/success states, small narrative moments |
+| **Icons** | `@momentum-design/icons` | Static UI glyphs — controls, status, navigation |
+| **Illustrations** | `@momentum-design/illustrations` | Larger *static* narrative or empty-state artwork |
+| **Brand visuals** | `@momentum-design/brand-visuals` | Logos, wordmarks, and approved product imagery |
+
+## What's in the library
+
+- **`src/lottie/`** — Lottie JSON animations (for example `calling`, `meeting`,
+  `space`, `personal_insight`), including grouped sets such as `reactions/` and
+  `cisco-ai-assistant/`.
+- **`src/svg/`** — animated SVGs (for example `webex-logo-loop`).
+
+Assets are distributed as source files: a Lottie renderer (such as the official
+dotLottie web player) plays the JSON, while animated SVGs can be embedded
+directly in HTML.
+
+## Consuming animations
+
+Render animations with the
+[`mdc-animation`](../../../components/src/components/animation/knowledge-base/animation.component.md)
+component, a wrapper around the Lottie renderer:
+
+```html
+<mdc-animation name="calling" loop="true"></mdc-animation>
+```
+
+- `name` — a bundled animation, resolved through the shipped manifest.
+- `src` — a URL to a Lottie JSON file; takes precedence over `name`.
+- `loop` — `true` (default), `false`, or a numeric loop count.
+- `autoplay` — starts automatically when loaded (default `true`).
+
+See the component doc for the full attribute contract and events.
+
+## Accessibility
+
+- **Decorative by default.** `mdc-animation` marks its internal graphic
+  `aria-hidden`; with no label the host is skipped by assistive technology.
+- **Label only meaningful animations.** Provide `aria-label`/`aria-labelledby`
+  when the animation conveys information; the host then receives `role="img"`.
+- **Respect reduced motion.** Honor `prefers-reduced-motion` — pause, shorten, or
+  replace non-essential animation for users who request it. Prefer `loop="false"`
+  (or a finite count) over infinite loops for content that need not move
+  continuously.
+
+## Contributing assets
+
+New animations are added to the `@momentum-design/animations` package source and
+ship through the normal release. Some assets are brand- or product-specific;
+keep product-level usage rules in the relevant product repository and this
+guideline focused on the shared library's mechanics.
+
+## Related
+
+- [Motion](../../tokens/knowledge-base/motion.md) — the timing/easing **tokens**
+  that animate UI state changes (distinct from these assets).
+- [Illustrations](../../illustrations/knowledge-base/illustrations.md) — static
+  narrative artwork.
+- [`mdc-animation`](../../../components/src/components/animation/knowledge-base/animation.component.md)
+  component (Tier 3) — rendering an animation.

--- a/packages/assets/brand-visuals/knowledge-base/brand-visuals.md
+++ b/packages/assets/brand-visuals/knowledge-base/brand-visuals.md
@@ -1,0 +1,86 @@
+---
+title: Brand visuals
+summary: Guidance for Momentum's brand-visuals library — approved logos, wordmarks, and imagery, how to consume them via mdc-brandvisual, and the criteria for inclusion.
+tier: 2
+---
+
+# Brand visuals
+
+Guidance for **product designers and developers** working with the Momentum
+brand-visuals library (`@momentum-design/brand-visuals`). This article explains
+what the library contains, how to consume it, and the criteria an asset must meet
+to be included.
+
+## What the brand-visuals library is
+
+`@momentum-design/brand-visuals` is the shared source of **approved** brand
+artwork — logos, wordmarks, device/product imagery, and backgrounds — intended
+for use across products. It centralizes brand assets so teams consume a single
+approved copy rather than hard-coding their own.
+
+Product-specific assets are **not** part of this library; they are managed by the
+respective product teams. This library holds only assets relevant across multiple
+products.
+
+## Brand visuals versus other Momentum assets
+
+| Asset type | Package | Use for |
+| --- | --- | --- |
+| **Brand visuals** | `@momentum-design/brand-visuals` | Logos, wordmarks, and approved product/partner imagery |
+| **Icons** | `@momentum-design/icons` | Static UI glyphs — controls, status, navigation |
+| **Illustrations** | `@momentum-design/illustrations` | Larger narrative or empty-state artwork |
+| **Animations** | `@momentum-design/animations` | Moving Lottie/SVG artwork |
+
+## What's in the library
+
+- **`src/logos/`** — product, company, and partner logos and wordmarks.
+- **`src/images/`** — approved photography and device imagery.
+- **`src/backgrounds/`** — brand background artwork.
+
+## Consuming brand visuals
+
+Render brand artwork with the
+[`mdc-brandvisual`](../../../components/src/components/brandvisual/knowledge-base/brandvisual.component.md)
+component, which loads an asset by name at runtime:
+
+```html
+<mdc-brandvisual name="webex-logo" alt-text="Webex"></mdc-brandvisual>
+```
+
+- `name` — the filename of the asset in `@momentum-design/brand-visuals`; changing
+  it triggers a new dynamic import. Success emits a `load` event; an unknown name
+  emits an `error` event.
+- `alt-text` — accessible alternative text, applied to the underlying `<img>` for
+  image (e.g. PNG) assets.
+
+See the component doc for the full attribute contract and events.
+
+## Accessibility
+
+- For **image** assets (PNG), set `alt-text` so screen readers announce the
+  artwork; the component forwards it to the `<img>`'s `alt`.
+- For inline **SVG** artwork, `mdc-brandvisual` sets no host role — provide an
+  accessible name via the surrounding context (for example a labelled container)
+  when the mark is meaningful. Treat purely decorative marks as decorative.
+
+## Criteria for inclusion
+
+Assets are admitted to the shared library only when they meet all three:
+
+- **Relevancy** — commonly used across multiple products, not a single product's
+  asset.
+- **Approval** — cleared through brand and quality approval.
+- **Utility** — meets the needs of multiple teams and reflects the brand's visual
+  identity.
+
+Requests to add an asset go through the Momentum team and are subject to the
+criteria above. Keep product-specific brand rules (clear-space, co-branding,
+campaign usage) in the product/brand source of truth and link to it rather than
+restating it here.
+
+## Related
+
+- [Illustrations](../../illustrations/knowledge-base/illustrations.md) — narrative
+  artwork (a different asset class).
+- [`mdc-brandvisual`](../../../components/src/components/brandvisual/knowledge-base/brandvisual.component.md)
+  component (Tier 3) — rendering a brand visual.

--- a/packages/assets/illustrations/knowledge-base/illustrations.md
+++ b/packages/assets/illustrations/knowledge-base/illustrations.md
@@ -1,0 +1,120 @@
+---
+title: Illustrations
+summary: Guidance for Momentum's illustration library — SVG illustrations, when to use them, how to consume them via mdc-illustration and mdc-illustrationprovider, and accessibility.
+tier: 2
+---
+
+# Illustrations
+
+Guidance for **product designers and developers** working with the Momentum
+illustration library (`@momentum-design/illustrations`). This article explains
+what the library contains, when to reach for an illustration, how illustrations
+are consumed, and the accessibility contract.
+
+## What the illustrations library is
+
+`@momentum-design/illustrations` ships Momentum's illustrations as **SVG** files
+(and Lit templates). Consumers load an illustration by name and render it; the
+package distributes the source assets rather than drawing them at runtime.
+
+Each illustration carries its own **baked-in palette and default size** — the
+choice of `name` selects both the artwork and its colouring. Illustrations are
+larger, narrative graphics, distinct from single-colour interface icons and from
+moving animation assets (see below).
+
+## Illustrations versus other Momentum assets
+
+| Asset type | Package | Use for |
+| --- | --- | --- |
+| **Illustrations** | `@momentum-design/illustrations` | Larger *static* narrative artwork — empty states, onboarding, confirmations |
+| **Icons** | `@momentum-design/icons` | Small, single-colour UI glyphs — controls, status, navigation |
+| **Animations** | `@momentum-design/animations` | Moving Lottie/SVG artwork |
+| **Brand visuals** | `@momentum-design/brand-visuals` | Logos, wordmarks, and approved product imagery |
+
+## When to use illustrations
+
+- **Use an illustration** for larger illustrative graphics: empty states,
+  onboarding screens, success/error confirmations, and feature highlights.
+- Use one when the asset should be loaded from the shared illustration source
+  rather than bundled inline.
+- **Use a single illustration per surface.** Pairing two illustrations on the
+  same empty state or confirmation dilutes their visual weight.
+
+Do **not** use an illustration where a smaller asset fits better:
+
+- Reach for an **icon** (`mdc-icon`) for small, single-colour interface glyphs.
+- Use an inline `<svg>` for a one-off graphic that does not need to load through
+  the illustration provider system.
+
+## Consuming illustrations
+
+Illustrations render through two components: a context
+[`mdc-illustrationprovider`](../../../components/src/components/illustrationprovider/knowledge-base/illustrationprovider.component.md)
+that configures the source once, and one or more
+[`mdc-illustration`](../../../components/src/components/illustration/knowledge-base/illustration.component.md)
+elements that each resolve a `name` into an inlined SVG. An `mdc-illustration`
+outside a provider cannot resolve its source and renders nothing.
+
+Momentum illustrations (dynamic import from the `@momentum-design/illustrations`
+package):
+
+```html
+<mdc-illustrationprovider illustration-set="momentum-illustrations">
+  <mdc-illustration name="empty-state-inbox"></mdc-illustration>
+</mdc-illustrationprovider>
+```
+
+Custom illustrations (fetched over HTTP from a URL the consumer hosts):
+
+```html
+<mdc-illustrationprovider
+  illustration-set="custom-illustrations"
+  url="/assets/illustrations"
+  file-extension="svg"
+>
+  <!-- application root -->
+</mdc-illustrationprovider>
+```
+
+- Mount the provider **once** near the application root; every nested
+  `mdc-illustration` inherits its configuration through context.
+- `name` selects the artwork (and its baked palette). If the illustration cannot
+  be fetched, nothing is rendered.
+- Override the rendered size with the `--mdc-illustration-size` CSS property only
+  when the layout demands a non-default footprint; the per-illustration defaults
+  are tuned to feel consistent across surfaces.
+
+See the component docs for the full attribute contracts, caching options, and
+`load`/`error` events.
+
+## Accessibility
+
+`mdc-illustration` handles two modes, selected by what the consumer sets:
+
+- **Decorative** (default) — no `aria-label`/`aria-labelledby`. The host has no
+  `role` and the inlined SVG is `aria-hidden`, so screen readers skip it.
+- **Informative** — set `aria-label` (or `aria-labelledby`). The host receives
+  `role="img"` and announces the accessible name; the SVG stays `aria-hidden` so
+  its contents are not announced twice.
+
+Decide deliberately whether each illustration is decorative or informative — that
+choice drives the ARIA contract. The provider renders no UI and owns no
+accessibility of its own.
+
+## Contributing assets
+
+New illustrations are added to the `@momentum-design/illustrations` package
+source and ship through the normal release. Keep product-specific usage rules in
+the relevant product repository and this guideline focused on the shared
+library's mechanics.
+
+## Related
+
+- [Animations](../../animations/knowledge-base/animations.md) — moving Lottie/SVG
+  artwork (a different asset class).
+- [Brand visuals](../../brand-visuals/knowledge-base/brand-visuals.md) — logos,
+  wordmarks, and product imagery.
+- [`mdc-illustration`](../../../components/src/components/illustration/knowledge-base/illustration.component.md)
+  and
+  [`mdc-illustrationprovider`](../../../components/src/components/illustrationprovider/knowledge-base/illustrationprovider.component.md)
+  components (Tier 3) — rendering illustrations.

--- a/packages/assets/illustrations/knowledge-base/illustrations.md
+++ b/packages/assets/illustrations/knowledge-base/illustrations.md
@@ -1,15 +1,17 @@
 ---
 title: Illustrations
-summary: Guidance for Momentum's illustration library — SVG illustrations, when to use them, how to consume them via mdc-illustration and mdc-illustrationprovider, and accessibility.
+summary: Guidance for Momentum's illustration library — style principles, when to use, sizing and colour, consumption via mdc-illustration and mdc-illustrationprovider, and accessibility.
 tier: 2
 ---
 
 # Illustrations
 
 Guidance for **product designers and developers** working with the Momentum
-illustration library (`@momentum-design/illustrations`). This article explains
-what the library contains, when to reach for an illustration, how illustrations
-are consumed, and the accessibility contract.
+illustration library (`@momentum-design/illustrations`). Momentum uses a distinct
+illustration style to explain complex ideas and abstract themes **clearly and
+universally**. This article covers the visual principles, when to reach for an
+illustration, sizing and colour, how illustrations are consumed in code, and the
+accessibility contract.
 
 ## What the illustrations library is
 
@@ -17,10 +19,25 @@ are consumed, and the accessibility contract.
 (and Lit templates). Consumers load an illustration by name and render it; the
 package distributes the source assets rather than drawing them at runtime.
 
-Each illustration carries its own **baked-in palette and default size** — the
-choice of `name` selects both the artwork and its colouring. Illustrations are
-larger, narrative graphics, distinct from single-colour interface icons and from
-moving animation assets (see below).
+Each illustration carries a **baked-in palette and default size** — the choice of
+`name` selects both the artwork and its colouring, and the container size is
+encoded in the name (for example `calling-320`). Illustrations are larger,
+narrative graphics, distinct from single-colour interface icons and from moving
+animation assets.
+
+## Illustration principles
+
+Momentum illustrations share one visual language. Keep new or customised artwork
+consistent with it:
+
+- **Geometric** — build from geometric shapes (circle, square, triangle, pill).
+- **Rounded** — take a cohesive approach to radii and terminals.
+- **Depth** — use overlapping lines and changes in scale to create the illusion
+  of depth.
+- **Open** — use composition and line to show a clear starting and end point.
+- **Continuous** — connect elements with a single continuous line to convey
+  movement or action.
+- **Simple** — use recognisable everyday objects in their simplest form.
 
 ## Illustrations versus other Momentum assets
 
@@ -33,18 +50,67 @@ moving animation assets (see below).
 
 ## When to use illustrations
 
-- **Use an illustration** for larger illustrative graphics: empty states,
-  onboarding screens, success/error confirmations, and feature highlights.
-- Use one when the asset should be loaded from the shared illustration source
-  rather than bundled inline.
-- **Use a single illustration per surface.** Pairing two illustrations on the
-  same empty state or confirmation dilutes their visual weight.
+Use illustrations **in moderation** — to supplement at a glance, reinforce
+interactivity, or simplify a complex idea. Used deliberately, a single
+illustration is a delightful addition to the experience. The core use cases:
+
+- **Empty states** — when there is no data or content to display; guide and
+  inform users on the actions they can take.
+- **Onboarding** — help users set up an area of the app for the first time, or
+  introduce a new feature.
+- **Success / error** — reinforce the message when a task completes successfully
+  or a system error occurs.
+- **Spot illustrations** — occasional, targeted moments: draw attention to
+  something important on a busy page, or explain a technical concept.
+
+Two habits keep illustrations effective:
+
+- **Use one illustration per view.** Multiple illustrations in a single view
+  overwhelm the page and make it hard to focus; pick the one place that most
+  needs attention.
+- **Pair with copy.** Illustrations support content, they do not stand on their
+  own. Where a space feels empty, pair the illustration with a short line of copy
+  rather than leaving the area blank.
 
 Do **not** use an illustration where a smaller asset fits better:
 
 - Reach for an **icon** (`mdc-icon`) for small, single-colour interface glyphs.
 - Use an inline `<svg>` for a one-off graphic that does not need to load through
   the illustration provider system.
+
+## Sizing
+
+Illustrations come in three base sizes, chosen by the artwork's complexity
+(simple → complex). All sizes use a **2.5px stroke weight**, and the container
+size is encoded in the illustration name.
+
+| Base size | Container | Resize range |
+| --- | --- | --- |
+| Small | 120×120px | 60–192px |
+| Medium | 192×192px | 120–320px |
+| Large | 320×320px | 192–480px |
+
+Pick the correct **base** illustration before scaling — starting from the right
+base keeps the artwork's integrity intact, and resized illustrations should keep
+the 2.5px stroke weight. In code, override the rendered size with the
+`--mdc-illustration-size` CSS property only when the layout demands a non-default
+footprint; the per-illustration defaults are tuned to feel consistent across
+surfaces.
+
+## Colour
+
+Colour is applied **deliberately and by context** — each use case has a defined
+set of colours, drawn from the Momentum palette. When in doubt, use a solid
+colour.
+
+- **Solid** — black or white depending on theme; the default for all
+  illustrations, and the option for **spot illustrations**. It promotes
+  accessibility, simplicity, and consistency across the UI.
+- **Gradient** — a brand-forward option that lightens the mood or adds
+  personality, reserved for **empty states, onboarding, and success / error**.
+
+Colouring is baked into each illustration `name`; pick a different `name` to
+change palette rather than recolouring at runtime.
 
 ## Consuming illustrations
 
@@ -78,11 +144,10 @@ Custom illustrations (fetched over HTTP from a URL the consumer hosts):
 
 - Mount the provider **once** near the application root; every nested
   `mdc-illustration` inherits its configuration through context.
-- `name` selects the artwork (and its baked palette). If the illustration cannot
-  be fetched, nothing is rendered.
-- Override the rendered size with the `--mdc-illustration-size` CSS property only
-  when the layout demands a non-default footprint; the per-illustration defaults
-  are tuned to feel consistent across surfaces.
+- `name` selects the artwork (and its baked palette and size). If the
+  illustration cannot be fetched, nothing is rendered.
+- Override the rendered size with `--mdc-illustration-size` only when the layout
+  demands a non-default footprint.
 
 See the component docs for the full attribute contracts, caching options, and
 `load`/`error` events.
@@ -101,12 +166,15 @@ Decide deliberately whether each illustration is decorative or informative — t
 choice drives the ARIA contract. The provider renders no UI and owns no
 accessibility of its own.
 
-## Contributing assets
+## Requesting or contributing illustrations
 
-New illustrations are added to the `@momentum-design/illustrations` package
-source and ship through the normal release. Keep product-specific usage rules in
-the relevant product repository and this guideline focused on the shared
-library's mechanics.
+Reuse an existing library illustration whenever the visual metaphor and meaning
+still make sense. If nothing fits, combine elements from existing illustrations
+before drawing something new. New or changed illustrations are requested through
+the Momentum change-request process and ship with the
+`@momentum-design/illustrations` package. Keep product-specific usage rules in the
+relevant product repository and this guideline focused on the shared library's
+mechanics.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Adds Tier 2 knowledge-base guidelines for three asset packages, following the `momentum-contributing-to-knowledge-base` workflow and mirroring the existing `icons.md` / `fonts.md` shape:

- **`packages/assets/illustrations/knowledge-base/illustrations.md`** — SVG illustrations: style **principles** (geometric, rounded, depth, open, continuous, simple), when to use (empty states, onboarding, success/error, spot; one-per-view; pair-with-copy), **sizing** (S/M/L base containers, resize ranges, 2.5px stroke, size encoded in the name), **colour** (solid default vs gradient by use case), consumption via `mdc-illustration` + `mdc-illustrationprovider` (Momentum vs custom sets, sizing override), and the decorative/informative accessibility contract.
- **`packages/assets/animations/knowledge-base/animations.md`** — Lottie/SVG animation assets: library contents, consumption via `mdc-animation`, accessibility (decorative default, reduced motion), and an explicit **animations-vs-motion-tokens** boundary so the two systems are not conflated.
- **`packages/assets/brand-visuals/knowledge-base/brand-visuals.md`** — approved logos/wordmarks/imagery: library contents, consumption via `mdc-brandvisual`, and the relevancy/approval/utility inclusion criteria.

Each doc cross-links its paired Tier 3 component doc; product-specific rules are routed out to product repos rather than restated. `index.packages.json` regenerated (tier 2 now includes the three new topics).

## Notes

- **`illustrations.md` is now Figma-reconciled.** Shipped code + component docs remain the source of truth for mechanics (consumption, ARIA, sizing override); the design intent (principles, use cases, sizing, colour, reuse-before-custom) is folded in from the Momentum illustration **training** deck (treated as authoritative — more current than the older guidelines file). Two brand-neutral edits: the Webex "swoop" motif is folded into the generic **Continuous** principle rather than named, and the change-request contact is generalised to the Momentum process (no personal contact details).
- **Cross-PR link:** `animations.md` links `tokens/knowledge-base/motion.md`, which lands in the motion PR (#2010). The link resolves once that PR merges; no impact on this PR's validation.

## Validation

- `yarn knowledge-base:validate` passes (also enforced by the pre-commit hook).
- Index regenerated and committed.

## Test plan

- [ ] KB validation is green in CI.
- [ ] Rendered docs read correctly and cross-links resolve after dependent PRs merge.
