### PR TITLE
fix(stepper): synchronize inherited context before rendering

### DIFF
--- a/packages/components/src/components/stepper/stepper.e2e-test.ts
+++ b/packages/components/src/components/stepper/stepper.e2e-test.ts
@@ -74,6 +74,55 @@ const takeScreenshot = async (componentsPage: ComponentsPage, orientation: Orien
   });
 };
 
+// AI-Assisted: Cover initial non-default context, direct child overrides, and subsequent provider updates.
+test('should keep non-default context authoritative and remain responsive to updates', async ({
+  componentsPage,
+}) => {
+  const children = `
+    <mdc-stepperitem label="Step 1"></mdc-stepperitem>
+    <mdc-stepperconnector></mdc-stepperconnector>
+    <mdc-stepperitem label="Step 2"></mdc-stepperitem>
+  `;
+  const stepper = await setup(componentsPage, {
+    children,
+    orientation: ORIENTATION.VERTICAL,
+    variant: VARIANT.STACKED,
+  });
+  const items = componentsPage.page.locator('mdc-stepperitem');
+  const connector = componentsPage.page.locator('mdc-stepperconnector');
+
+  await expect(items.nth(0)).toHaveAttribute('variant', VARIANT.STACKED);
+  await expect(items.nth(1)).toHaveAttribute('variant', VARIANT.STACKED);
+  await expect(connector).toHaveAttribute('orientation', ORIENTATION.VERTICAL);
+
+  const [itemUpdatedInSingleCycle, connectorUpdatedInSingleCycle] = await Promise.all([
+    items.nth(0).evaluate((element, variant) => {
+      element.setAttribute('variant', variant);
+      return (element as HTMLElement & { updateComplete: Promise<boolean> }).updateComplete;
+    }, VARIANT.INLINE),
+    connector.evaluate((element, orientation) => {
+      element.setAttribute('orientation', orientation);
+      return (element as HTMLElement & { updateComplete: Promise<boolean> }).updateComplete;
+    }, ORIENTATION.HORIZONTAL),
+  ]);
+
+  expect(itemUpdatedInSingleCycle).toBe(true);
+  expect(connectorUpdatedInSingleCycle).toBe(true);
+
+  await expect(items.nth(0)).toHaveAttribute('variant', VARIANT.STACKED);
+  await expect(connector).toHaveAttribute('orientation', ORIENTATION.VERTICAL);
+
+  await componentsPage.setAttributes(stepper, {
+    orientation: ORIENTATION.HORIZONTAL,
+    variant: VARIANT.INLINE,
+  });
+
+  await expect(items.nth(0)).toHaveAttribute('variant', VARIANT.INLINE);
+  await expect(items.nth(1)).toHaveAttribute('variant', VARIANT.INLINE);
+  await expect(connector).toHaveAttribute('orientation', ORIENTATION.HORIZONTAL);
+});
+// End AI-Assisted
+
 test('mdc-stepper', async ({ componentsPage }) => {
   const children = `
       <mdc-stepperitem label="Step 1" status="completed"></mdc-stepperitem>

--- a/packages/components/src/components/stepperconnector/stepperconnector.component.ts
+++ b/packages/components/src/components/stepperconnector/stepperconnector.component.ts
@@ -31,18 +31,21 @@ class StepperConnector extends Component {
    */
   @property({ type: String, reflect: true }) orientation: OrientationType = DEFAULTS.ORIENTATION;
 
+  // AI-Assisted: Synchronize inherited configuration before rendering while keeping the provider authoritative.
   /**
    * @internal
    */
   private readonly stepperContext = providerUtils.consume({ host: this, context: Stepper.Context });
 
-  override updated(changedProperties: Map<string, unknown>): void {
-    super.updated(changedProperties);
+  override willUpdate(changedProperties: Map<string, unknown>): void {
+    super.willUpdate(changedProperties);
 
     const context = this.stepperContext?.value;
-    if (!context || !context.orientation) return;
-    this.orientation = context.orientation;
+    if (context?.orientation && this.orientation !== context.orientation) {
+      this.orientation = context.orientation;
+    }
   }
+  // End AI-Assisted
 
   public override render() {
     return html` <div part="connector"></div> `;

--- a/packages/components/src/components/stepperitem/stepperitem.component.ts
+++ b/packages/components/src/components/stepperitem/stepperitem.component.ts
@@ -78,18 +78,21 @@ class StepperItem extends KeyDownHandledMixin(KeyToActionMixin(TabIndexMixin(Com
   @property({ type: Number, reflect: true, attribute: 'step-number' })
   stepNumber?: number;
 
+  // AI-Assisted: Synchronize inherited configuration before rendering while keeping the provider authoritative.
   /**
    * @internal
    */
   private readonly stepperContext = providerUtils.consume({ host: this, context: Stepper.Context });
 
-  override updated(changedProperties: Map<string, unknown>): void {
-    super.updated(changedProperties);
+  override willUpdate(changedProperties: Map<string, unknown>): void {
+    super.willUpdate(changedProperties);
 
     const context = this.stepperContext?.value;
-    if (!context || !context.variant) return;
-    this.variant = context.variant;
+    if (context?.variant && this.variant !== context.variant) {
+      this.variant = context.variant;
+    }
   }
+  // End AI-Assisted
 
   override connectedCallback(): void {
     super.connectedCallback();


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

Fix a rendering loop by synchronizing stepper item and connector context in willUpdate() instead of updated(). Add regression coverage confirming provider values are applied within a single update cycle.

### Breaking Change

No breaking change
