### PR TITLE
fix(menupopover): ignore menu item click when press and release differ

### DIFF
--- a/packages/components/src/components/menupopover/menupopover.component.ts
+++ b/packages/components/src/components/menupopover/menupopover.component.ts
@@ -54,11 +54,26 @@ class MenuPopover extends Popover {
 
   private menuItemsWithSubMenus: Array<HTMLElement> = [];
 
+  /**
+   * The menu item (if any) on which the pointer was pressed down.
+   * Used together with `handlePointerUp` to detect press/release mismatches (see `handlePointerUp`).
+   */
+  private pressStartMenuItem: Element | null = null;
+
+  /**
+   * Set to true when the pointerdown and pointerup of an interaction landed on different menu
+   * items (or the pointerup landed outside any item). When true, the following `click` event's
+   * action is ignored, see `handleMouseClick`.
+   */
+  private ignoreNextItemClick = false;
+
   constructor() {
     super();
     this.addEventListener('keydown', this.handleKeyDown);
     this.addEventListener('keyup', this.handleKeyUp);
     this.addEventListener('created', this.handleItemCreation);
+    this.addEventListener('pointerdown', this.handlePointerDown);
+    this.addEventListener('pointerup', this.handlePointerUp);
   }
 
   /**
@@ -289,6 +304,52 @@ class MenuPopover extends Popover {
   }
 
   /**
+   * Checks whether the given event's nearest `mdc-menupopover` ancestor in the composed path is
+   * this popover instance. Nested submenus are rendered inside their parent's light DOM, so
+   * pointer/click events from a submenu's items also bubble up to the parent popover; this
+   * ensures only the popover that directly owns the target handles the event.
+   * @param event - The event to check.
+   */
+  private isOwnPopoverEvent(event: Event): boolean {
+    return event.composedPath().find(el => (el as HTMLElement).tagName === this.tagName) === this;
+  }
+
+  /**
+   * Records the menu item (if any) on which the pointer was pressed down.
+   * @param event - The pointerdown event.
+   */
+  private handlePointerDown = (event: PointerEvent): void => {
+    if (!this.isOwnPopoverEvent(event)) return;
+    const target = event.target as Element;
+    this.pressStartMenuItem = isValidMenuItem(target) ? target : null;
+  };
+
+  /**
+   * Compares the menu item actually under the pointer when it was released to the one recorded
+   * on pointerdown.
+   *
+   * Browsers disagree on whether/how a `click` event fires when mousedown and mouseup happen on
+   * different elements (e.g., the user pressed on one menu item, dragged, and released
+   * elsewhere): Chrome does not fire `click` at all in that case, while Firefox still fires it,
+   * targeting the mousedown element. This flags the mismatch so `handleMouseClick` can ignore the
+   * following `click` event's action, normalizing behavior to Chrome's (no action, interaction
+   * cancelled).
+   *
+   * Note: `event.target`/`composedPath()` on `pointerup` cannot be used to find the release
+   * element here, since some browsers (e.g. Firefox) retarget them back to the pointerdown
+   * element instead of reflecting the actual pointer position. `document.elementFromPoint` is used
+   * instead to hit-test the real cursor position.
+   * @param event - The pointerup event.
+   */
+  private handlePointerUp = (event: PointerEvent): void => {
+    if (!this.isOwnPopoverEvent(event)) return;
+    const releaseTarget = document.elementFromPoint(event.clientX, event.clientY);
+    const releaseMenuItem = isValidMenuItem(releaseTarget) ? releaseTarget : null;
+    this.ignoreNextItemClick = this.pressStartMenuItem !== releaseMenuItem;
+    this.pressStartMenuItem = null;
+  };
+
+  /**
    * Handles mouse click events on the menu items.
    * This method checks if the clicked element is a valid menu item and not a submenu trigger.
    * If it is, it closes all other menu popovers to ensure only one menu is open at a time.
@@ -296,6 +357,12 @@ class MenuPopover extends Popover {
    */
   private handleMouseClick(event: Event): void {
     const target = event.target as HTMLElement;
+
+    // Ignore the action if the pointerdown/pointerup of this interaction landed on different menu
+    // items (see `handlePointerUp`), so behavior is consistent across browsers.
+    const ignoreClick = this.ignoreNextItemClick;
+    this.ignoreNextItemClick = false;
+    if (ignoreClick) return;
 
     // if the target is not a valid menu item or if the event is not trusted (
     // e.g., triggered by keydown originally), do nothing. Pressing space and enter

--- a/packages/components/src/components/menupopover/menupopover.e2e-test.ts
+++ b/packages/components/src/components/menupopover/menupopover.e2e-test.ts
@@ -383,6 +383,50 @@ test('mdc-menupopover', async ({ componentsPage }) => {
         await componentsPage.page.keyboard.press('ArrowUp');
         await expect(menupopover.locator(menuItemSelector).nth(0)).toBeFocused();
       });
+
+      // Pressing on one menuitem and releasing on another (or outside) is handled inconsistently
+      // by the native `click` event across browsers (Chrome does not fire it, Firefox fires it
+      // targeting the press location). These steps assert the menu normalizes to "no action".
+      await test.step('Pressing on one menuitem and releasing on another does not trigger any action', async () => {
+        await setup({ componentsPage, html: defaultHTML });
+        await triggerElement.click();
+        await expect(menupopover).toBeVisible();
+
+        const items = menupopover.locator(menuItemSelector);
+        const profileItem = items.nth(0);
+        const logoutItem = items.nth(3); // skips disabled Settings
+
+        const waitForAction = await componentsPage.waitForEvent(menupopover, 'action');
+        const profileBox = await profileItem.boundingBox();
+        const logoutBox = await logoutItem.boundingBox();
+        if (!profileBox || !logoutBox) throw new Error('Could not resolve menu item bounding boxes');
+
+        await componentsPage.page.mouse.move(profileBox.x + profileBox.width / 2, profileBox.y + profileBox.height / 2);
+        await componentsPage.page.mouse.down();
+        await componentsPage.page.mouse.move(logoutBox.x + logoutBox.width / 2, logoutBox.y + logoutBox.height / 2);
+        await componentsPage.page.mouse.up();
+
+        await expect(waitForAction).not.toEventEmitted();
+        await expect(menupopover).toBeVisible();
+      });
+
+      await test.step('Pressing on a menuitem and releasing outside the menu does not trigger any action', async () => {
+        await setup({ componentsPage, html: defaultHTML });
+        await triggerElement.click();
+        await expect(menupopover).toBeVisible();
+
+        const profileItem = menupopover.locator(menuItemSelector).nth(0);
+        const waitForAction = await componentsPage.waitForEvent(menupopover, 'action');
+        const profileBox = await profileItem.boundingBox();
+        if (!profileBox) throw new Error('Could not resolve menu item bounding box');
+
+        await componentsPage.page.mouse.move(profileBox.x + profileBox.width / 2, profileBox.y + profileBox.height / 2);
+        await componentsPage.page.mouse.down();
+        await componentsPage.page.mouse.move(500, 350);
+        await componentsPage.page.mouse.up();
+
+        await expect(waitForAction).not.toEventEmitted();
+      });
     });
 
     // Keyboard Navigation


### PR DESCRIPTION
Menu item selection relied solely on the native `click` event, whose target/firing behavior is inconsistent across browsers when mousedown and mouseup land on different elements:
- Chrome does not fire `click` at all in that case.
- Firefox still fires `click`, targeting the mousedown element even though the pointer was released elsewhere (or outside the menu).

Track pointerdown/pointerup ourselves and compare the menu item under the pointer at press vs. release (using document.elementFromPoint, since pointerup's own target/composedPath can be retargeted back to the pointerdown element by the browser). If they differ, ignore the following click's action, normalizing behavior to Chrome's 'interaction cancelled' semantics on all browsers.

### Breaking Change

none
