### PR TITLE
feat(tokens): add closed-caption theme colors

### DIFF
--- a/packages/assets/tokens/src/theme/stable/dark.json
+++ b/packages/assets/tokens/src/theme/stable/dark.json
@@ -2311,6 +2311,128 @@
               "description": ""
             }
           }
+        },
+        "caption": {
+          "background": {
+            "dark": {
+              "green": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.green.90}",
+                "description": "HEX: #0E2B20\nUsed for closed-caption component"
+              },
+              "blue": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.blue.90}",
+                "description": "HEX: #0A274A\nUsed for closed-caption component"
+              },
+              "purple": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.decorative.purple.90}",
+                "description": "HEX: #3B1840\nUsed for closed-caption component"
+              },
+              "yellow": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.yellow.90}",
+                "description": "HEX: #36220C\nUsed for closed-caption component"
+              }
+            },
+            "light": {
+              "green": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.green.10}",
+                "description": "HEX: #CEF5EB\nUsed for closed-caption component"
+              },
+              "blue": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.blue.10}",
+                "description": "HEX: #DBF0FF\nUsed for closed-caption component"
+              },
+              "purple": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.decorative.purple.10}",
+                "description": "HEX: #FCF2FC\nUsed for closed-caption component"
+              },
+              "yellow": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.yellow.10}",
+                "description": "HEX: #FFEBC2\nUsed for closed-caption component"
+              }
+            }
+          },
+          "text": {
+            "dark": {
+              "normal": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.black-alpha.95}",
+                "description": "HEX: #000000 95%\nUsed for closed-caption component"
+              },
+              "green": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.green.40}",
+                "description": "HEX: #3CC29A\nUsed for closed-caption component"
+              },
+              "blue": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.blue.40}",
+                "description": "HEX: #64B4FA\nUsed for closed-caption component"
+              },
+              "purple": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.decorative.purple.40}",
+                "description": "HEX: #F294F1\nUsed for closed-caption component"
+              },
+              "yellow": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.yellow.40}",
+                "description": "HEX: #F2990A\nUsed for closed-caption component"
+              }
+            },
+            "light": {
+              "normal": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.white-alpha.95}",
+                "description": "HEX: #FFFFFF 95%\nUsed for closed-caption component"
+              },
+              "green": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.green.70}",
+                "description": "HEX: #185E46\nUsed for closed-caption component"
+              },
+              "blue": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.blue.70}",
+                "description": "HEX: #0353A8\nUsed for closed-caption component"
+              },
+              "purple": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.decorative.purple.70}",
+                "description": "HEX: #932099\nUsed for closed-caption component"
+              },
+              "yellow": {
+                "parent": "theme/stable/dark",
+                "type": "color",
+                "value": "{color.core.yellow.70}",
+                "description": "HEX: #7D4705\nUsed for closed-caption component"
+              }
+            }
+          }
         }
       },
       "scrollbar": {

--- a/packages/assets/tokens/src/theme/stable/light.json
+++ b/packages/assets/tokens/src/theme/stable/light.json
@@ -2326,6 +2326,128 @@
               "description": ""
             }
           }
+        },
+        "caption": {
+          "background": {
+            "dark": {
+              "green": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.green.90}",
+                "description": "HEX: #0E2B20\nUsed for closed-caption component"
+              },
+              "blue": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.blue.90}",
+                "description": "HEX: #0A274A\nUsed for closed-caption component"
+              },
+              "purple": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.decorative.purple.90}",
+                "description": "HEX: #3B1840\nUsed for closed-caption component"
+              },
+              "yellow": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.yellow.90}",
+                "description": "HEX: #36220C\nUsed for closed-caption component"
+              }
+            },
+            "light": {
+              "green": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.green.10}",
+                "description": "HEX: #CEF5EB\nUsed for closed-caption component"
+              },
+              "blue": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.blue.10}",
+                "description": "HEX: #DBF0FF\nUsed for closed-caption component"
+              },
+              "purple": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.decorative.purple.10}",
+                "description": "HEX: #FCF2FC\nUsed for closed-caption component"
+              },
+              "yellow": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.yellow.10}",
+                "description": "HEX: #FFEBC2\nUsed for closed-caption component"
+              }
+            }
+          },
+          "text": {
+            "dark": {
+              "normal": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.black-alpha.95}",
+                "description": "HEX: #000000 95%\nUsed for closed-caption component"
+              },
+              "green": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.green.40}",
+                "description": "HEX: #3CC29A\nUsed for closed-caption component"
+              },
+              "blue": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.blue.40}",
+                "description": "HEX: #64B4FA\nUsed for closed-caption component"
+              },
+              "purple": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.decorative.purple.40}",
+                "description": "HEX: #F294F1\nUsed for closed-caption component"
+              },
+              "yellow": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.yellow.40}",
+                "description": "HEX: #F2990A\nUsed for closed-caption component"
+              }
+            },
+            "light": {
+              "normal": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.white-alpha.95}",
+                "description": "HEX: #FFFFFF 95%\nUsed for closed-caption component"
+              },
+              "green": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.green.70}",
+                "description": "HEX: #185E46\nUsed for closed-caption component"
+              },
+              "blue": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.blue.70}",
+                "description": "HEX: #0353A8\nUsed for closed-caption component"
+              },
+              "purple": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.decorative.purple.70}",
+                "description": "HEX: #932099\nUsed for closed-caption component"
+              },
+              "yellow": {
+                "parent": "theme/stable/light",
+                "type": "color",
+                "value": "{color.core.yellow.70}",
+                "description": "HEX: #7D4705\nUsed for closed-caption component"
+              }
+            }
+          }
         }
       },
       "scrollbar": {


### PR DESCRIPTION
Add 18 caption tokens under color.theme.common.caption for stable light and dark themes.

<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

### Description

## Summary
- Adds 18 closed-caption theme tokens under `color.theme.common.caption` for stable light and dark themes
- Scoped to caption colors only — no core, motion, skeleton, or other token changes

## Tokens added

### Background (8)
| Token | Core reference | Hex |
|---|---|---|
| `background.dark.green` | `core.green.90` | `#0E2B20` |
| `background.light.green` | `core.green.10` | `#CEF5EB` |
| `background.dark.blue` | `core.blue.90` | `#0A274A` |
| `background.light.blue` | `core.blue.10` | `#DBF0FF` |
| `background.dark.purple` | `decorative.purple.90` | `#3B1840` |
| `background.light.purple` | `decorative.purple.10` | `#FCF2FC` |
| `background.dark.yellow` | `core.yellow.90` | `#36220C` |
| `background.light.yellow` | `core.yellow.10` | `#FFEBC2` |

### Text (10)
| Token | Core reference | Hex |
|---|---|---|
| `text.dark.normal` | `black-alpha.95` | `#000000` @ 95% |
| `text.light.normal` | `white-alpha.95` | `#FFFFFF` @ 95% |
| `text.dark.green` | `core.green.40` | `#3CC29A` |
| `text.light.green` | `core.green.70` | `#185E46` |
| `text.dark.blue` | `core.blue.40` | `#64B4FA` |
| `text.light.blue` | `core.blue.70` | `#0353A8` |
| `text.dark.purple` | `decorative.purple.40` | `#F294F1` |
| `text.light.purple` | `decorative.purple.70` | `#932099` |
| `text.dark.yellow` | `core.yellow.40` | `#F2990A` |
| `text.light.yellow` | `core.yellow.70` | `#7D4705` |

**Note:** Base text tokens use `text.dark.normal` / `text.light.normal` (not `text.dark`) so color variants can share the same parent path.

### Breaking Change
N/A
