### PR TITLE
fix(components): input label accessibility in safari

### DIFF
--- a/packages/components/src/components/input/input.component.ts
+++ b/packages/components/src/components/input/input.component.ts
@@ -403,6 +403,7 @@ class Input
       ?readonly="${this.readonly}"
       ?required="${this.required}"
       type="${type}"
+      aria-labelledby="${DEFAULTS.HEADING_ID}"
       aria-describedby="${ifDefined(
         this.helpText ? FORMFIELD_DEFAULTS.HELPER_TEXT_ID : (this.dataAriaDescribedby ?? ''),
       )}"

--- a/packages/components/src/components/input/input.constants.ts
+++ b/packages/components/src/components/input/input.constants.ts
@@ -1,6 +1,6 @@
 import utils from '../../utils/tag-name';
 import { BUTTON_VARIANTS, ICON_BUTTON_SIZES } from '../button/button.constants';
-import { VALIDATION } from '../formfieldwrapper/formfieldwrapper.constants';
+import { VALIDATION, DEFAULTS as FFW_DEFAULTS } from '../formfieldwrapper/formfieldwrapper.constants';
 import type { IconNames } from '../icon/icon.types';
 import { TYPE, VALID_TEXT_TAGS } from '../text/text.constants';
 
@@ -32,6 +32,7 @@ const PREFIX_TEXT_OPTIONS = {
 };
 
 const DEFAULTS = {
+  HEADING_ID: FFW_DEFAULTS.HEADING_ID,
   VALIDATION: VALIDATION.DEFAULT,
   ICON_SIZE_VALUE: 1,
   ICON_SIZE_UNIT: 'rem',


### PR DESCRIPTION
### Description

Because WebKit’s accessibility engine builds its tree top-down, standard HTML <label for=""> references are handled differently than explicit ARIA tokens.

When Safari parses aria-labelledby="heading-id", it skips the native layout engine's for lookup mechanism entirely and maps the node explicitly in the Accessibility API. This is why adding both attributes ensures cross-browser coverage: the for attribute manages mouse-click focusing, while aria-labelledby ensures Safari's VoiceOver speaks the label aloud.

more details:
https://nolanlawson.com/2022/11/28/shadow-dom-and-accessibility-the-trouble-with-aria/

breaking change: none
