### PR TITLE
docs(skills): add component creation workflow

### DIFF
--- a/.github/skills/create-component/SKILL.md
+++ b/.github/skills/create-component/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: create-component
+description:
+  'Create a new Lit web component or widget in the Momentum Design components package end to end, including its API,
+  accessibility, consumer-owned content, RTL and text-expansion support, styling, Storybook stories, Playwright tests,
+  exports, generated integrations, and Tier 3 documentation. Use when asked to create, add, build, or scaffold a
+  component under packages/components. Do not use for changes limited to an existing component, asset-only work,
+  product-specific components, or generic Lit projects.'
+---
+
+# Create a Momentum component
+
+Build production-ready components for `@momentum-design/components`. Keep this skill focused on orchestration and
+quality gates; use current repository sources for implementation rules.
+
+## Apply repository rules once
+
+Ensure the applicable [repository](../../../AGENTS.md) and [components package](../../../packages/components/AGENTS.md)
+instructions are in context. Do not reload instructions already provided in the conversation.
+
+Run `git status --short` before proposing changes and preserve pre-existing work. Present a concrete implementation plan
+and wait for explicit approval before editing component files. Complete the component-or-widget confirmation checkpoint
+below before creating that plan. Re-plan and request approval again if later findings materially change the API,
+accessibility model, component classification, design contract, or file scope.
+
+## Use an optional Figma specification
+
+Accept a node-specific Figma Design URL as optional input. Do not require Figma when the user provides no design spec.
+
+When a Figma URL is supplied, load and follow the canonical Figma design-to-code skill completely before proposing the
+component plan. Prefer an installed `/figma-design-to-code` skill; otherwise read
+`skill://figma/figma-design-to-code/SKILL.md` from the Figma MCP server.
+
+Apply only these Momentum-specific additions:
+
+- Compare the derived design requirements with current package conventions and the chosen analogue. Include conflicts,
+  repository token mappings, and proposed deviations in the component plan.
+- Keep the private Figma URL and fetched design data out of committed files and knowledge-base content. Record only the
+  derived implementation decisions.
+
+## Load cross-cutting guidance progressively
+
+Before approval, load only the cross-cutting guidance needed to classify the component and define its public,
+accessibility, consumer-content, bidirectional-layout, and text-expansion contracts. Search headings or key terms before
+opening a long guide, read only the matching section range, and do not revisit sources already understood.
+
+Load additional guidance when its trigger applies:
+
+- For every new shared-library entry, use
+  [the kinds of components](../../../packages/components/knowledge-base/snowflake-components.md#the-kinds-of-components)
+  to classify it as a component or widget. If shared-library fit is uncertain, continue with the
+  [quick decision check](../../../packages/components/knowledge-base/snowflake-components.md#quick-decision-check) and
+  expand only if the result remains unclear.
+- For accessibility, start with
+  [component responsibility](../../../knowledge-base/accessibility.md#what-components-handle), then load only matching
+  [cross-cutting requirements](../../../knowledge-base/accessibility.md#cross-cutting-requirements). Read
+  [interaction patterns](../../../knowledge-base/interaction-patterns.md) only for custom, composite, overlay,
+  selection, or feedback behavior—not a native control whose behavior is already defined.
+- When the contract includes visible or accessibility-only text or locale-sensitive display values, read the
+  [component text ownership convention](../../../packages/components/conventions/component-text-ownership.md).
+- In [internationalization](../../../knowledge-base/internationalization.md), select only the sections matching
+  bidirectionality, text expansion, or directional icons in the contract. Read the exact
+  [content pattern](../../../knowledge-base/content-guidelines.md#content-patterns) only when authoring consumer-side
+  example copy for stories or documentation. Read
+  [responsive design](../../../knowledge-base/responsive-design.md) only for breakpoint or adaptive-overlay behavior
+  beyond ordinary reflow.
+
+For a novel interactive pattern, verify current native HTML and WAI-ARIA Authoring Practices guidance. Prefer native
+semantics and adapt interaction guidance to shadow DOM and established repository behavior.
+
+## Phase 1: establish the contract
+
+Before creating an implementation plan, confirm the classification separately:
+
+1. Search components, stories, and knowledge-base topics for the requested purpose and neighboring patterns. Prefer an
+   existing component when it already meets the need.
+2. Apply the linked component-or-widget guidance to the requested purpose and search results. Propose one classification
+   with a concise repository-based rationale, then ask the user whether the new entry should be a `component` or a
+   `widget`.
+3. Wait for the user to explicitly confirm `component` or `widget`. Do not start developing or presenting the
+   implementation plan before receiving that answer.
+
+After the classification is confirmed, continue establishing the contract:
+
+1. Choose one primary analogue from the search results. Before approval, inspect only the files needed to compare its
+   public and semantic contract. Add at most one targeted analogue when a named contract question remains unresolved.
+2. Search for reusable models, mixins, utilities, styles, assets, and integration points to confirm feasibility. Defer
+   their implementations, generator internals, stories, tests, and documentation until after approval unless a material
+   contract decision cannot otherwise be made.
+3. Resolve only material unknowns with the user. Do not infer unavailable requirements.
+
+Define the component's:
+
+- shared-library purpose, unprefixed scaffold name, `mdc-` tag, PascalCase class name, component-or-widget
+  classification confirmed during the pre-plan checkpoint, and any explicitly requested release state. Do not use
+  `Work In Progress` as a fallback category;
+- content model, slots, dependencies, properties, attributes, methods, events, defaults, and state ownership;
+- for composed or slotted children, the membership and state-change signals the component consumes and how they cover
+  user-initiated and programmatic updates;
+- native semantics, accessible name, ARIA ownership, focus, keyboard, pointer, disabled/read-only, and announcement
+  behavior;
+- the consumer-content contract, text expansion, RTL, responsive, forced-color, and reduced-motion behavior;
+- when a Figma node is supplied, the Figma-derived contract, repository token mappings, conflicts, and proposed
+  deviations;
+- stories, functional and visual tests, accessibility checks, manual checks, assets, and validation commands.
+
+Present a plan with the confirmed component-or-widget decision and rationale, files, compact public API table,
+accessibility and consumer-content contracts, bidirectional layout, text expansion, stories and tests, and validation.
+Identify the classification as explicitly confirmed before planning. When a node was supplied, include applicable Figma
+findings, token mappings, conflicts, and proposed deviations. Propose `Tier 3` documentation through the
+[knowledge-base contribution skill](../momentum-contributing-to-knowledge-base/SKILL.md) and its
+[Tier 3 writing guide](../momentum-tier-3-writing-guide/SKILL.md) because one component owns the topic. State that
+approving the plan also confirms that placement. Wait for explicit approval.
+
+## Phase 2: scaffold and implement
+
+Run the repository generator from the root in an interactive terminal:
+
+```bash
+yarn components generate:component
+```
+
+Provide the lowercase component name without `mdc-` or hyphens. Set the class name deliberately to proper PascalCase
+during implementation.
+
+Inspect the complete generator diff immediately. Confirm expected component, style, type, story, test, registration,
+export, and Code Connect files were created without disturbing unrelated exports. Replace runtime, story, and test
+placeholders; remove unused optional files and empty scaffolding. Keep an unresolved Code Connect stub only when no
+authorized exact mapping exists, and report it at handoff.
+
+Before implementation, inspect the relevant files from the primary analogue. Inspect a reusable implementation only when
+the approved contract actually uses it.
+
+Implement the approved contract using current analogues. Preserve these outcome gates:
+
+- Keep the public API minimal, typed, documented, and consistent with related components. Avoid redundant state.
+- Use the narrowest existing signal for changes in composed or slotted content. Prefer child component events for state
+  changes and `slotchange` for membership changes. Use an observer only when the approved contract requires changes that
+  available events and lifecycle hooks cannot report; document that reason, observe the narrowest target and mutation
+  set, and clean up owned listeners, observers, timers, subscriptions, and asynchronous work across disconnection and
+  reconnection.
+- Reuse package primitives and utilities. Integrate dependencies, public exports, typed events, React event mappings,
+  slots, CSS parts, CSS properties, and custom states required by the contract.
+- When a Figma node was supplied, implement the approved Figma-derived contract and re-plan before making a material
+  visual deviation.
+- Prefer native accessibility. Implement names, roles, states, relationships, keyboard and pointer behavior, focus,
+  disabled/read-only behavior, and announcements across shadow boundaries. Cover RTL, forced colors, reduced motion,
+  zoom, and reflow where relevant.
+- Implement the approved consumer-content contract. Inherit `dir`, use logical layout, and allow consumer-provided text
+  to expand.
+- Use existing Momentum assets, semantic tokens, typography, focus, and motion foundations. Do not invent design values.
+
+## Phase 3: complete supporting artifacts
+
+Before writing stories, read the canonical
+[Storybook convention](../../../packages/components/conventions/component-storybook.md), then inspect current analogous
+stories. Keep the first story `Example`, map the approved component-or-widget classification and any explicit release
+state to the correct story root, and cover meaningful variants, interaction, accessibility usage, and consumer-provided
+long and multiple-language content. Follow the convention's direction-coverage rules. Replace all generator placeholders
+and remove metadata that the convention marks obsolete.
+
+Before writing tests, read the testing guide's [scope](../../../packages/components/TESTING.md#scope),
+[setup](../../../packages/components/TESTING.md#setup), and
+[local-development](../../../packages/components/TESTING.md#local-development) sections and inspect current fixtures and
+helpers. Read the [snapshot-update](../../../packages/components/TESTING.md#update-visual-regression-snapshots) section
+only when snapshots are in scope. Test observable public behavior, API updates, events, interaction, focus,
+accessibility semantics, cleanup, and visual states applicable to the contract. Use `componentsPage`, the
+component-local `setup` pattern, automated accessibility checks, and representative LTR, RTL, and forced-color visuals.
+Inspect every changed image.
+
+For component documentation, follow the
+[knowledge-base contribution skill](../momentum-contributing-to-knowledge-base/SKILL.md) and its
+[Tier 3 writing guide](../momentum-tier-3-writing-guide/SKILL.md) only at this phase. Create the canonical topic at:
+
+```text
+packages/components/src/components/<component>/knowledge-base/<component>.component.md
+```
+
+Search for overlap, link to cross-cutting guidance instead of duplicating it, regenerate the index, and surface the
+AI-drafted topic for required human review.
+
+## Phase 4: validate the integration
+
+Format changed files, then run the smallest useful checks before broadening:
+
+```bash
+yarn components analyze
+yarn components build
+yarn components test:e2e:skip-snapshot <component>.e2e-test.ts
+yarn knowledge-base:index
+yarn analyze:root
+```
+
+When approved snapshots are in scope and Docker or Podman is available, run the targeted documented update command,
+rerun without update mode, and inspect the LTR, RTL, and high-contrast results.
+
+After building:
+
+1. Verify the component contract in `dist/custom-elements.json`.
+2. Verify the generated React wrapper and typed event mappings under `src/react/<component>/index.ts`; do not commit
+   untracked build output.
+3. Inspect the story in a local browser using the [Storybook navigation skill](../navigating-storybook/SKILL.md) or an
+   equivalent local-browser capability. Exercise themes, keyboard, focus, long content, both global directions, and
+   relevant states. When a Figma node was supplied, compare the rendered states with its MCP design context and
+   screenshot, and report intentional deviations without publishing the private URL.
+4. Check repeated mount/unmount when the component owns external resources.
+5. Run `git diff --check` and inspect the complete diff for unrelated changes, placeholders, debugging output, and
+   accidental generated artifacts.
+
+Fix failures caused by the work. Report exact commands or manual checks that could not run; never imply they passed or
+suppress accessibility, type, lint, or test failures.
+
+## Report completion
+
+Lead with the implemented outcome. Summarize the public contract, material accessibility, consumer-content, RTL,
+text-expansion, and applicable Figma-derived decisions or deviations, supporting artifacts, generated integration
+checks, commands and results, and outstanding placeholders or manual validation. Include the component-or-widget
+classification and rationale, and state that the user explicitly confirmed it before planning. Identify the Tier 3
+document that requires human sign-off. Do not call the component complete while required work or known failures remain.

--- a/.github/skills/navigating-storybook/SKILL.md
+++ b/.github/skills/navigating-storybook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: navigating-storybook
-description: "Navigate and inspect Momentum Design components in Storybook using Chrome DevTools MCP. Use for viewing rendered stories, testing interactions, and debugging memory leaks in the browser. Applies to packages/components only."
+description: 'Navigate and inspect Momentum Design components in Storybook using Chrome DevTools MCP. Use for viewing rendered stories, testing interactions, and debugging memory leaks in the browser. Applies to packages/components only.'
 ---
 
 # Navigating Storybook with Chrome DevTools MCP
@@ -66,6 +66,29 @@ http://localhost:6006/iframe.html?id=components-textarea--example
 
 The iframe URL loads only the story content (no Storybook chrome), which is ideal for inspecting components.
 
+Use the full Storybook URL when validation depends on manager controls such as direction or theme:
+
+```text
+http://localhost:6006/?path=/story/{story-id}
+```
+
+## Exercise global direction
+
+Validate the same story in both directions through the Storybook direction toolbar. Do not depend on a hard-coded
+`dir="rtl"` wrapper because that bypasses the integration consumers use in Storybook.
+
+For deterministic navigation or browser automation, set the `storybook-addon-rtl` global in the full story URL:
+
+```text
+http://localhost:6006/?path=/story/components-textarea--example&globals=addonRtl:rtl
+http://localhost:6006/?path=/story/components-textarea--example&globals=addonRtl:ltr
+```
+
+In each direction, inspect logical layout, directional icons, keyboard behavior, focus order, wrapping, and overflow that
+apply to the component. Use the canonical
+[Storybook convention](../../../packages/components/conventions/component-storybook.md#exercise-direction-through-storybook)
+for story-authoring decisions.
+
 ## Fallback: Querying the Story Index
 
 If you cannot determine the story ID from the source (e.g., dynamically generated stories), fetch the index:
@@ -76,7 +99,7 @@ If you cannot determine the story ID from the source (e.g., dynamically generate
    () => {
      const json = JSON.parse(document.body.innerText);
      const keys = Object.keys(json.entries || {});
-     return keys.filter((k) => k.includes("textarea"));
+     return keys.filter((k) => k.includes('textarea'));
    };
    ```
 3. Use the returned ID in the iframe URL.
@@ -93,7 +116,7 @@ Use `mcp_io_github_chr_evaluate_script` to inspect DOM state:
 
 ```javascript
 () => {
-  const component = document.querySelector("mdc-textarea");
+  const component = document.querySelector('mdc-textarea');
   return {
     tagName: component?.tagName,
     shadowChildren: component?.shadowRoot?.children.length,
@@ -120,13 +143,13 @@ filePath: "scratch/heap-before.heapsnapshot"
 
 ```javascript
 async () => {
-  const container = document.createElement("div");
+  const container = document.createElement('div');
   document.body.appendChild(container);
 
   // Mount components
   for (let i = 0; i < 50; i++) {
-    const el = document.createElement("mdc-textarea");
-    el.setAttribute("label", `Test ${i}`);
+    const el = document.createElement('mdc-textarea');
+    el.setAttribute('label', `Test ${i}`);
     container.appendChild(el);
   }
   await new Promise((r) => setTimeout(r, 500));
@@ -148,6 +171,9 @@ async () => {
 2. Navigate: `mcp_io_github_chr_navigate_page` → iframe URL
 3. Snapshot: `mcp_io_github_chr_take_snapshot`
 4. Optionally screenshot: `mcp_io_github_chr_take_screenshot`
+
+When direction or another toolbar-owned global is in scope, repeat the workflow through the full Storybook URL with each
+required global value.
 
 ### Test Component Interaction
 

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -12,7 +12,11 @@ repository managed by Yarn Workspaces and is published to npm at
 ## General Guidelines
 
 - Use [TypeScript](https://www.typescriptlang.org/) for all code.
-- Follow the coding conventions in `packages/components/conventions/*.md`.
+- Read the [components conventions index](conventions/README.md) completely
+  before changing component files. Then read only the applicable convention
+  documents; do not preload the directory.
+- When creating a new component, follow the
+  [create-component skill](../../.github/skills/create-component/SKILL.md).
 - Prefer existing mixins in `packages/components/src/utils/mixins/` to extend
   functionality.
 - Icons are rendered using the `mdc-icon` component (e.g.,
@@ -111,15 +115,13 @@ Refer to [lit.dev](https://lit.dev).
   configuration.
 - **Consistent naming**: Follow established patterns for similar functionality
   across components.
-- **Type safety**: Use TypeScript interfaces and enums for better developer
-  experience.
+- **Type safety**: Follow the applicable package conventions for public APIs and
+  finite value sets.
 - **Backward compatibility**: Consider migration paths when changing public
   APIs.
 
 ### Accessibility (A11Y)
 
-- Always include proper ARIA attributes (`aria-live`, `aria-busy`, `role`,
-  etc.).
 - Ensure screen reader compatibility with meaningful announcements.
 - Support keyboard navigation where applicable.
 - Test with actual assistive technologies, not just automated tools.

--- a/packages/components/TESTING.md
+++ b/packages/components/TESTING.md
@@ -96,6 +96,28 @@ recommended:
      yarn components test:e2e:firefox # run on firefox whithout snapshots
    ```
 
+### Visual regression screenshots
+
+Author visual assertions through `componentsPage.visualRegression.takeScreenshot(name, options)`
+(`config/playwright/setup/utils/visual-regression.ts`) instead of `page.screenshot()` or manual
+`page.emulateMedia()` calls. For the default `stickersheet` source, one call already produces every
+required variant for that fixture:
+
+- `<name>-high-contrast.png` — forced-colors mode, captured automatically, only on Chromium and msedge
+- `<name>-ltr.png` and `<name>-rtl.png` — normal contrast, one shot per direction
+
+Internally it toggles `forcedColors` on for the high-contrast shot, then resets it to `'none'` before taking
+the LTR/RTL pair. Two rules follow directly from that:
+
+- Call `takeScreenshot` **exactly once per visual fixture**. A second call for the same fixture reruns the
+  whole high-contrast/LTR/RTL sequence and produces snapshots that duplicate the first call's.
+- Never wrap a `takeScreenshot` call in your own `page.emulateMedia({ forcedColors: ... })`. The helper's own
+  reset overwrites a manual override, so the forced-colors case you meant to capture silently degrades to a
+  normal-contrast screenshot — same pixels, misleading name.
+
+Give the fixture one descriptive `name` (e.g. `mdc-checkboxtree`); the helper appends the `-ltr`/`-rtl`/
+`-high-contrast` suffix itself, so don't fold a variant into the name yourself.
+
 ### Update Visual Regression snapshots
 
 To update Visual Regression snapshots, follow the steps below to run E2E testing

--- a/packages/components/config/playwright/setup/utils/visual-regression.ts
+++ b/packages/components/config/playwright/setup/utils/visual-regression.ts
@@ -70,14 +70,22 @@ class VisualRegression {
   }
 
   /**
-   * Takes a screenshot of the whole page, with the passed in options
-   * If options.element is provided, it will take a screenshot of that element instead of the whole page.
+   * Captures visual-regression snapshots of the page, or of `options.element` when provided.
    *
-   * @param name - name of the screenshot, file extension will be appended automatically!
-   * @param options - An object that contains the
-   * - element to take screenshot from
-   * - assertion after switching direction
-   * - type of screenshot - stickersheet or userflow
+   * The default `stickersheet` source captures `<name>-high-contrast` on Chromium-based browsers,
+   * followed by `<name>-ltr` and `<name>-rtl`. Forced-colors mode and document direction are managed
+   * and reset internally, so call this method only once per fixture and do not set `forcedColors`
+   * around it. The `userflow` source captures one LTR snapshot named
+   * `<name>-userflow-<fileNameSuffix>`.
+   *
+   * Snapshot capture is skipped when `E2E_SKIP_SNAPSHOT` is `true`. Pending icon requests and browser
+   * paints are awaited before snapshots are compared. For `stickersheet` captures,
+   * `options.assertionAfterSwitchingDirection` is invoked after each direction change and before the
+   * corresponding snapshot is captured.
+   *
+   * @param name - Base snapshot name. Capture-specific suffixes and the file extension are added automatically.
+   * @param options - Playwright screenshot options plus the target element, capture source, user-flow filename
+   * suffix, and direction-change callback configuration.
    */
   async takeScreenshot(name: string, options?: ScreenShotOptions): Promise<void> {
     const elementToTakeScreenShotFrom = options?.element || this.page;

--- a/packages/components/config/plop/templates/add/component/{{componentName}}.stories.ts.hbs
+++ b/packages/components/config/plop/templates/add/component/{{componentName}}.stories.ts.hbs
@@ -11,9 +11,6 @@ const meta: Meta = {
   tags: ['autodocs'],
   component: '{{prefix}}{{separator}}{{componentName}}',
   render,
-  parameters: {
-    badges: ['wip'],
-  },
   argTypes: {
     ...classArgType,
     ...styleArgType,

--- a/packages/components/conventions/README.md
+++ b/packages/components/conventions/README.md
@@ -1,38 +1,41 @@
 # Conventions
 
-The conventions in this folder should be followed and considered during
-development and review.
+Use the `Applies when` column to select relevant guidance. The linked document
+remains the source of truth for each convention.
 
 ## General Coding
 
-| Convention                                                                                                                                                            |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Component naming](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/component-naming-guidelines.md)                       |
-| [Clean Code Guidelines](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/clean-code-guidelines.md)                        |
-| [Component Folder Structure](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/component-code-structure.md)                |
-| [Component Error Handling](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/component-error-handling.md)                  |
-| [Component Import Guidelines: Index File Structure](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/component-import.md) |
-| [Typescript Type Only Imports](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/typescript-type-only-imports.md)          |
-| [Using Enums and Alternatives in TypeScript](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/constants-and-enums.md)     |
-| [No relative workspace imports](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/no-relative-imports-workspace.md)        |
-| [Component attribute initialisation](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/component-initialisation.md)        |
+| Convention                                                                 | Applies when                                                            |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| [Component naming](./component-naming-guidelines.md)                       | Naming a component class, internal CSS class, or CSS part.              |
+| [Clean Code Guidelines](./clean-code-guidelines.md)                        | Writing or reviewing production code, comments, logs, or generated IDs. |
+| [Component Folder Structure](./component-code-structure.md)                | Scaffolding a component or deciding where component files belong.       |
+| [Component text ownership](./component-text-ownership.md)                  | Adding visible, accessibility-only, or locale-sensitive display text.   |
+| [Component Error Handling](./component-error-handling.md)                  | Handling asynchronous or recoverable component errors.                  |
+| [Component Import Guidelines: Index File Structure](./component-import.md) | Adding component dependencies or referencing component tag names.       |
+| [Typescript Type Only Imports](./typescript-type-only-imports.md)          | Importing TypeScript symbols used only as types.                        |
+| [Using Enums and Alternatives in TypeScript](./constants-and-enums.md)     | Defining a finite set of values or exported constants.                  |
+| [Mixin typing](./mixin-tsdoc-guidelines.md)                                | Adding public or protected APIs through a TypeScript mixin.             |
+| [No relative workspace imports](./no-relative-imports-workspace.md)        | Importing code or assets from another workspace package.                |
+| [Component attribute initialisation](./component-initialisation.md)        | Initializing attributes or other DOM-related state.                     |
 
 ## Accessibility
 
-| Convention                                                                                                                                                              |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Aria Delegation vs Host Aria per Component](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/component-aria-delegation.md) |
+| Convention                                                                   | Applies when                                                             |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [Aria Delegation vs Host Aria per Component](./component-aria-delegation.md) | Choosing whether ARIA semantics live on the host or an internal control. |
 
 ## Styling
 
-| Convention                                                                                                                                       |
-| ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [Component Styling](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/component-styling.md)           |
-| [Using data attributes](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/data-attributes-on-host.md) |
+| Convention                                                    | Applies when                                                                |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [Component Styling](./component-styling.md)                   | Styling a component, exposing CSS customization, or adding animation.       |
+| [Height and width as styles](./height-and-width-as-styles.md) | Exposing consumer-controlled component height or width.                     |
+| [Using data attributes](./data-attributes-on-host.md)         | Representing host state without depending on consumer-editable class names. |
 
 ## Documentation
 
-| Convention                                                                                                                                                 |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Writing proper stories in Storybook](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/component-storybook.md) |
-| [TSDoc per Component](https://github.com/momentum-design/momentum-design/blob/main/packages/components/conventions/component-tsdoc.md)                     |
+| Convention                                                      | Applies when                                                                |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [Writing proper stories in Storybook](./component-storybook.md) | Creating stories or changing a component's release status.                  |
+| [TSDoc per Component](./component-tsdoc.md)                     | Documenting a component, public API, slots, parts, events, or dependencies. |

--- a/packages/components/conventions/component-storybook.md
+++ b/packages/components/conventions/component-storybook.md
@@ -35,17 +35,21 @@ export const Variant1: StoryObj = {
 - Do not delete the Example story or rename it! It has to stay `Example`.
 - If you want to show other flows, variants etc., create new stories below the
   Example story for them (see code snippet above).
+- Do not manually add internal, derived, or read-only state to `argTypes`. When
+  the custom-elements manifest exposes a non-consumer field, use
+  [`hideControls`](../config/storybook/utils.ts) to remove it from Storybook.
+- Do not create a story solely to demonstrate RTL. Use Storybook's global
+  direction toggle instead. Add a direction-specific story only when the global
+  toggle cannot express the consumer scenario, such as mixed-direction content
+  or an intentional per-element `dir` override.
 
 ## Tagging and releasing of components
 
-To release a component / change its status, its advised to use the storybook
-parameter `badges` and the `title` attribute to move it into the right Story
-folder and tag it with the "stable" badge.
+To release a component or widget / change its status, use the `title` attribute
+to move it into the right Story folder.
 
-To release a component, the following 2 actions have to be done:
-
-- Change the `title` from `Work In Progress/*` to `Components/*`
-- Change the `badges` parameter from `wip` to `stable`
+To release it, change the `title` from `Work In Progress/*` to `Components/*` or
+`Widgets/*`, depending on its classification.
 
 Work in progress component:
 
@@ -55,9 +59,6 @@ const meta: Meta = {
   tags: ['autodocs'],
   component: 'mdc-component',
   render,
-  parameters: {
-    badges: ['wip'],
-  },
   ...
 ```
 
@@ -69,8 +70,7 @@ const meta: Meta = {
   tags: ['autodocs'],
   component: 'mdc-component',
   render,
-  parameters: {
-    badges: ['stable'],
-  },
   ...
 ```
+
+For a stable / released widget, use `Widgets/widget` as the title.

--- a/packages/components/conventions/component-text-ownership.md
+++ b/packages/components/conventions/component-text-ownership.md
@@ -1,0 +1,88 @@
+# Component text ownership
+
+## Principle
+
+Components own structure, behavior, and presentation. Consumers own every
+human-readable string, including visible copy and text exposed only to assistive
+technologies.
+
+This convention applies to text rendered by a component or assigned to an
+accessibility API. It does not apply to standards-defined tokens that are not
+human-language copy, such as roles, ARIA state values, event names, or IDs.
+
+## Consumer inputs
+
+Expose every piece of text through the component's public API:
+
+- Use a slot when consumers may need markup, icons, or other structured content.
+- Use a property or attribute when the component must place a plain string in a
+  specific location, such as an input placeholder, an accessible label, an
+  accessible description, or a live-region announcement.
+- Reuse consumer-provided visible text for an accessible name or description
+  when it has the same meaning. Do not require consumers to provide the same
+  copy twice.
+- Keep raw values used for component state separate from their display strings.
+  Consumers must translate and format dates, times, numbers, currencies,
+  plurals, and other locale-sensitive values before passing display text to a
+  component.
+
+Document accessibility-critical text inputs as required and cover them in tests.
+If a consumer omits one, do not substitute built-in English copy.
+
+## Prohibited component behavior
+
+Do not:
+
+- hard-code labels, instructions, placeholders, validation messages, empty
+  states, loading states, action names, or announcements;
+- provide fallback copy for an omitted property, attribute, or slot;
+- translate text or select a language inside a component;
+- call `Intl` or another locale-sensitive formatter in a component
+  implementation or component-specific helper to produce visible or
+  accessibility-only text;
+- assemble sentences from fixed fragments and consumer values.
+
+For consumer-side translation, formatting, bidirectionality, and text-expansion
+guidance, follow
+[Internationalization](../../../knowledge-base/internationalization.md). For
+writing example copy in stories or documentation, follow
+[Content guidelines](../../../knowledge-base/content-guidelines.md).
+
+## Example
+
+### Don't
+
+```typescript
+render() {
+  return html`
+    <button aria-label="Close"></button>
+    ${this.items.length === 0 ? html`<p>No results</p>` : this.renderItems()}
+  `;
+}
+```
+
+### Do
+
+```typescript
+@property({ type: String, attribute: 'close-aria-label' })
+closeAriaLabel = '';
+
+render() {
+  return html`
+    <button aria-label=${this.closeAriaLabel}></button>
+    ${this.items.length === 0 ? html`<slot name="empty-state"></slot>` : this.renderItems()}
+  `;
+}
+```
+
+The consumer supplies both strings:
+
+```html
+<mdc-example close-aria-label="Close">
+  <span slot="empty-state">No results</span>
+</mdc-example>
+```
+
+Stories and tests must provide representative consumer copy. Verify that the
+component renders or announces that copy through its public API and does not
+introduce fallback text when an optional input is absent.


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

> [!NOTE]  
> **This is a tooling change only, not affecting consumers.**

### Description

- add the end-to-end create-component skill
- route component creation through package guidance
- replace convention URLs with local relative links
- improve the convention index to include all conventions + a guidance when to use them
- improve TSDoc of the takeScreenshot function + TESTING.md to increase chance that agents will use it properly

### Breaking Change

None.