### PR TITLE
fix(deploy): docs github action fail

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -82,6 +82,8 @@ jobs:
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
### Description

Docs GitHub Action failed with

> github-actions[bot].fatal: unable to access

because its token did not have write access to the repository.

Breaking change: none