### PR TITLE
fix(automation): escape backticks in release notes

### DIFF
--- a/packages/tools/automation/src/commands/create-release/create-release.ts
+++ b/packages/tools/automation/src/commands/create-release/create-release.ts
@@ -55,8 +55,8 @@ class CreateRelease extends Command {
       const pullRequestDescription = await Git.getPullRequestDetails(latestCommit.commit);
       const releaseNotes = '## $title\r\n$body';
 
-      // escaping double quotes in the body to avoid breakages in the pipeline
-      const escapedBody = pullRequestDescription[0].body.replace(/"/g, '\\"');
+      // escaping double quotes and backticks in the body to avoid breakages in the pipeline
+      const escapedBody = pullRequestDescription[0].body.replace(/(["`])/g, '\\$1');
       const notes = releaseNotes
         .replace('$title', pullRequestDescription[0].title)
         .replace('$body', escapedBody)

--- a/packages/tools/automation/src/commands/create-release/create-release.unit.test.ts
+++ b/packages/tools/automation/src/commands/create-release/create-release.unit.test.ts
@@ -96,11 +96,11 @@ describe('Create Release', () => {
     expect(results).toEqual('Released: release complete');
   });
 
-  it('should release the valid package if body has " in it', async () => {
+  it('should release the valid package if body has double quotes and backticks in it', async () => {
     gitPRDescriptionSpy = jest.spyOn(Git, 'getPullRequestDetails').mockImplementation(() => Promise.resolve([
       {
         title: 'fake-pr-title',
-        body: 'fake-pr-body including <img alt="test ..."/>',
+        body: 'fake-pr-body including ```html\r\n<img alt="test ..."/>\r\n```',
         html_url: 'https://github.com/fake-pr-link',
       },
     ]));
@@ -124,7 +124,7 @@ describe('Create Release', () => {
       );
     const mockNotes = [
       '## fake-pr-title\r\n',
-      'fake-pr-body including <img alt=\\"test ...\\"/>\r\n',
+      'fake-pr-body including \\`\\`\\`html\r\n<img alt=\\"test ...\\"/>\r\n\\`\\`\\`\r\n',
       ' ### PR Link:\n',
       'https://github.com/fake-pr-link\r\n',
       ' ### Package:\n',


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

Updated the internal release automation to correctly handle Markdown code blocks in release notes. This prevents GitHub release creation failures and **does not affect library APIs, behavior, or published package contents. No consumer action is required.**

### Breaking Change

None.
