### PR TITLE
fix(components): prevent tablist focus steal after scroll arrow click

### DIFF
--- a/packages/components/src/components/tablist/tablist.component.ts
+++ b/packages/components/src/components/tablist/tablist.component.ts
@@ -104,6 +104,10 @@ class TabList extends ListNavigationMixin(
    */
   @state() private showBackwardArrowButton: boolean = false;
 
+  private readonly boundHandleFocus = (event: FocusEvent): void => {
+    void this.handleFocus(event);
+  };
+
   /**
    * @internal
    */
@@ -210,12 +214,12 @@ class TabList extends ListNavigationMixin(
       this.activeTabId = getFirstTab(this.navItems)?.tabId;
     }
 
-    this.tabsContainer?.addEventListener('focusin', this.handleFocus.bind(this));
+    this.tabsContainer?.addEventListener('focusin', this.boundHandleFocus);
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.tabsContainer?.removeEventListener('focusin', this.handleFocus);
+    this.tabsContainer?.removeEventListener('focusin', this.boundHandleFocus);
   }
 
   /**
@@ -246,6 +250,12 @@ class TabList extends ListNavigationMixin(
      * This also covers the case when previous focus was on a tab that belongs to another tablist.
      */
     if (event.relatedTarget instanceof Tab || !(event.target instanceof Tab)) {
+      return;
+    }
+
+    // After scrolling with arrow buttons, focus moves from the button to the clicked tab.
+    // Do not redirect that focus back to the currently active tab.
+    if (event.relatedTarget instanceof Button) {
       return;
     }
 

--- a/packages/components/src/components/tablist/tablist.e2e-test.ts
+++ b/packages/components/src/components/tablist/tablist.e2e-test.ts
@@ -389,6 +389,19 @@ test('mdc-tablist', async ({ componentsPage }) => {
         });
         await expect(arrowButtons.last()).toBeFocused();
       });
+
+      await test.step(`Given a tablist component with 5 tabs and a smaller viewport,
+        user can select a tab after scrolling with the forward arrow button via mouse click`, async () => {
+        await componentsPage.page.setViewportSize({ width: 320, height: 450 });
+        await setup({ componentsPage, 'active-tab-id': 'calls-tab' });
+        await expect(mdcTablist).toHaveAttribute('active-tab-id', 'calls-tab');
+        await arrowButtons.last().click();
+        await tabs.last().click();
+        await expect(tabs.last()).toHaveAttribute('aria-selected', 'true');
+        await expect(tabs.last()).toHaveAttribute('active');
+        await expect(mdcTablist).toHaveAttribute('active-tab-id', 'meetings-tab');
+        await expect(tabs.last()).toBeFocused();
+      });
     }
   });
 });

--- a/packages/components/src/components/tablist/tablist.feature
+++ b/packages/components/src/components/tablist/tablist.feature
@@ -94,3 +94,12 @@ Feature: Tablist component
     When I press Enter or Space on the arrow buttons
     Then the tablist should visually update to show the scrolled tabs
     And there should be no accessibility violations
+
+  Scenario: Select tab after scrolling with arrow button via mouse click
+    Given the tablist component is rendered in a small viewport
+    And the first tab is active
+    When I click the forward arrow button to scroll
+    And I click the last tab
+    Then the last tab should be active and have aria-selected "true"
+    And the active-tab-id should be "meetings-tab"
+    And the last tab should be focused


### PR DESCRIPTION
### Description

Fixes a TabList focus bug where clicking a tab after scrolling with the forward/back arrow buttons failed to change selection. After a scroll-arrow click, focus moves from the arrow `mdc-button` to the clicked tab, but `handleFocus` redirected focus back to the currently active tab.

Changes:
- Skip `handleFocus` when `relatedTarget` is a scroll arrow `Button`, so the clicked tab keeps focus and selection
- Store a bound `focusin` handler so `removeEventListener` correctly unregisters on disconnect
- Add Playwright e2e coverage for mouse click: scroll forward arrow → click last tab
- Add matching Gherkin scenario in `tablist.feature`

### Breaking Change

No breaking changes.
